### PR TITLE
Feature: Adjustable Automatic reply

### DIFF
--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -536,19 +536,18 @@
         ></textarea>
         <div class="form-group">
           Automatic message respects BBCode, we recommend testing it in a
-          message to yourself first as there isn't a preview here.
-          You will still see messages unless you have the
-          "Hide private channel messages" option above selected.
-          Even then, if they send a second message it will bypass
-          the restriction and show you their message.
+          message to yourself first as there isn't a preview here. You will
+          still see messages unless you have the "Hide private channel messages"
+          option above selected. Even then, if they send a second message it
+          will bypass the restriction and show you their message.
         </div>
       </div>
 
       <h5>Exception List</h5>
       <div class="form-group">
         Filters and automatic replies are not applied to these character names.
-        Separate names with a linefeed. Friends and bookmarked characters
-        bypass filtering automatically.
+        Separate names with a linefeed. Friends and bookmarked characters bypass
+        filtering automatically.
       </div>
 
       <div class="form-group">

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -459,7 +459,7 @@
           Increase <b>match scores</b> for non-matching characters
         </label>
       </div>
-	  
+
       <div class="form-group">
         <label class="control-label" for="risingFilter.autoReply">
           <input
@@ -470,7 +470,7 @@
           Send an automatic 'no thank you' response to matching characters if
           they message you
         </label>
-		
+
         <label class="control-label" for="risingFilter.useCustomAutoReplyMessage">
           <input
             type="checkbox"
@@ -479,14 +479,14 @@
           />
           Use a custom message defined below instead of the default message
         </label>
-		
+
         <textarea
           class="form-control"
-		  rows="5"
+          rows="5"
           v-model="risingFilter.autoReplyMessage"
           placeholder="Put custom message for automatic replies here"
         ></textarea>
-	  </div>
+       </div>
 
       <h5>Character Age Match</h5>
       <div class="form-group">Leave empty for no limit.</div>

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -460,34 +460,6 @@
         </label>
       </div>
 
-      <div class="form-group">
-        <label class="control-label" for="risingFilter.autoReply">
-          <input
-            type="checkbox"
-            id="risingFilter.autoReply"
-            v-model="risingFilter.autoReply"
-          />
-          Send an automatic 'no thank you' response to matching characters if
-          they message you
-        </label>
-
-        <label class="control-label" for="risingFilter.useCustomAutoReplyMessage">
-          <input
-            type="checkbox"
-            id="risingFilter.useCustomAutoReplyMessage"
-            v-model="risingFilter.useCustomAutoReplyMessage"
-          />
-          Use a custom message defined below instead of the default message
-        </label>
-
-        <textarea
-          class="form-control"
-          rows="5"
-          v-model="risingFilter.autoReplyMessage"
-          placeholder="Put custom message for automatic replies here"
-        ></textarea>
-       </div>
-
       <h5>Character Age Match</h5>
       <div class="form-group">Leave empty for no limit.</div>
 
@@ -532,11 +504,51 @@
         </label>
       </div>
 
+      <h5>Automatic Replies</h5>
+      <div class="form-group">
+        <label class="control-label" for="risingFilter.autoReply">
+          <input
+            type="checkbox"
+            id="risingFilter.autoReply"
+            v-model="risingFilter.autoReply"
+          />
+          Send an automatic 'no thank you' response to matching characters if
+          they message you
+        </label>
+
+        <label
+          class="control-label"
+          for="risingFilter.useCustomAutoReplyMessage"
+        >
+          <input
+            type="checkbox"
+            id="risingFilter.useCustomAutoReplyMessage"
+            v-model="risingFilter.useCustomAutoReplyMessage"
+          />
+          Use a custom message defined below instead of the default message
+        </label>
+
+        <textarea
+          class="form-control"
+          rows="5"
+          v-model="risingFilter.autoReplyMessage"
+          placeholder="Put custom message for automatic replies here"
+        ></textarea>
+        <div class="form-group">
+          Automatic message respects BBCode, we recommend testing it in a
+          message to yourself first as there isn't a preview here.
+          You will still see messages unless you have the
+          "Hide private channel messages" option above selected.
+          Even then, if they send a second message it will bypass
+          the restriction and show you their message.
+        </div>
+      </div>
+
       <h5>Exception List</h5>
       <div class="form-group">
-        Filters are not applied to these character names. Separate names with a
-        linefeed. Friends and bookmarked characters bypass filtering
-        automatically.
+        Filters and automatic replies are not applied to these character names.
+        Separate names with a linefeed. Friends and bookmarked characters
+        bypass filtering automatically.
       </div>
 
       <div class="form-group">

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -441,16 +441,6 @@
       </div>
 
       <div class="form-group filters">
-        <label class="control-label" for="risingFilter.autoReply">
-          <input
-            type="checkbox"
-            id="risingFilter.autoReply"
-            v-model="risingFilter.autoReply"
-          />
-          Send an automatic 'no thank you' response to matching characters if
-          they message you
-        </label>
-
         <label class="control-label" for="risingFilter.penalizeMatches">
           <input
             type="checkbox"
@@ -469,6 +459,34 @@
           Increase <b>match scores</b> for non-matching characters
         </label>
       </div>
+	  
+      <div class="form-group">
+        <label class="control-label" for="risingFilter.autoReply">
+          <input
+            type="checkbox"
+            id="risingFilter.autoReply"
+            v-model="risingFilter.autoReply"
+          />
+          Send an automatic 'no thank you' response to matching characters if
+          they message you
+        </label>
+		
+        <label class="control-label" for="risingFilter.useCustomAutoReplyMessage">
+          <input
+            type="checkbox"
+            id="risingFilter.useCustomAutoReplyMessage"
+            v-model="risingFilter.useCustomAutoReplyMessage"
+          />
+          Use a custom message defined below instead of the default message
+        </label>
+		
+        <textarea
+          class="form-control"
+		  rows="5"
+          v-model="risingFilter.autoReplyMessage"
+          placeholder="Put custom message for automatic replies here"
+        ></textarea>
+	  </div>
 
       <h5>Character Age Match</h5>
       <div class="form-group">Leave empty for no limit.</div>

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -89,6 +89,8 @@ export class Settings implements ISettings {
     penalizeMatches: true,
     rewardNonMatches: false,
     autoReply: true,
+	useCustomAutoReplyMessage: false,
+    autoReplyMessage: '',
     minAge: null,
     maxAge: null,
     smartFilters: {

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -89,7 +89,7 @@ export class Settings implements ISettings {
     penalizeMatches: true,
     rewardNonMatches: false,
     autoReply: true,
-	useCustomAutoReplyMessage: false,
+    useCustomAutoReplyMessage: false,
     autoReplyMessage: '',
     minAge: null,
     maxAge: null,

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -90,7 +90,11 @@ export class Settings implements ISettings {
     rewardNonMatches: false,
     autoReply: true,
     useCustomAutoReplyMessage: false,
-    autoReplyMessage: '',
+    autoReplyMessage: '\n' +
+      '[sub][color=orange][b][AUTOMATED MESSAGE][/b][/color][/sub]\n' +
+       'Sorry, the player of this character is not interested in characters matching your profile.\n' +
+       '\n' +
+       '🦄 Need a filter for yourself? Try out [url=https://horizn.moe/]F-Chat Horizon[/url]',
     minAge: null,
     maxAge: null,
     smartFilters: {

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -90,11 +90,12 @@ export class Settings implements ISettings {
     rewardNonMatches: false,
     autoReply: true,
     useCustomAutoReplyMessage: false,
-    autoReplyMessage: '\n' +
+    autoReplyMessage:
+      '\n' +
       '[sub][color=orange][b][AUTOMATED MESSAGE][/b][/color][/sub]\n' +
-       'Sorry, the player of this character is not interested in characters matching your profile.\n' +
-       '\n' +
-       '🦄 Need a filter for yourself? Try out [url=https://horizn.moe/]F-Chat Horizon[/url]',
+      'Sorry, the player of this character is not interested in characters matching your profile.\n' +
+      '\n' +
+      '🦄 Need a filter for yourself? Try out [url=https://horizn.moe/]F-Chat Horizon[/url]',
     minAge: null,
     maxAge: null,
     smartFilters: {

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -842,8 +842,9 @@ export async function testSmartFilterForPrivateMessage(
     //        Sowwwy...
     // cachedProfile.character.character.name !== 'YiffBot 4000' &&
     cachedProfile.match.isFiltered &&
-    core.state.settings.risingFilter.autoReply &&
-    !cachedProfile.match.autoResponded
+    core.state.settings.risingFilter.autoReply
+	//	DO NOT FORGET TO RE-ENABLE THIS LINE BEFORE PR
+	//    !cachedProfile.match.autoResponded
   ) {
     cachedProfile.match.autoResponded = true;
 
@@ -853,32 +854,56 @@ export async function testSmartFilterForPrivateMessage(
       await Conversation.testPostDelay();
 
       // tslint:disable-next-line:prefer-template
-      const message = {
-        recipient: fromChar.name,
-        message:
-          '\n[sub][color=orange][b][AUTOMATED MESSAGE][/b][/color][/sub]\n' +
-          'Sorry, the player of this character is not interested in characters matching your profile.' +
-          `${core.state.settings.risingFilter.hidePrivateMessages ? ' They did not see your message. To bypass this warning, send your message again.' : ''}\n` +
-          '\n' +
-          '🦄 Need a filter for yourself? Try out [url=https://hearmeneigh.github.io/fchat-rising/]F-Chat Horizon[/url]'
-      };
+	  if (core.state.settings.risingFilter.useCustomAutoReplyMessage) {
+        const message = {
+          recipient: fromChar.name,
+          message: core.state.settings.risingFilter.autoReplyMessage
+        };
 
-      core.connection.send('PRI', message);
-      core.cache.markLastPostTime();
+        core.connection.send('PRI', message);
+        core.cache.markLastPostTime();
 
-      if (core.state.settings.logMessages) {
-        const logMessage = createMessage(
-          Interfaces.Message.Type.Message,
-          core.characters.ownCharacter,
-          message.message,
-          new Date()
-        );
+        if (core.state.settings.logMessages) {
+          const logMessage = createMessage(
+            Interfaces.Message.Type.Message,
+            core.characters.ownCharacter,
+            message.message,
+            new Date()
+          );
 
-        await withNeutralVisibilityPrivateConversation(fromChar, async p => {
-          // core.logs.logMessage(p, logMessage)
-          await p.addMessage(logMessage);
-        });
-      }
+          await withNeutralVisibilityPrivateConversation(fromChar, async p => {
+            // core.logs.logMessage(p, logMessage)
+            await p.addMessage(logMessage);
+          });
+        }
+	  } else {
+        const message = {
+          recipient: fromChar.name,
+          message:
+            '\n[sub][color=orange][b][AUTOMATED MESSAGE][/b][/color][/sub]\n' +
+            'Sorry, the player of this character is not interested in characters matching your profile.' +
+            `${core.state.settings.risingFilter.hidePrivateMessages ? ' They did not see your message. To bypass this warning, send your message again.' : ''}\n` +
+            '\n' +
+            '🦄 Need a filter for yourself? Try out [url=https://horizn.moe/]F-Chat Horizon[/url]'
+        };
+
+        core.connection.send('PRI', message);
+        core.cache.markLastPostTime();
+
+        if (core.state.settings.logMessages) {
+          const logMessage = createMessage(
+            Interfaces.Message.Type.Message,
+            core.characters.ownCharacter,
+            message.message,
+            new Date()
+          );
+
+          await withNeutralVisibilityPrivateConversation(fromChar, async p => {
+            // core.logs.logMessage(p, logMessage)
+            await p.addMessage(logMessage);
+          });
+        }
+	  }
     });
   }
 

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -842,9 +842,8 @@ export async function testSmartFilterForPrivateMessage(
     //        Sowwwy...
     // cachedProfile.character.character.name !== 'YiffBot 4000' &&
     cachedProfile.match.isFiltered &&
-    core.state.settings.risingFilter.autoReply
-    //	  DO NOT FORGET TO RE-ENABLE THIS LINE BEFORE PR
-    //    !cachedProfile.match.autoResponded
+    core.state.settings.risingFilter.autoReply &&
+    !cachedProfile.match.autoResponded
   ) {
     cachedProfile.match.autoResponded = true;
 
@@ -881,7 +880,7 @@ export async function testSmartFilterForPrivateMessage(
           recipient: fromChar.name,
           message:
             '\n[sub][color=orange][b][AUTOMATED MESSAGE][/b][/color][/sub]\n' +
-            'Sorry, the player of this character is not interested in characters matching your profile.' +
+            'Sorry, the player of this character is not interested in characters matching your profile.\n' +
             `${core.state.settings.risingFilter.hidePrivateMessages ? ' They did not see your message. To bypass this warning, send your message again.' : ''}\n` +
             '\n' +
             '🦄 Need a filter for yourself? Try out [url=https://horizn.moe/]F-Chat Horizon[/url]'

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -843,8 +843,8 @@ export async function testSmartFilterForPrivateMessage(
     // cachedProfile.character.character.name !== 'YiffBot 4000' &&
     cachedProfile.match.isFiltered &&
     core.state.settings.risingFilter.autoReply
-	//	DO NOT FORGET TO RE-ENABLE THIS LINE BEFORE PR
-	//    !cachedProfile.match.autoResponded
+    //	  DO NOT FORGET TO RE-ENABLE THIS LINE BEFORE PR
+    //    !cachedProfile.match.autoResponded
   ) {
     cachedProfile.match.autoResponded = true;
 
@@ -854,7 +854,7 @@ export async function testSmartFilterForPrivateMessage(
       await Conversation.testPostDelay();
 
       // tslint:disable-next-line:prefer-template
-	  if (core.state.settings.risingFilter.useCustomAutoReplyMessage) {
+      if (core.state.settings.risingFilter.useCustomAutoReplyMessage) {
         const message = {
           recipient: fromChar.name,
           message: core.state.settings.risingFilter.autoReplyMessage
@@ -876,7 +876,7 @@ export async function testSmartFilterForPrivateMessage(
             await p.addMessage(logMessage);
           });
         }
-	  } else {
+      } else {
         const message = {
           recipient: fromChar.name,
           message:
@@ -903,7 +903,7 @@ export async function testSmartFilterForPrivateMessage(
             await p.addMessage(logMessage);
           });
         }
-	  }
+      }
     });
   }
 

--- a/learn/filter/types.ts
+++ b/learn/filter/types.ts
@@ -37,6 +37,8 @@ export interface SmartFilterSettings {
   penalizeMatches: boolean;
   rewardNonMatches: boolean;
   autoReply: boolean;
+  useCustomAutoReplyMessage: boolean;
+  autoReplyMessage: string;
   showFilterIcon: boolean;
 
   minAge: number | null;


### PR DESCRIPTION
Figured I should just do it rather than make a feature request, so here it is. Finally contributing instead of just sending issues your way!

Allows users to set a custom automatic reply message, completely optional and can keep the original message instead with a toggle.
Moves autoreply to the bottom of the filters tab, just above exemptions. Gives a little more explanation of how it works too.
Comes with the original message (without the logic for hidePrivateMessages) as a default in the box so people can see it and work from it.
Also comes with a fix for the incorrect link I pointed out earlier included in it.

Tested on my end with two profiles of mine and appears to be working as far as I have put it through the paces.