### PR TITLE
Fixes Windows notifications being stinky poopoo

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -435,7 +435,7 @@ function onReady(): void {
 
   log.info('Starting application.');
 
-  app.setAppUserModelId('com.squirrel.fchat.F-Chat');
+  app.setAppUserModelId('net.flist.fchat');
   app.on('open-file', createWindow);
 
   if (settings.version !== app.getVersion()) {

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -28,7 +28,7 @@ export default class Notifications extends BaseNotifications {
           remote.getCurrentWebContents().id
         );
         conversation.show();
-        browserWindow.restore();
+        if (browserWindow.isMinimized()) browserWindow.restore();
         browserWindow.focus();
         notification.close();
       };

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -28,6 +28,7 @@ export default class Notifications extends BaseNotifications {
           remote.getCurrentWebContents().id
         );
         conversation.show();
+        browserWindow.restore();
         browserWindow.focus();
         notification.close();
       };

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "horizon-electron",
   "version": "1.30.3",
   "author": "The F-List Team and FChat Horizon Contributors",
-  "description": "A heavily modded FChat 3.0 client for F-List, continued from Rising",
+  "description": "FChat Horizon",
   "homepage": "https://horizn.moe",
   "main": "main.js",
   "license": "MIT",


### PR DESCRIPTION
After 1.30.1 the App ID for building in Electron was changed to ``net.flist.fchat``– except that it wasn't updated in main.ts. I don't really know how many people have already switched to post-1.29 versions, and I don't think flip-flopping the appId in electron's package.json is a good idea either. [We have already seen what happened because of the first change](https://github.com/Fchat-Horizon/Horizon/issues/119), so we better just stick with the new appId from now on.

Making this a draft PR because I want to see if this breaks something horribly first. It seems fine for now though. I also want to force push #123 (and the fixes for the issue below) in one commit, but I want to test the changes individually first. I don't yet know if changing the appID like this breaks stuff on existing Linux and Mac installations.

Fixes #94 