### PR TITLE
fix: lack of shadows in black (and other) user names

### DIFF
--- a/scss/themes/variables/_dark_derived.scss
+++ b/scss/themes/variables/_dark_derived.scss
@@ -1,5 +1,6 @@
 $blue-color: #06f;
 
-.blackText {
+.blackText,
+.blackNameText {
   @include text-outline($gray-600);
 }

--- a/scss/themes/variables/_default_derived.scss
+++ b/scss/themes/variables/_default_derived.scss
@@ -1,8 +1,10 @@
-.purpleText {
+.purpleText,
+.purpleNameText {
   @include text-outline(#306);
 }
 
-.blackText {
+.blackText,
+.blackNameText {
   @include text-outline($gray-600);
 }
 

--- a/scss/themes/variables/_dracula_derived.scss
+++ b/scss/themes/variables/_dracula_derived.scss
@@ -1,5 +1,6 @@
 $blue-color: $blue-color;
 
-.blackText {
+.blackText,
+.blackNameText {
   @include text-outline($gray-600);
 }

--- a/scss/themes/variables/_light_derived.scss
+++ b/scss/themes/variables/_light_derived.scss
@@ -1,3 +1,4 @@
-.whiteText {
+.whiteText,
+.whiteNameText {
   @include text-outline($gray-600);
 }


### PR DESCRIPTION
I personally think it'd be cleaner if instead of this we just set the CSS rule for custom usernames and BBCode text to be one and the same. But since that robs people of the opportunity to potentially update a theme to use different colours (and this being the solution that was proposed by @CodingWithAnxiety  in #45 ).

Fixes #45.