### PR TITLE
Fix scary "Logs corrupt! Repair now!" 

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 
 # Download
 
-[Windows x64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat%20Horizon-win-x64.exe) |
-[Windows arm64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat%20Horizon-win-arm64.exe) |
-[MacOS (Universal)](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat%20Horizon-mac-universal.dmg) |
-[Linux x64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat%20Horizon-linux-x64.AppImage) |
-[Linux arm64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat%20Horizon-linux-arm64.AppImage)
+[Windows x64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-win-x64.exe) |
+[Windows arm64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-win-arm64.exe) |
+[MacOS (Universal)](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-mac-universal.dmg) |
+[Linux x64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-x64.AppImage) |
+[Linux arm64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-arm64.AppImage)
 
 # F-Chat Horizon
 
@@ -75,7 +75,7 @@ F-chat Rising can be installed on all _major_ operating systems (Minus BSDs.)
 > Due to that nature of Mac, MacOS builds are **experimental**. Please [contact me](https://horizn.moe/contact.html) if you have any issues.
 
 1. Download the installer. This _should_ work for M1 / Intel based systems
-   - [MacOS (Universal)](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat%20Horizon-mac-universal.dmg)
+   - [MacOS (Universal)](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-mac-universal.dmg)
 2. Open the downloaded .dmg file and drag the application to your Applications folder.
 
 ## Linux

--- a/chat/PmPartnerAdder.vue
+++ b/chat/PmPartnerAdder.vue
@@ -39,6 +39,8 @@
     }
 
     submit(): void {
+      if (!this.name) return;
+
       const c = core.characters.get(this.name);
 
       if (c) {

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -319,6 +319,7 @@ Once this process has started, do not interrupt it or your logs will get corrupt
     'The value for the parameter {0} is invalid. Please use the Help (click the ? button) if you need further information.',
   'commands.invalidCharacter':
     'The character you entered is not online. Put the name in double quotes if you want to override. Please use the Help (click the ? button) if you need further information.',
+  'commands.emptyCharacter': 'Enter a character name.',
   'commands.help': 'Command Help',
   'commands.help.syntax': 'Syntax: {0}',
   'commands.help.contextChannel':

--- a/chat/slash_commands.ts
+++ b/chat/slash_commands.ts
@@ -94,6 +94,7 @@ export function parse(
             value.charAt(value.length - 1) === '"'
           ) {
             values[i] = value.substring(1, value.length - 1);
+            if (!values[i]) return l('commands.emptyCharacter');
             break;
           }
           const char = core.characters.get(value);


### PR DESCRIPTION
There is a problem in the [PM Partner Adder](https://github.com/Fchat-Horizon/Horizon/blob/main/chat/PmPartnerAdder.vue#L42) where if you enter a blank value and hit the button, you get a scary "logs are corrupt! repair now!" notice as a result of opening a PM with an empty-named character. The notice appears to be the result of trying to open a log file with no name.

There does not appear to be _actual_ corruption from simply opening the chat pane; but I haven't tried sending a message to see if bad things happen when trying to write to the non-existent log; probably not, since the user with no name cannot be online and thus you can't send them any messages. But a normal user shouldn't be ending up in this position in the first place.

This PR is the minimum necessary code to fix the jumpscare. There are only two places I've found that allow raw user-input for a character name, but there may be more. The `/priv` chat command is the yet-mentioned. I opt to fix the issue directly at the sources instead of in `core.characters.get()` function on three beliefs:
1. Changing `.get()` to be able to return null and hunting down all the places that might affect requires an amount of work greater than none.
2. Other potential changes (allow `.get()` to turn an empty string into a predetermined name, for example) require additional consideration that would delay a fix.
3. Sanitizing external input as soon as it enters the application is best practice.

There are additional problems with the surrounding code in both places (`if Character is not Falsey ...`? Really? The entire PmPartnerAdder is completely broken...) but they don't turn an innocent roleplayer's heart to ice by invoking the terrifying "logs corrupt" message, so they don't need to be addressed here.