### PR TITLE
Fix zoom in hotkey + re-allow zooming out

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -546,7 +546,7 @@ function onReady(): void {
         click: (_m: electron.MenuItem, w: electron.BrowserWindow) => {
           // log.info('MENU ZOOM-');
           zoomLevel = Math.max(
-            0,
+            -3,
             zoomLevel - w.webContents.getZoomFactor() / 2
           );
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -538,7 +538,7 @@ function onReady(): void {
           for (const win of windows)
             win.webContents.send('update-zoom', zoomLevel);
         },
-        accelerator: 'CmdOrCtrl+Plus'
+        accelerator: 'CmdOrCtrl+='
       },
       {
         // role: 'zoomIn',


### PR DESCRIPTION
Some Electron update made the existing Ctrl + Plus hotkey not work and made zooming out no longer possible, so these two quick fixes should resolve those issues.

Additionally, it looks like the overall font/zoom has been slightly increased overall, but I wasn't able to find a reliable way to globally fix that. Might be worth looking into if someone else wants to use this PR as a baseline.

Closes #52.