### PR TITLE
User list tab consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixes #15, ALinux Arm64 build are actually x86_64 [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+- Fixes #15, Linux Arm64 build are actually x86_64 [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
 
 ### Changed
 
 - Build system now uses electron-builder **Note to self, we need to update CONTRIBUTING.MD**
 - Release scripts are a little more robust
-- 
+
 ### Removed
 
 - pack.js related build tools
-- 
+
 ## [1.29.1] - 2024-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). You also read it on our [website](https://fchat-horizon.github.io/docs/changelog.html).
 
 ## [Development]
+> [!CAUTION]
+> Beware of development builds!
+> These are unstable, unreleased, and should **not be used** except for development.
+> You **will** lose data, and you **will** regret it!
+> _You have been warned!_
 
-(none, currently!)
+### Added
 
+- Overhauled build system [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+- Deb, tar.gz linux builds [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+
+### Fixed
+
+- Fixes #15, ALinux Arm64 build are actually x86_64 [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+
+### Changed
+
+- Build system now uses electron-builder **Note to self, we need to update CONTRIBUTING.MD**
+- Release scripts are a little more robust
+- 
+### Removed
+
+- pack.js related build tools
+- 
 ## [1.29.1] - 2024-03-02
 
 ### Added

--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -168,7 +168,7 @@
       )).channel;
     }
 
-    get isConsoleTab(): boolean{
+    get isConsoleTab(): boolean {
       return (
         core.conversations.selectedConversation ===
         core.conversations.consoleTab

--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -10,12 +10,14 @@
       style="flex-shrink: 0"
       :tabs="
         channel
-          ? { friends: l('users.friends'), members: l('users.members') }
-          : { profile: 'Profile', friends: l('users.friends') }
+          ? { 0: l('users.friends'), 1: l('users.members') }
+          : !isConsoleTab
+            ? { 0: l('users.friends'), 1: 'Profile' }
+            : { 0: l('users.friends') }
       "
       v-model="tab"
     ></tabs>
-    <div class="users" style="padding-left: 10px" v-show="tab === 'friends'">
+    <div class="users" style="padding-left: 10px" v-show="tab === '0'">
       <h4>{{ l('users.friends') }}</h4>
       <div v-for="character in friends" :key="character.name">
         <user
@@ -36,7 +38,7 @@
     <div
       v-if="channel"
       style="padding-left: 5px; flex: 1; display: flex; flex-direction: column"
-      v-show="tab === 'members'"
+      v-show="tab === '1'"
     >
       <div class="users" style="flex: 1; padding-left: 5px">
         <h4>
@@ -66,10 +68,10 @@
       </div>
     </div>
     <div
-      v-if="!channel"
+      v-if="!channel && !isConsoleTab"
       style="flex: 1; display: flex; flex-direction: column"
       class="profile"
-      v-show="tab === 'profile'"
+      v-show="tab === '1'"
     >
       <a :href="profileUrl" target="_blank" class="btn profile-button">
         <span class="fa fa-fw fa-user"></span>
@@ -136,12 +138,16 @@
     components: { characterPage, user: UserView, sidebar: Sidebar, tabs: Tabs }
   })
   export default class UserList extends Vue {
-    tab = 'friends';
+    tab = '0';
     expanded = window.innerWidth >= 992;
     filter = '';
     l = l;
     sorter = (x: Character, y: Character) =>
-      x.name < y.name ? -1 : x.name > y.name ? 1 : 0;
+      x.name.toLocaleLowerCase() < y.name.toLocaleLowerCase()
+        ? -1
+        : x.name.toLocaleLowerCase() > y.name.toLocaleLowerCase()
+          ? 1
+          : 0;
 
     sortType: (typeof availableSorts)[number] = 'normal';
 
@@ -162,6 +168,12 @@
       )).channel;
     }
 
+    get isConsoleTab(): boolean{
+      return (
+        core.conversations.selectedConversation ===
+        core.conversations.consoleTab
+      );
+    }
     get profileName(): string | undefined {
       return this.channel
         ? undefined


### PR DESCRIPTION
Cut and paste job of one of my unmerged PRs for Rising, but something I felt was necessary. This does the following

1. Orders character names in the friends/ bookmarks list identically to channel lists, ignoring capitalization for the order.
2. Switching between conversations now keeps the same tab active, switching between the channel list and the profile view for PMs and rooms. Previously it would just jump all over the place if you swapped between conversation types.
3. No more profile view for the console tab.

Since I did a cut and paste job from my previous PR; I didn't test it as thoroughly as I did way back, all I've done is check if things seem to be okay at a first glance after building and running. Unless the relevant interfaces or functions I call have been changed substantially, I doubt it'll be a problem and I'll see if I can get the other things I had submitted for 1.28 (and have used in private) can be merged as well.