### PR TITLE
docs(readme): fix table of contents link to AUR package info

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     - [Debian/Ubuntu (deb)](#debianubuntu-deb)
     - [AppImage](#appimage)
     - [Tarball (tar.gz)](#tarball-targz)
-    - [Arch-based (pacman)](#arch-based-pacman)
+    - [Arch-based (AUR)](#arch-based-aur)
 - [Usage](#usage)
   - [Getting started](#getting-started)
   - [Wiki](#wiki)


### PR DESCRIPTION
This wasn't properly updated when it was switched to an AUR package, so just a small correction.

P.S. wish I could contribute more, been super busy :cry: