### PR TITLE
docs: Fix broken linux download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,20 +115,20 @@ Select the correct package for your distribution and architecture:
    ./F-Chat.Horizon
    ```
 
-### Arch-based (pacman)
+### Arch-based (AUR)
 
 > [!NOTE]
-> There is currently no offical support for arch.
-> You will have you build the .pacman file yourself. `cd electron` and run `pnpm build:linux:arch`
->
-> You need to have pacman available on your system to build the arch builds. Duh.
+> The AUR package currently doesn't support ARM.
 
-1. Download the `.pacman` file for your architecture.
-   - [Linux x64 .pacman](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-x64.pacman)
-   - [Linux arm64 .pacman](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-arm64.pacman)
-2. Install:
+- With an AUR helper:
    ```bash
-   sudo pacman -U F-Chat.Horizon-linux-<arch>.pacman
+   yay|paru|etc -S fchat-horizon-bin
+   ```
+- Manually:
+   ```bash
+   git clone https://aur.archlinux.org/fchat-horizon-bin.git
+   cd fchat-horizon-bin
+   makepkg -si
    ```
 
 # Usage

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 [Windows x64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-win-x64.exe) |
 [Windows arm64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-win-arm64.exe) |
 [MacOS (Universal)](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-mac-universal.dmg) |
-[Linux x64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-x64.AppImage) |
+[Linux x64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-x86_64.AppImage) |
 [Linux arm64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-arm64.AppImage)
 
 # F-Chat Horizon
@@ -85,7 +85,7 @@ Select the correct package for your distribution and architecture:
 ### Debian/Ubuntu (deb)
 
 1. Download the `.deb` file for your architecture.
-   - [Linux x64 .deb](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-x64.deb)
+   - [Linux x64 .deb](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-amd64.deb)
    - [Linux arm64 .deb](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-arm64.deb)
 2. Install:
    ```bash
@@ -95,7 +95,7 @@ Select the correct package for your distribution and architecture:
 ### AppImage
 
 1. Download the AppImage for your architecture:
-   - [Linux x64 .AppImage](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-x64.AppImage)
+   - [Linux x64 .AppImage](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-x86_64.AppImage)
    - [Linux arm64 .AppImage](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-arm64.AppImage)
 2. Make it executable, then run:
    ```bash


### PR DESCRIPTION
Electron builds have weirdly inconsistent naming, it turns out.

Arch Linux link remains dead pending something happening there. (#76)

Closes #64.