### PR TITLE
Fixes broken channel tag formatting

### DIFF
--- a/chat/ChannelTagView.vue
+++ b/chat/ChannelTagView.vue
@@ -5,12 +5,9 @@
     :disabled="channel && channel.isJoined"
   >
     <span class="fa fa-hashtag"></span>
-    <template v-if="channel"
-      >{{ channel.name
-      }}<span class="bbcode-pseudo">
-        ({{ channel.memberCount }})</span
-      ></template
-    >
+    <!-- This doesn't look particularly nice, but Prettier breaks the formatting of the actual tag component. -->
+    <!-- prettier-ignore -->
+    <template v-if="channel">{{ channel.name }}<span class="bbcode-pseudo"> ({{ channel.memberCount }})</span></template>
     <template v-else>{{ text }}</template>
   </a>
 </template>


### PR DESCRIPTION
Prettier is sometimes too opinionated for its own good and wound up breaking the formatting of channel BBCode tags.

Before:
![image](https://github.com/user-attachments/assets/e7e914b7-4336-4bff-b51a-15892325749f)

After:
![image](https://github.com/user-attachments/assets/3dc28721-7a4c-4047-80fb-026f0c0934df)
