### PR TITLE
Fixes overly long user names breaking the user list

### DIFF
--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -19,7 +19,11 @@
     ></tabs>
     <div class="users" style="padding-left: 10px" v-show="tab === '0'">
       <h4>{{ l('users.friends') }}</h4>
-      <div v-for="character in friends" :key="character.name">
+      <div
+        v-for="character in friends"
+        :key="character.name"
+        class="userlist-item"
+      >
         <user
           :character="character"
           :showStatus="true"
@@ -27,7 +31,11 @@
         ></user>
       </div>
       <h4>{{ l('users.bookmarks') }}</h4>
-      <div v-for="character in bookmarks" :key="character.name">
+      <div
+        v-for="character in bookmarks"
+        :key="character.name"
+        class="userlist-item"
+      >
         <user
           :character="character"
           :showStatus="true"
@@ -45,7 +53,11 @@
           {{ l('users.memberCount', channel.sortedMembers.length) }}
           <a class="btn sort" @click="switchSort"><i class="fa fa-sort"></i></a>
         </h4>
-        <div v-for="member in filteredMembers" :key="member.character.name">
+        <div
+          v-for="member in filteredMembers"
+          :key="member.character.name"
+          class="userlist-item"
+        >
           <user
             :character="member.character"
             :channel="channel"
@@ -285,6 +297,12 @@
       .body {
         overflow-x: hidden;
       }
+    }
+
+    .userlist-item {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
     }
 
     @media (min-width: breakpoint-min(md)) {

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -167,6 +167,10 @@
   font-weight: 600;
 }
 
+.userlist-item {
+  color: $text-muted;
+}
+
 .message {
   word-wrap: break-word;
   padding-bottom: 1px;


### PR DESCRIPTION
Before/ After:

<img width="206" alt="Screenshot 2025-04-14 at 11 25 06" src="https://github.com/user-attachments/assets/1dc15bb1-6f71-4a89-ba72-ae58c09e6af5" /> <img width="210" alt="Screenshot 2025-04-14 at 11 24 03" src="https://github.com/user-attachments/assets/e90a9c2f-785f-4043-add2-5314fce29d92" />


I opted for the muted color for the ellipsis over trying to get them to match the child color, because that'd have required reorganisation of the actual components which I felt was going too far.