### PR TITLE
Unifies copyright information

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -1,8 +1,8 @@
 {
   "name": "horizon-electron",
   "version": "1.30.1",
-  "author": "The F-List Team and Mister Stallion (Esq.)",
-  "description": "F-List.net Chat Client",
+  "author": "The F-List Team and FChat Horizon Cobtributors",
+  "description": "A heavily modded FChat 3.0 client for F-List, continued from Rising",
   "homepage": "https://horizn.moe",
   "main": "main.js",
   "license": "MIT",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "horizon-electron",
   "version": "1.30.1",
-  "author": "The F-List Team and FChat Horizon Cobtributors",
+  "author": "The F-List Team and FChat Horizon Contributors",
   "description": "A heavily modded FChat 3.0 client for F-List, continued from Rising",
   "homepage": "https://horizn.moe",
   "main": "main.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fchat-horizon",
   "version": "1.30.1",
-  "author": "The F-List Team and FChat Horizon Cobtributors",
+  "author": "The F-List Team and FChat Horizon Contributors",
   "description": "A heavily modded FChat 3.0 client for F-List, continued from Rising",
   "license": "MIT",
   "main": "main.js",


### PR DESCRIPTION
The Electron app specifically uses the ``electron/package.json`` file to display its author information for the installed app, not the one in the root project.
It now has the same info as that one.

Also fixes #31 