### PR TITLE
Fixes .dmg icon positions

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -42,19 +42,19 @@
       "background": "build/dmg.png",
       "contents": [
         {
-          "x": 130,
-          "y": 220
+          "x": 554,
+          "y": 110
         },
         {
-          "x": 410,
-          "y": 220,
+          "x": 554,
+          "y": 344,
           "type": "link",
           "path": "/Applications"
         }
       ],
       "window": {
-        "width": 540,
-        "height": 380
+        "width": 658,
+        "height": 498
       }
     },
     "linux": {


### PR DESCRIPTION
Fixes #115 

Before:
![image](https://github.com/user-attachments/assets/07fa65fd-5698-4254-9c0c-1d1598df2c65)

After:
<img width="659" alt="image" src="https://github.com/user-attachments/assets/5eccdb39-7c1d-4264-b0e6-a56cd3b41cef" />

