### PR TITLE
Brings MacOS devtools shortcut in line with platform's expectations

### DIFF
--- a/electron/chat.ts
+++ b/electron/chat.ts
@@ -64,10 +64,18 @@ import { WordPosSearch } from '../learn/dictionary/word-pos-search';
 
 log.debug('init.chat');
 
-document.addEventListener('keydown', (e: KeyboardEvent) => {
-  if (e.ctrlKey && e.shiftKey && getKey(e) === Keys.KeyI)
-    remote.getCurrentWebContents().toggleDevTools();
-});
+document.addEventListener(
+  'keydown',
+  process.platform !== 'darwin'
+    ? (e: KeyboardEvent) => {
+        if (e.ctrlKey && e.shiftKey && getKey(e) === Keys.KeyI)
+          remote.getCurrentWebContents().toggleDevTools();
+      }
+    : (e: KeyboardEvent) => {
+        if (e.metaKey && e.altKey && getKey(e) === Keys.KeyI)
+          remote.getCurrentWebContents().toggleDevTools();
+      }
+);
 
 /* process.env.SPELLCHECKER_PREFER_HUNSPELL = '1';
 const sc = nativeRequire<{


### PR DESCRIPTION
Chrome (and Safari) on MacOS uses Command+Option+I to open the dev tools– this is taken care of for the dev tools window that opens for the entire Electron window while in development mode, but the one that opens for an individual tab instance uses the same shortcut regardless of platform.