### PR TITLE
Fixes Dracula theme BBCode colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixes #15, ALinux Arm64 build are actually x86_64 [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+- Fixes #15, Linux Arm64 build are actually x86_64 [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
 
 ### Changed
 
 - Build system now uses electron-builder **Note to self, we need to update CONTRIBUTING.MD**
 - Release scripts are a little more robust
-- 
+
 ### Removed
 
 - pack.js related build tools
-- 
+
 ## [1.29.1] - 2024-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). You also read it on our [website](https://fchat-horizon.github.io/docs/changelog.html).
 
 ## [Development]
+> [!CAUTION]
+> Beware of development builds!
+> These are unstable, unreleased, and should **not be used** except for development.
+> You **will** lose data, and you **will** regret it!
+> _You have been warned!_
 
-(none, currently!)
+### Added
 
+- Overhauled build system [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+- Deb, tar.gz linux builds [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+
+### Fixed
+
+- Fixes #15, ALinux Arm64 build are actually x86_64 [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+
+### Changed
+
+- Build system now uses electron-builder **Note to self, we need to update CONTRIBUTING.MD**
+- Release scripts are a little more robust
+- 
+### Removed
+
+- pack.js related build tools
+- 
 ## [1.29.1] - 2024-03-02
 
 ### Added

--- a/scss/themes/chat/dracula.scss
+++ b/scss/themes/chat/dracula.scss
@@ -5,6 +5,19 @@
 @import '../../flist_derived';
 @import '../variables/dracula_derived';
 
+//BBCode colors.
+$red-color: $dracula-red;
+$green-color: $dracula-green;
+$blue-color: #1185fe;
+$yellow-color: $dracula-yellow;
+$purple-color: lighten(saturate($dracula-purple, 0.36), 10.78);
+$cyan-color: $dracula-cyan;
+$white-color: $dracula-foreground;
+$black-color: #000;
+$brown-color: #8a6d3b;
+$pink-color: $dracula-pink;
+$gray-color: #ccc;
+$orange-color: $dracula-orange;
 // Apply variables to theme.
 @import '../chat';
 
@@ -43,18 +56,6 @@ $genders: (
   'cunt-boy': $dracula-green
 );
 
-$red-color: $dracula-red;
-$green-color: $dracula-green;
-$blue-color: darken(saturate($dracula-cyan, 0.45), 36.86);
-$yellow-color: $dracula-yellow;
-$purple-color: lighten(saturate($dracula-purple, 0.36), 10.78);
-$cyan-color: $dracula-cyan;
-$white-color: $dracula-foreground;
-$black-color: #000;
-$brown-color: #8a6d3b;
-$pink-color: $dracula-pink;
-$gray-color: #ccc;
-$orange-color: $dracula-orange;
 
 .btn-primary,
 .btn-primary:hover,

--- a/scss/themes/chat/dracula.scss
+++ b/scss/themes/chat/dracula.scss
@@ -10,7 +10,7 @@ $red-color: $dracula-red;
 $green-color: $dracula-green;
 $blue-color: #1185fe;
 $yellow-color: $dracula-yellow;
-$purple-color: lighten(saturate($dracula-purple, 0.36), 10.78);
+$purple-color: $dracula-purple;
 $cyan-color: $dracula-cyan;
 $white-color: $dracula-foreground;
 $black-color: #000;

--- a/scss/themes/chat/dracula.scss
+++ b/scss/themes/chat/dracula.scss
@@ -56,7 +56,6 @@ $genders: (
   'cunt-boy': $dracula-green
 );
 
-
 .btn-primary,
 .btn-primary:hover,
 .list-group-item.active {


### PR DESCRIPTION
Though I mostly did this because the blue text was pretty illegible in this theme, these were always the intended colors instead of using the default ones. I just didn't get to push this fix upstream.

![image](https://github.com/user-attachments/assets/018e18a4-fec9-4156-91ac-db95d8eb2690)
