### PR TITLE
fix: Channel message lag

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -356,25 +356,17 @@
       window.addEventListener('keydown', this.keydownListener);
       this.setFontSize(core.state.settings.fontSize);
 
-      this.$watch(
-        'conversations.channelConversations',
-        newVal => {
-          if (newVal?.length) {
-            this.channelCanGlow = false;
-          }
-        },
-        { deep: true }
-      );
+      this.$watch('conversations.channelConversations', newVal => {
+        if (newVal?.length) {
+          this.channelCanGlow = false;
+        }
+      });
 
-      this.$watch(
-        'conversations.privateConversations',
-        newVal => {
-          if (newVal?.length) {
-            this.privateCanGlow = false;
-          }
-        },
-        { deep: true }
-      );
+      this.$watch('conversations.privateConversations', newVal => {
+        if (newVal?.length) {
+          this.privateCanGlow = false;
+        }
+      });
 
       Sortable.create(<HTMLElement>this.$refs['privateConversations'], {
         animation: 50,


### PR DESCRIPTION
Closes #102.

This probably needs further testing but I don't have time now. But I can't see that the removal `deep: true` has any negative effect (or any effect at all) and the lag problem is gone with it removed.