### PR TITLE
enhancement: Original colour option for gender markers

### DIFF
--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -354,6 +354,21 @@
       </div>
 
       <div class="form-group">
+        <label class="control-label" for="horizonGenderMarkerOrigColor">
+          <input
+            type="checkbox"
+            id="horizonGenderMarkerOrigColor"
+            v-model="horizonGenderMarkerOrigColor"
+            :disabled="
+              !horizonShowGenderMarker || !horizonShowCustomCharacterColors
+            "
+          />
+          Make gender icon use the original gender color instead of the custom
+          name color
+        </label>
+      </div>
+
+      <div class="form-group">
         <label class="control-label" for="horizonChangeOfflineColor">
           <input
             type="checkbox"
@@ -695,6 +710,7 @@
     risingShowHighQualityPortraits!: boolean;
     horizonShowCustomCharacterColors!: boolean;
     horizonShowGenderMarker!: boolean;
+    horizonGenderMarkerOrigColor!: boolean;
     horizonChangeOfflineColor!: boolean;
     horizonNotifyFriendSignIn!: boolean;
 
@@ -751,6 +767,7 @@
       this.horizonShowCustomCharacterColors =
         settings.horizonShowCustomCharacterColors;
       this.horizonShowGenderMarker = settings.horizonShowGenderMarker;
+      this.horizonGenderMarkerOrigColor = settings.horizonGenderMarkerOrigColor;
       this.horizonChangeOfflineColor = settings.horizonChangeOfflineColor;
 
       this.horizonNotifyFriendSignIn = settings.horizonNotifyFriendSignIn;
@@ -857,6 +874,7 @@
         risingShowHighQualityPortraits: this.risingShowHighQualityPortraits,
         horizonShowCustomCharacterColors: this.horizonShowCustomCharacterColors,
         horizonShowGenderMarker: this.horizonShowGenderMarker,
+        horizonGenderMarkerOrigColor: this.horizonGenderMarkerOrigColor,
         horizonChangeOfflineColor: this.horizonChangeOfflineColor,
         horizonNotifyFriendSignIn: this.horizonNotifyFriendSignIn,
 

--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -171,7 +171,13 @@
           : 'none';
 
       if (character.gender) {
-        genderClass = `fa ${getGenderIcon(character.gender, character.status)}`;
+        if (!core.state.settings.horizonGenderMarkerOrigColor) {
+          genderClass = `fa ${getGenderIcon(character.gender, character.status)}`;
+        } else {
+          genderClass =
+            `fa ${getGenderIcon(character.gender, character.status)}` +
+            ` gender-${gender}`;
+        }
       }
     }
 
@@ -183,7 +189,7 @@
 
     const userClass =
       `user-view` +
-      (isBookmark ? ' user-bookmark' : '') +
+      (isBookmark && !useOfflineColor ? ' user-bookmark' : '') +
       (character.overrides.characterColor && !useOfflineColor
         ? ` ${character.overrides.characterColor}NameText`
         : ` gender-${gender}`);

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -78,6 +78,7 @@ export class Settings implements ISettings {
   risingShowHighQualityPortraits = true;
   horizonShowCustomCharacterColors = true;
   horizonShowGenderMarker = false;
+  horizonGenderMarkerOrigColor = false;
   horizonChangeOfflineColor = false;
   horizonNotifyFriendSignIn = false;
 

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -288,6 +288,7 @@ export namespace Settings {
     readonly risingShowHighQualityPortraits: boolean;
     readonly horizonShowCustomCharacterColors: boolean;
     readonly horizonShowGenderMarker: boolean;
+    readonly horizonGenderMarkerOrigColor: boolean;
     readonly horizonChangeOfflineColor: boolean;
     readonly horizonNotifyFriendSignIn: boolean;
 


### PR DESCRIPTION
Implements the original gender-dots original colour as an option for the new gender icons as requested in https://github.com/Fchat-Horizon/Horizon/pull/139. Option disables whenever the markers are off or whenever the custom name colours are off to indicate that it requires these to change anything.

This version doesn't autoupdate, currently haven't found a good solution to make the colour change for this autoupdate. Easiest manual update is turning the icons off and on again. 

Might come back to see about a better method for this but the implementation of it currently doesn't align well with any of the attempted methods for the markers automatic updating, even the original method that was potentially poor on the performance. Ideal method performance-wise would just be watching for the setting changing in SettingsView itself and toggling markers off and back on again. I couldn't get it going in the little test run I had setting this up though.

This also includes a tiny fix for the new offline colour changing option, when using bookmark names they will properly go grey now when the bookmark goes offline.

Prettier has been run on it.