### PR TITLE
fix: Remove unnecessary include line from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,5 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "experimentalDecorators": true
-  },
-  "include": ["./electron/main.ts"]
+  }
 }


### PR DESCRIPTION
The default include grabs all valid files in any directory nested to any degree, so this include is actually *excluding* all other files, which seems to be fine at build time(?) but it makes LSPs in editors very upset with a ton of errors that would be handled by tsconfig.