### PR TITLE
Adds 'Copy url' option to character gallery images

### DIFF
--- a/electron/chat.ts
+++ b/electron/chat.ts
@@ -167,9 +167,19 @@ webContents.on('context-menu', (_, props) => {
     );
   else if (
     props.linkURL.length > 0 &&
-    props.mediaType === 'none' &&
     props.linkURL.substr(0, props.pageURL.length) !== props.pageURL
   ) {
+    if (props.mediaType === 'none') {
+      menuTemplate.push({
+        id: 'toggleStickyness',
+        label: 'Toggle Sticky Preview',
+        click(): void {
+          EventBus.$emit('imagepreview-toggle-stickyness', {
+            url: props.linkURL
+          });
+        }
+      });
+    }
     menuTemplate.push({
       id: 'copyLink',
       label: l('action.copyLink'),
@@ -179,15 +189,7 @@ webContents.on('context-menu', (_, props) => {
         else electron.clipboard.writeText(props.linkURL);
       }
     });
-    menuTemplate.push({
-      id: 'toggleStickyness',
-      label: 'Toggle Sticky Preview',
-      click(): void {
-        EventBus.$emit('imagepreview-toggle-stickyness', {
-          url: props.linkURL
-        });
-      }
-    });
+
     if (process.platform === 'win32')
       menuTemplate.push({
         id: 'incognito',


### PR DESCRIPTION
This technically also adds this to instances of the ``[icon]`` tag, but those are actually broken (see #157) so we'll pretend that this is a bandage fix for that too :^)

Closes #138 