### PR TITLE
Experiment: Changes most F-Chat (Horizon) instances to be consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Table of Contents <!-- omit in toc -->
 
 - [Download](#download)
-- [F-Chat Horizon](#f-chat-horizon)
+- [Horizon](#f-chat-horizon)
   - [Features](#features)
   - [Goals](#goals)
 - [Installing](#installing)
@@ -27,7 +27,7 @@
 [Linux x64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-x86_64.AppImage) |
 [Linux arm64](https://github.com/Fchat-Horizon/Horizon/releases/latest/download/F-Chat.Horizon-linux-arm64.AppImage)
 
-# F-Chat Horizon
+# Horizon
 
 This repository contains a continuation of the heavily customized F-Chat Rising, a version of the mainline F-Chat 3.0 client.
 
@@ -43,7 +43,7 @@ In a non-exhaustive list, F-Chat Horizon has these features!
 
 ## Goals
 
-F-Chat Horizon aims to be an opinionated fork of F-Chat Rising. Instead of aiming solely to be a more customized fork of the original client, we aim to:
+Horizon aims to be an opinionated fork of F-Chat Rising. Instead of aiming solely to be a more customized fork of the original client, we aim to:
 
 - Set a sound foundation for further forks, with different goals.
 - Enforce code-quality standards

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -12,7 +12,7 @@ const strings: { [key: string]: string | undefined } = {
   'action.open': 'Show',
   'action.close': 'Close',
   'action.quit': 'Quit',
-  'action.about': 'About F-Chat Horizon',
+  'action.about': 'About Horizon',
   'action.newWindow': 'Open new window',
   'action.newTab': 'Open new tab',
   'action.updateAvailable': 'UPDATE AVAILABLE',
@@ -31,7 +31,7 @@ const strings: { [key: string]: string | undefined } = {
   'consoleWarning.head': 'THIS IS THE DANGER ZONE.',
   'consoleWarning.body': `ANYTHING YOU WRITE OR PASTE IN HERE COULD BE USED TO STEAL YOUR PASSWORDS OR TAKE OVER YOUR ENTIRE COMPUTER. This is where happiness goes to die. If you aren't a developer or a special kind of daredevil, please get out of here!`,
   help: 'Help',
-  'help.fchat': 'F-Chat Horizon Help and Changelog',
+  'help.fchat': 'Horizon Help and Changelog',
   'help.feedback': 'Report a Bug / Suggest Something',
   'help.rules': 'F-List Rules',
   'help.faq': 'F-List FAQ',
@@ -42,8 +42,8 @@ const strings: { [key: string]: string | undefined } = {
   'spellchecker.remove': 'Remove from Dictionary',
   'spellchecker.noCorrections': 'No corrections available',
   'window.newTab': 'New tab',
-  title: 'F-Chat',
-  'title.connected': 'F-Chat ({0})',
+  title: 'Horizon',
+  'title.connected': 'Horizon ({0})',
   version: 'Version {0}',
   filter: 'Type to filter...',
   confirmYes: 'Yes',
@@ -192,11 +192,11 @@ Are you sure?`,
   'settings.logDir': 'Change log location',
   'settings.logDir.confirm': `Do you want to set your log location to {0}?
 
-No files will be moved. If you click Yes here, F-Chat will shut down. If you would like to keep your log files, please move them manually before restarting F-Chat.
+No files will be moved. If you click Yes here, Horizon will shut down. If you would like to keep your log files, please move them manually before restarting Horizon.
 
 Current log location: {1}`,
   'settings.logDir.inAppDir':
-    'Please set your log directory to a location outside of the F-Chat installation directory, as it would otherwise be overwritten during an update.',
+    'Please set your log directory to a location outside of the Horizon installation directory, as it would otherwise be overwritten during an update.',
   'settings.logMessages': 'Log messages',
   'settings.logAds': 'Log ads',
   'settings.fontSize': 'Font size (experimental)',

--- a/electron/BrowserOption.vue
+++ b/electron/BrowserOption.vue
@@ -53,7 +53,7 @@
                   <div>
                     This is an advanced setting. By changing this setting to an
                     unsupported program (i.e. not a browser), you might not be
-                    able to open links from F-Chat anymore.
+                    able to open links from Horizon anymore.
                   </div>
 
                   <div v-if="isMac">

--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -10,7 +10,7 @@
       class="border-bottom"
       id="window-tabs"
     >
-      <h4 style="padding: 2px 0">F-Chat</h4>
+      <h4 style="padding: 2px 0">{{ l('title') }}</h4>
       <div
         class="btn"
         :class="'btn-' + (hasUpdate ? 'warning' : 'light')"

--- a/electron/about.html
+++ b/electron/about.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8" />
-    <title>About F-Chat Horizon</title>
+    <title>About Horizon</title>
     <style>
       body {
         font-family:
@@ -57,8 +57,8 @@
   </head>
   <body>
     <div class="container">
-      <img alt="F-Chat Horizon Logo" class="app-logo" />
-      <h1>F-Chat Horizon</h1>
+      <img alt="Horizon Logo" class="app-logo" />
+      <h1>Horizon</h1>
       <p>A modern F-Chat client</p>
 
       <div class="version-info">
@@ -83,7 +83,7 @@
         <a href="https://github.com/CodingWithAnxiety" target="_blank"
           >CodingWithAnxiety</a
         >. <br />
-        Thank you for using F-Chat Horizon!
+        Thank you for using Horizon!
       </p>
     </div>
 

--- a/electron/blocker/blocker.ts
+++ b/electron/blocker/blocker.ts
@@ -76,7 +76,7 @@ export class BlockerIntegration {
       log.warn(
         'adblock.init.error',
         'Adblocker failed to initialize.' +
-          'This does not break F-Chat Horizon, but may produce slower image previews',
+          'This does not break Horizon, but may produce slower image previews',
         err
       );
 

--- a/electron/browser_option.html
+++ b/electron/browser_option.html
@@ -6,7 +6,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self' 'unsafe-inline'; img-src https://static.f-list.net"
     />
-    <title>F-Chat</title>
+    <title>Horizon</title>
     <link href="fa.css" rel="stylesheet" />
   </head>
   <body>

--- a/electron/chat.ts
+++ b/electron/chat.ts
@@ -313,7 +313,7 @@ onSettings(settings);
 log.debug('init.chat.core');
 
 const connection = new Connection(
-  `F-Chat 3.0 (${process.platform})`,
+  `Horizon (${process.platform})`,
   remote.app.getVersion(),
   Socket
 );

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,14 +1,14 @@
 {
   "name": "horizon-electron",
   "version": "1.31.0",
-  "author": "The F-List Team and FChat Horizon Contributors",
-  "description": "FChat Horizon",
+  "author": "The F-List Team and Horizon Contributors",
+  "description": "Horizon",
   "homepage": "https://horizn.moe",
   "main": "main.js",
   "license": "MIT",
   "build": {
     "appId": "net.flist.fchat",
-    "productName": "F-Chat Horizon",
+    "productName": "Horizon",
     "artifactName": "${productName}-${os}-${arch}.${ext}",
     "directories": {
       "app": "app"
@@ -29,7 +29,7 @@
       "allowToChangeInstallationDirectory": true,
       "createDesktopShortcut": true,
       "createStartMenuShortcut": true,
-      "shortcutName": "F-Chat Horizon"
+      "shortcutName": "Horizon"
     },
     "mac": {
       "icon": "build/icon.icns",

--- a/electron/release-scripts/windows.ps1
+++ b/electron/release-scripts/windows.ps1
@@ -2,7 +2,7 @@
 
 <#
 .SYNOPSIS
-Windows build script for F-Chat Horizon.
+Windows build script for Horizon.
 
 .PARAMETER ReleaseVersion
 The version string for the release.

--- a/electron/window.html
+++ b/electron/window.html
@@ -6,7 +6,7 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self' 'unsafe-inline'; img-src https://static.f-list.net https://iili.io https://static1.e621.net https://i.imgur.com https://freeimage.host https://v3.redgifs.com"
     />
-    <title>F-Chat</title>
+    <title>Horizon</title>
     <link href="fa.css" rel="stylesheet" />
   </head>
   <body>

--- a/helpers/dialog.ts
+++ b/helpers/dialog.ts
@@ -4,7 +4,7 @@ export class Dialog {
   static confirmDialog(message: string): boolean {
     const result = remote.dialog.showMessageBoxSync({
       message,
-      title: 'F-Chat Horizon',
+      title: 'Horizon',
       type: 'question',
       buttons: ['Yes', 'No'],
       defaultId: 1,

--- a/learn/recommend/profile-recommendation.ts
+++ b/learn/recommend/profile-recommendation.ts
@@ -96,7 +96,7 @@ export class ProfileRecommendationAnalyzer {
         `ADD_HQ_AVATAR`,
         ProfileRecommendationLevel.CRITICAL,
         'Add a high-quality portrait',
-        'Profiles with a high-quality portraits stand out in chats with other F-Chat Horizon players.',
+        'Profiles with a high-quality portraits stand out in chats with other Horizon users.',
         'https://github.com/Fchat-Horizon/Horizon/wiki/High%E2%80%90Quality-Portraits'
       );
     } else if (!ProfileCache.isSafeRisingPortraitURL(profileUrl)) {

--- a/mobile/index.html
+++ b/mobile/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0, viewport-fit=cover" />
-	<title>FChat 3.0</title>
+	<title>Horizon</title>
 </head>
 <body>
 <div id="app">

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fchat-horizon",
   "version": "1.31.0",
-  "author": "The F-List Team and FChat Horizon Contributors",
+  "author": "The F-List Team and Horizon Contributors",
   "description": "A heavily modded FChat 3.0 client for F-List, continued from Rising",
   "license": "MIT",
   "main": "main.js",


### PR DESCRIPTION
\>Website refers to it as just "Horizon"
\>Look inside
\>Half the code calls it "F-Chat Horizon" in places visible to users
\>The other half just calls it "F-Chat" in places visible to users

<img width="491" alt="image" src="https://github.com/user-attachments/assets/08f9e349-68a6-49be-a169-88f3688ec4a0" />




<img width="1142" alt="Screenshot 2025-05-03 at 20 07 35" src="https://github.com/user-attachments/assets/d84c230b-cdab-484f-954e-7e4c96826eaf" />
