### PR TITLE
feature: Dot for original color when using custom color

### DIFF
--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -696,8 +696,7 @@
         settings.risingShowHighQualityPortraits;
       this.horizonShowCustomCharacterColors =
         settings.horizonShowCustomCharacterColors;
-      this.horizonCCCOriginalDot =
-        settings.horizonCCCOriginalDot;
+      this.horizonCCCOriginalDot = settings.horizonCCCOriginalDot;
 
       this.risingFilter = settings.risingFilter;
 

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -334,6 +334,17 @@
       </div>
 
       <div class="form-group">
+        <label class="control-label" for="horizonCCCOriginalDot">
+          <input
+            type="checkbox"
+            id="horizonCCCOriginalDot"
+            v-model="horizonCCCOriginalDot"
+          />
+          Show a dot with the original gender colour
+        </label>
+      </div>
+
+      <div class="form-group">
         <label class="control-label" for="risingCharacterTheme">
           Override UI theme (for this character only)
           <select
@@ -631,6 +642,7 @@
     risingShowPortraitInMessage!: boolean;
     risingShowHighQualityPortraits!: boolean;
     horizonShowCustomCharacterColors!: boolean;
+    horizonCCCOriginalDot!: boolean;
 
     risingFilter!: SmartFilterSettings = {} as any;
 
@@ -684,6 +696,8 @@
         settings.risingShowHighQualityPortraits;
       this.horizonShowCustomCharacterColors =
         settings.horizonShowCustomCharacterColors;
+      this.horizonCCCOriginalDot =
+        settings.horizonCCCOriginalDot;
 
       this.risingFilter = settings.risingFilter;
 
@@ -787,6 +801,7 @@
         risingShowPortraitInMessage: this.risingShowPortraitInMessage,
         risingShowHighQualityPortraits: this.risingShowHighQualityPortraits,
         horizonShowCustomCharacterColors: this.horizonShowCustomCharacterColors,
+        horizonCCCOriginalDot: this.horizonCCCOriginalDot,
 
         risingColorblindMode: this.risingColorblindMode,
         risingFilter: {

--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -12,6 +12,8 @@
     @click.right.passive="dismiss(true)"
     @click.left.passive="dismiss(true)"
     ><img v-if="!!avatar" :src="avatarUrl" class="user-avatar" /><span
+    v-if="!!cccDot" :class="cccDot"></span
+    ><span
       v-if="!!statusClass"
       :class="statusClass"
     ></span
@@ -58,6 +60,7 @@
   export interface StatusClasses {
     rankIcon: string | null;
     smartFilterIcon: string | null;
+    cccDot: string | null;
     statusClass: string | null;
     matchClass: string | null;
     matchScore: number | string | null;
@@ -77,6 +80,7 @@
     let matchClass = null;
     let matchScore = null;
     let smartFilterIcon: string | null = null;
+    let cccDot: string | null = null;
 
     if (character.isChatOp) {
       rankIcon = 'far fa-gem';
@@ -129,6 +133,13 @@
     const baseGender = character.overrides.gender || character.gender;
     const gender = baseGender !== undefined ? baseGender.toLowerCase() : 'none';
 
+    if (
+      core.state.settings.horizonCCCOriginalDot &&
+      character.overrides.characterColor
+    ) {
+      cccDot = 'fa fa-genderless' + ` gender-${gender}`;
+    }
+
     const isBookmark =
       showBookmark &&
       core.connection.isOpen &&
@@ -137,14 +148,14 @@
 
     const userClass =
       `user-view` +
-      ` gender-${gender}` +
       (isBookmark ? ' user-bookmark' : '') +
       (character.overrides.characterColor
         ? ` ${character.overrides.characterColor}NameText`
-        : '');
+        : ` gender-${gender}`);
     // `user-view gender-${gender}${isBookmark ? ' user-bookmark' : ''}`;
 
     return {
+      cccDot,
       rankIcon: rankIcon ? `user-rank ${rankIcon}` : null,
       statusClass: statusClass ? `user-status ${statusClass}` : null,
       matchClass,
@@ -184,6 +195,7 @@
 
     rankIcon: string | null = null;
     smartFilterIcon: string | null = null;
+    cccDot: string | null = null;
     statusClass: string | null = null;
     matchClass: string | null = null;
     matchScore: number | string | null = null;
@@ -270,6 +282,7 @@
 
       this.rankIcon = res.rankIcon;
       this.smartFilterIcon = res.smartFilterIcon;
+      this.cccDot = res.cccDot;
       this.statusClass = res.statusClass;
       this.matchClass = res.matchClass;
       this.matchScore = res.matchScore;

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -77,6 +77,7 @@ export class Settings implements ISettings {
   risingShowPortraitInMessage = true;
   risingShowHighQualityPortraits = true;
   horizonShowCustomCharacterColors = true;
+  horizonCCCOriginalDot = true;
 
   risingFilter = {
     hideAds: false,

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -287,6 +287,7 @@ export namespace Settings {
     readonly risingShowPortraitInMessage: boolean;
     readonly risingShowHighQualityPortraits: boolean;
     readonly horizonShowCustomCharacterColors: boolean;
+    readonly horizonCCCOriginalDot: boolean;
 
     readonly risingFilter: SmartFilterSettings;
 

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -73,7 +73,7 @@
   .body {
     height: 100%;
     display: none;
-    width: 200px;
+    width: 210px;
     flex-direction: column;
     overflow: auto;
   }


### PR DESCRIPTION
Puts a dot beside people with custom colors for their names so you can still easily spot the gender while preserving their custom name color. Appears in chat, sidebar, and at the top of private conversations.

Has included option to enable/disable it. Currently set to default to on.

Had to expand the sidebar by 10 pixels to accomodate a name with it that was very long.