### PR TITLE
Makes conversation list status icons consistent w/ user list

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -577,11 +577,11 @@
         crown: { color: 'online', icon: ['fas', 'fa-crown'] },
         online: { color: 'online', icon: ['fas', 'fa-circle'] },
         looking: { color: 'online', icon: ['fa', 'fa-eye'] },
-        offline: { color: 'offline', icon: ['fas', 'fa-circle'] },
-        busy: { color: 'away', icon: ['fas', 'fa-circle'] },
-        idle: { color: 'away', icon: ['fas', 'fa-circle'] },
-        dnd: { color: 'away', icon: ['fas', 'fa-circle'] },
-        away: { color: 'away', icon: ['fas', 'fa-circle'] }
+        offline: { color: 'offline', icon: ['fa', 'fa-ban'] },
+        busy: { color: 'away', icon: ['fa', 'fa-cog'] },
+        idle: { color: 'away', icon: ['far', 'fa-clock'] },
+        dnd: { color: 'dnd', icon: ['fa', 'fa-minus-circle'] },
+        away: { color: 'away', icon: ['far', 'fa-circle'] }
       };
 
       const cls = { [styling[status].color]: true };
@@ -745,6 +745,9 @@
 
         .away {
           color: #c7894f;
+        }
+        .dnd {
+          color: #ce2d4f;
         }
 
         .fa-comment,


### PR DESCRIPTION
Because there's a big difference in expectations between someone being set to "Busy" and someone set to "Do not disturb". These are the same icons used for UserView elements in the user list and search results.

<img width="309" alt="Screenshot 2025-04-18 at 18 29 22" src="https://github.com/user-attachments/assets/e3c1655c-b946-4d6d-9b97-b9d3ada1e97d" />
