### PR TITLE
fix: Duplicate event listeners

### DIFF
--- a/chat/preview/event-bus.ts
+++ b/chat/preview/event-bus.ts
@@ -69,7 +69,7 @@ class EventBusManager {
 
     this.eventCallbacks[eventName] = _.filter(
       this.eventCallbacks[eventName],
-      cb => cb !== callback
+      cb => cb.toString() !== callback.toString()
     );
   }
 

--- a/electron/Index.vue
+++ b/electron/Index.vue
@@ -384,11 +384,6 @@
         this.shouldShowSpinner = true;
       }, 250);
 
-      // tslint:disable-next-line no-floating-promises
-      await core.cache.start(this.settings, this.hasCompletedUpgrades);
-
-      log.debug('init.chat.cache.done');
-
       void EIconStore.getSharedStore(); // intentionally background
 
       log.debug('init.eicons.update.done');


### PR DESCRIPTION
Cache startup was being run more than once, it seems more correct to have that function called when a connection is established ([here](https://github.com/Fchat-Horizon/Horizon/blob/f798c39b57d067d55646e54c78cbb626bc33a9c4/chat/Chat.vue#L277)) rather than when this is called, otherwise relogging will break them.

Also fixes the handling of duplicate event listeners in the event bus, although this should not strictly be necessary and the solution in place is rather fragile. Comparing two functions like this will never have equality unless converted to a primitive. This probably wants a refactor, realistically...

Closes https://github.com/Fchat-Horizon/Horizon/issues/37.

P.S. First contribution, woo. 