### PR TITLE
fix: Check if logged in before fetching character-specific settings

### DIFF
--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -94,36 +94,38 @@
     if (showStatus || character.status === 'crown')
       statusClass = `fa-fw ${getStatusIcon(character.status)}`;
 
-    const cache =
-      (showMatch && core.state.settings.risingAdScore) ||
-      core.state.settings.risingFilter.showFilterIcon
-        ? core.cache.profileCache.getSync(character.name)
-        : undefined;
+    if (core.connection.character) {
+      const cache =
+        (showMatch && core.state.settings.risingAdScore) ||
+        core.state.settings.risingFilter.showFilterIcon
+          ? core.cache.profileCache.getSync(character.name)
+          : undefined;
 
-    // undefined == not interested
-    // null == no cache hit
-    if (cache === null && showMatch) {
-      void core.cache.addProfile(character.name);
-    }
-
-    if (core.state.settings.risingAdScore && showMatch && cache) {
-      if (
-        cache.match.searchScore >= kinkMatchWeights.unicornThreshold &&
-        cache.match.matchScore === Scoring.MATCH
-      ) {
-        matchClass = 'match-found unicorn';
-        matchScore = 'unicorn';
-      } else {
-        matchClass = `match-found ${Score.getClasses(cache.match.matchScore)}`;
-        matchScore = cache.match.matchScore;
+      // undefined == not interested
+      // null == no cache hit
+      if (cache === null && showMatch) {
+        void core.cache.addProfile(character.name);
       }
-    }
 
-    if (
-      core.state.settings.risingFilter.showFilterIcon &&
-      cache?.match.isFiltered
-    ) {
-      smartFilterIcon = 'user-filter fas fa-filter';
+      if (core.state.settings.risingAdScore && showMatch && cache) {
+        if (
+          cache.match.searchScore >= kinkMatchWeights.unicornThreshold &&
+          cache.match.matchScore === Scoring.MATCH
+        ) {
+          matchClass = 'match-found unicorn';
+          matchScore = 'unicorn';
+        } else {
+          matchClass = `match-found ${Score.getClasses(cache.match.matchScore)}`;
+          matchScore = cache.match.matchScore;
+        }
+      }
+
+      if (
+        core.state.settings.risingFilter.showFilterIcon &&
+        cache?.match.isFiltered
+      ) {
+        smartFilterIcon = 'user-filter fas fa-filter';
+      }
     }
 
     const baseGender = character.overrides.gender || character.gender;

--- a/chat/message_view.ts
+++ b/chat/message_view.ts
@@ -59,7 +59,9 @@ const userPostfix: { [key: number]: string | undefined } = {
           : '',
         createElement(UserView, {
           props: {
-            avatar: core.state.settings.risingShowPortraitInMessage,
+            avatar: core.connection.character
+              ? core.state.settings.risingShowPortraitInMessage
+              : false,
             character: message.sender,
             channel: this.channel
           }
@@ -158,6 +160,7 @@ export default class MessageView extends Vue {
   }
 
   getMessageScoreClasses(message: Conversation.Message): string {
+    if (!core.connection.character) return '';
     if (
       !core.state.settings.risingAdScore ||
       message.type !== Conversation.Message.Type.Ad


### PR DESCRIPTION
Checking logs before logging in at least once on a new tab throws errors when it tries to check character specific settings, which causes the logs to fail to load. 
So let's skip over those settings when we're not logged in.

(force pushed a commit message reword)