### PR TITLE
Stops pinging frontpage when note checker is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,17 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixes #15, ALinux Arm64 build are actually x86_64 [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+- Fixes #15, Linux Arm64 build are actually x86_64 [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
 
 ### Changed
 
 - Build system now uses electron-builder **Note to self, we need to update CONTRIBUTING.MD**
 - Release scripts are a little more robust
-- 
+
 ### Removed
 
 - pack.js related build tools
-- 
+
 ## [1.29.1] - 2024-03-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,30 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). You also read it on our [website](https://fchat-horizon.github.io/docs/changelog.html).
 
 ## [Development]
+> [!CAUTION]
+> Beware of development builds!
+> These are unstable, unreleased, and should **not be used** except for development.
+> You **will** lose data, and you **will** regret it!
+> _You have been warned!_
 
-(none, currently!)
+### Added
 
+- Overhauled build system [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+- Deb, tar.gz linux builds [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+
+### Fixed
+
+- Fixes #15, ALinux Arm64 build are actually x86_64 [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/db43135677cb8e5e57f51bb0ffb417834ccd4103)
+
+### Changed
+
+- Build system now uses electron-builder **Note to self, we need to update CONTRIBUTING.MD**
+- Release scripts are a little more robust
+- 
+### Removed
+
+- pack.js related build tools
+- 
 ## [1.29.1] - 2024-03-02
 
 ### Added

--- a/site/note-checker.ts
+++ b/site/note-checker.ts
@@ -1,7 +1,7 @@
 import { SiteSession, SiteSessionInterface } from './site-session';
 import log from 'electron-log'; //tslint:disable-line:match-default-export-name
 import { EventBus } from '../chat/preview/event-bus';
-
+import core from '../chat/core';
 /* tslint:disable:no-unsafe-any */
 
 export interface NoteCheckerCount {
@@ -50,7 +50,8 @@ export class NoteChecker implements SiteSessionInterface {
 
   private async check(): Promise<NoteCheckerCount> {
     log.debug('notechecker.check');
-
+    if (!core.state.settings.risingShowUnreadOfflineCount)
+      return this.latestCount;
     const res = await this.session.get('/', true);
     const messagesMatch = res.body.match(
       /NavigationMessages.*?([0-9]+?) Messages/


### PR DESCRIPTION
This was another (requested) fix I originally made for the Rising repository. It also means that you won't appear as recently online just for having the app open.