### PR TITLE
fix: Fix ctrl-tab falling out of sync after dragging a tab

### DIFF
--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -28,6 +28,7 @@
           v-for="(tab, index) in tabs"
           :key="'tab-' + index"
           class="nav-item"
+          :data-id="index"
           @click.middle="remove(tab)"
         >
           <a
@@ -366,20 +367,18 @@
 
       log.debug('init.window.tab');
 
-      // console.log('SORTABLE', Sortable);
-
-      Sortable.create(<HTMLElement>this.$refs['tabs'], {
+      let tabsorder: string[];
+      const sortable = Sortable.create(<HTMLElement>this.$refs['tabs'], {
         animation: 50,
+        onStart: () => {
+          tabsorder = sortable.toArray();
+        },
         onEnd: e => {
-          // log.debug('ONEND', e);
           if (e.oldIndex === e.newIndex) return;
-
-          // log.debug('PRE', this.tabs);
-          //
-          // const tab = this.tabs.splice(e.oldIndex!, 1)[0];
-          // this.tabs.splice(e.newIndex!, 0, tab);
-          //
-          // log.debug('POST', this.tabs);
+          let elem = this.tabs[e.oldIndex!];
+          this.tabs.splice(e.oldIndex!, 1);
+          this.tabs.splice(e.newIndex!, 0, elem);
+          sortable.sort(tabsorder, false);
         },
         onMove: (e: { related: HTMLElement }) => e.related.id !== 'addTab',
         filter: '.addTab'

--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -375,7 +375,7 @@
         },
         onEnd: e => {
           if (e.oldIndex === e.newIndex) return;
-          let elem = this.tabs[e.oldIndex!];
+          const elem = this.tabs[e.oldIndex!];
           this.tabs.splice(e.oldIndex!, 1);
           this.tabs.splice(e.newIndex!, 0, elem);
           sortable.sort(tabsorder, false);


### PR DESCRIPTION
Dragging a sortable seems to not update the list it's based on, only its internal list (and thus only the rendering order, which breaks the ctrl+tab hotkeys). There's a Vue version of Sortable.js (Vue.Draggable) that seems to fix this but this is a not-terrible workaround for now.

Interestingly, while dragging a tab doesn't update the original list, updating the original list also messes with the internal list, hence the awkward workaround here.

Closes #68