### PR TITLE
Fixes Windows fileDescription property for executable

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "horizon-electron",
   "version": "1.30.3",
   "author": "The F-List Team and FChat Horizon Contributors",
-  "description": "A heavily modded FChat 3.0 client for F-List, continued from Rising",
+  "description": "F-Chat Horizon",
   "homepage": "https://horizn.moe",
   "main": "main.js",
   "license": "MIT",


### PR DESCRIPTION
I'm not sure where else this description is even used aside from Task Manager and when you mouse over the executable file, but electron-builder sets the .exe's fileDescription property to this value. Which is, uh...

![image](https://github.com/user-attachments/assets/a6d89fd1-f354-4fc3-bc96-8f0a47374aad)


Not what it's supposed to be used for.

After the change:

![image](https://github.com/user-attachments/assets/20146ae2-5a6c-4645-856a-a2987c68d864)


Blame this on me, because I had the "bright" idea of copying over the package info from the main Node project.

