### PR TITLE
fix: Listeners are not properly removed when logging out

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -464,6 +464,7 @@
       void core.adCenter.load();
     }
 
+    @Hook('destroyed')
     destroyed(): void {
       window.removeEventListener('keydown', this.keydownListener);
       window.removeEventListener('focus', this.focusListener);


### PR DESCRIPTION
Normally, trying to add an event listener to the DOM that already exists fails, but adding one in a Vue component mount hook creates another instance of the function, bypassing the built-in duplicate check.

When logging out, the event listeners added here aren't removed properly because logging out only unmounts it, it doesn't trigger the destroy hook. Vue 3 has an onUnmounted hook for this, but this is the best we have.

There might be other solutions to this, like removing any others before we add them or having some variable keep track of them, but this seems the simplest and least messy.

...event listener bug 2: electric boogaloo!