### PR TITLE
Changes Prettier pre-commit hook to check instead of write

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -26,6 +26,24 @@ jobs:
           pr_number="${GITHUB_REF#refs/pull/}"
           pr_number="${pr_number%/merge}"
           echo "version=pr-${pr_number}" >> $GITHUB_OUTPUT
+  #This is its own job, because a build's success should be independent of Prettier's opinions (and vice versa). Sometimes we might want to push noncompliant code.
+  prettier:
+    name: Prettier Validation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Install Prettier
+        run: |
+          pnpm install -g prettier
+      - name: Prettier Format Check
+        run: |
+          pnpm check
 
   build:
     name: Build

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-pnpm lint
+pnpm check

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "watch": "cd electron && pnpm watch",
     "start": "cd electron && pnpm start",
     "lint": "pnpm prettier --write .",
+    "check": "pnpm prettier --check .",
     "prepare": "husky"
   },
   "pnpm": {


### PR DESCRIPTION
Current situation:
1. Person writes code and commits
2. Prettier checks and writes changes
3. Because Prettier doesn't return a non-zero exit code on a successful write run (and why would it?), the commit goes through
4. Now Prettier's changes are unstaged and not part of the commit
5. "Oops, I forgot to format myself but now prettier did it for me!"
6. Person winds up making an additional formatting commit

Rinse and repeat until half the commit history of a file is just "Prettier". Not even being snarky to any poor contributors here, I'm just as guilty of this as anyone else :')

Meanwhile ``prettier --check .`` returns 1 as the exit code if it finds formatting errors in any files, which blocks a commit from happening. You can still run ``git commit --no-verify[...]`` if you _really_ want to push unformatted code.

Right now the whole development branch is Prettier compliant anyway, ~~but to prevent any more trouble we could also add a Prettier check in the PR pipeline.~~

Edit:

Force pushed a newer version. It keeps ``pnpm lint`` intact as a command, and the check shorthand has now moved to ``pnpm check``, which both the pre-commit hook and a new job in the PR Build Validation pipeline use.
Code formatting is exactly the kind of thing you'd want to validate on both ends, so I don't think making it an extra workflow job is excessive.