### PR TITLE
Experimental gender matcher rework (Community feedback appreciated)

### DIFF
--- a/learn/matcher.ts
+++ b/learn/matcher.ts
@@ -914,7 +914,7 @@ export class Matcher {
     }
 
     //Now we check if there is a specific preference listed.
-    const genderName = `${Gender[theirGender].toLowerCase()}s`;
+    const genderName = `${theirGender !== Gender.None ? Gender[theirGender].toLowerCase() : 'genderless'} characters`;
     const genderKinkScore = Matcher.getKinkGenderPreference(you, theirGender);
 
     if (genderKinkScore !== null) {

--- a/learn/matcher.ts
+++ b/learn/matcher.ts
@@ -62,7 +62,6 @@ export interface MatchResultCharacterInfo {
 
 export interface MatchResultScores {
   [key: number]: Score;
-  [TagId.Orientation]: Score;
   [TagId.Gender]: Score;
   [TagId.Age]: Score;
   [TagId.FurryPreference]: Score;
@@ -495,7 +494,6 @@ export class Matcher {
       total: 0,
 
       scores: {
-        [TagId.Orientation]: this.resolveOrientationScore(),
         [TagId.Gender]: this.resolveGenderScore(),
         [TagId.Age]: this.resolveAgeScore(),
         [TagId.FurryPreference]: this.resolveFurryPairingsScore(),
@@ -523,29 +521,17 @@ export class Matcher {
     return data;
   }
 
-  private resolveOrientationScore(): Score {
-    // Question: If someone identifies themselves as 'straight cuntboy', how should they be matched? like a straight female?
-
-    return Matcher.scoreOrientationByGender(
-      this.yourAnalysis.gender,
-      this.yourAnalysis.orientation,
-      this.theirAnalysis.gender
-    );
-  }
-
   static scoreOrientationByGender(
     yourGender: Gender | null,
     yourOrientation: Orientation | null,
     theirGender: Gender | null
   ): Score {
-    if (
-      yourGender === null ||
-      theirGender === null ||
-      yourOrientation === null ||
-      yourGender === Gender.None ||
-      theirGender === Gender.None
-    )
-      return new Score(Scoring.NEUTRAL);
+    //Pansexual characters are assumed to love all equally unless otherwise specified.
+    if (yourOrientation === Orientation.Pansexual) {
+      return new Score(Scoring.MATCH, 'Loves <span>all genders</span>');
+    }
+    if (yourGender === null || theirGender === null || yourOrientation === null)
+      return new Score(Scoring.WEAK_MISMATCH, 'Cannot infer preference.');
 
     // CIS
     // tslint:disable-next-line curly
@@ -558,7 +544,6 @@ export class Matcher {
         if (
           yourOrientation === Orientation.Gay ||
           yourOrientation === Orientation.Bisexual ||
-          yourOrientation === Orientation.Pansexual ||
           (yourOrientation === Orientation.BiFemalePreference &&
             theirGender === Gender.Female) ||
           (yourOrientation === Orientation.BiMalePreference &&
@@ -583,7 +568,6 @@ export class Matcher {
           yourOrientation === Orientation.Straight ||
           yourOrientation === Orientation.Bisexual ||
           yourOrientation === Orientation.BiCurious ||
-          yourOrientation === Orientation.Pansexual ||
           (yourOrientation === Orientation.BiFemalePreference &&
             theirGender === Gender.Female) ||
           (yourOrientation === Orientation.BiMalePreference &&
@@ -604,7 +588,10 @@ export class Matcher {
       }
     }
 
-    return new Score(Scoring.NEUTRAL);
+    return this.formatKinkScore(
+      KinkPreference.Maybe,
+      Gender[theirGender].toLowerCase() + 's'
+    );
   }
 
   static formatKinkScore(score: KinkPreference, description: string): Score {
@@ -919,48 +906,29 @@ export class Matcher {
 
     const yourGender = this.yourAnalysis.gender;
     const yourOrientation = this.yourAnalysis.orientation;
-    const theirGender = this.theirAnalysis.gender;
-
+    let theirGender = this.theirAnalysis.gender;
+    //Some people leave this field blank to imply their character is genderless too.
+    //Should we keep this, or automatically assume that the person in question forgot to fill this in?
     if (theirGender === null) {
-      return new Score(Scoring.NEUTRAL);
+      theirGender = Gender.None;
     }
 
+    //Now we check if there is a specific preference listed.
     const genderName = `${Gender[theirGender].toLowerCase()}s`;
     const genderKinkScore = Matcher.getKinkGenderPreference(you, theirGender);
 
-    if (genderKinkScore !== null)
+    if (genderKinkScore !== null) {
+      //If there is, we return it.
       return Matcher.formatKinkScore(genderKinkScore, genderName);
-
-    if (yourGender && yourOrientation) {
-      if (
-        Matcher.isCisGender(yourGender) &&
-        !Matcher.isCisGender(theirGender)
-      ) {
-        if (
-          [
-            Orientation.Straight,
-            Orientation.Gay,
-            Orientation.Bisexual,
-            Orientation.BiCurious,
-            Orientation.BiFemalePreference,
-            Orientation.BiMalePreference
-          ].includes(yourOrientation)
-        ) {
-          const nonBinaryPref = Matcher.getKinkPreference(you, Kink.Nonbinary);
-
-          if (nonBinaryPref) {
-            return Matcher.formatKinkScore(nonBinaryPref, 'non-binary genders');
-          }
-
-          return new Score(
-            Scoring.MISMATCH,
-            'No <span>non-binary</span> genders'
-          );
-        }
-      }
     }
 
-    return new Score(Scoring.NEUTRAL);
+    //No preference listed? Then we return based on assumed preference from the orientation.
+    let score = Matcher.scoreOrientationByGender(
+      yourGender,
+      yourOrientation,
+      theirGender
+    );
+    return score;
   }
 
   private resolveBodyTypeScore(): Score {
@@ -1426,11 +1394,19 @@ export class Matcher {
     c: Character,
     gender: Gender
   ): KinkPreference | null {
-    if (!(gender in genderKinkMapping)) {
-      return null;
-    }
+    const pref = Matcher.getKinkPreference(c, genderKinkMapping[gender]);
+    if (pref) return pref;
 
-    return Matcher.getKinkPreference(c, genderKinkMapping[gender]);
+    //If we can't find the gender preference *and* the gender is a nonbinary one? We check
+    //if the character in question has the nonbinary kink listed as a catch-all.
+    if (!this.isCisGender(gender)) {
+      return (
+        Matcher.getKinkPreference(c, Kink.Nonbinary) || KinkPreference.Maybe
+      );
+    }
+    //If we *really* can't find it, we return null, rather than a maybe value.
+    //This function is strictly for checking if somebody has a kink listed. *Not* for the final match score.
+    return null;
   }
 
   static getKinkSpeciesPreference(

--- a/site/character_page/infotag.vue
+++ b/site/character_page/infotag.vue
@@ -68,7 +68,6 @@
     theirInterestIsRelevant(id: number): boolean {
       return (
         id === TagId.FurryPreference ||
-        id === TagId.Orientation ||
         id === TagId.SubDomRole ||
         id === TagId.Position ||
         id === TagId.PostLength

--- a/site/character_page/sidebar.vue
+++ b/site/character_page/sidebar.vue
@@ -113,7 +113,6 @@
         <!-- <infotag-item v-for="infotag in quickInfoItems" :infotag="infotag" :key="infotag.id" :characterMatch="characterMatch"></infotag-item> -->
         <infotag-item
           v-for="id in quickInfoIds"
-          v-if="character.character.infotags[id]"
           :infotag="getInfotag(id)"
           :data="character.character.infotags[id]"
           :key="id"


### PR DESCRIPTION
I don't intend for this to be the final version at all (or anywhere near final), this is mostly to get an idea of what works and get the ball rolling for discussion.

For people who are out of the loop, this is part of a [larger initiative](https://github.com/Fchat-Horizon/Horizon/issues/158) to rework the matcher algorithm to better suit people's needs and expectations. It also happens to be both the one that's not particularly hard technically, but pretty complicated when it comes to the sociological implications. Which is why I want feedback before I present a "definitive" plan.

## How it works

_"Your character"_ in this case means the character whose POV the matcher test done from, it might not strictly be the user's character since matches are done both ways (and then the lowest score between the two is taken as the canonical one). _"Their character"_ likewise refers to the target of the test. 

1. First we try and find if the their gender is somewhere in your preferences list. If it is, we take that score and disregard the orientation. The Non-binary preference is used as a fallback in case their character is non-binary, but their _specific_ gender does not appear anywhere.
2. If we cannot infer the match from your kinks, we then try to parse it through your orientation: Straight cis characters match with the opposite end, pansexual with all, etc. This was originally its own, independent score that's now merged into this one, but otherwise the logic has not been touched apart from considering pansexual characters as if they'd love every gender equally. (And no longer automatically treating bisexual characters as if they dislike non-binary ones, though this was added in the tail end of Rising's lifespan).
3. If neither gives us enough to go off, we just throw it as a maybe. I personally think all unknown variables should be treated as a maybe, rather than left out– because otherwise you'd end up with good scores on profiles with basically 0 information. See also #160.



## Known issues/ considerations

- ~~The profile viewer builds the entries in the left-hand info column based on matcher results, so by merging the orientation match into the gender score orientations are no longer visible on profiles. For the full rework, this logic will be decoupled so all info will be visible properly, but I don't want to fix this for this proof of concept.~~ Fixed.

I'm going to add that I'm not trans myself, but I'm well aware of the issues that many trans people have with some of the gender options on the main site. When it comes to the matcher, I want it to be as inclusive as possible, so I'd be thankful for any input that can help with that.

- ~~How are bisexual characters meant to match with non-binary characters in the orientation check? I have left the logic untouched at the moment so that this can be discussed, but my idea would have been:~~ **_This bas been implemented the way I defined below. Feedback would be appreciated._**
  - Bisexual characters match the same as pansexual characters
  - Bi-F and Bi-F will have a weak match (dark green/ yes) with all genders _except_ the one they have a lean towards, which will be a strong match.
  - Bicurious gets treated as if the character were straight, except any "No" matches are now "Maybes"
- I have no colloquial term for them, but for genders like purples and greens; how are they meant to be treated when it comes to checking orientations? I'd personally assume that they are meant to be grouped by gender identity, but I don't want this to come off as insensitive.
- Transgender as an umbrella term for many different gender identities makes it kind of impossible to match people using just their orientation. I don't know what we can do about this given the limited options people have on the main site, other than telling people to fill in their profile more.
- ~~Genderless characters can sometimes be referred to as "nones", ie. "...likes nones", which is uh... Probably not what they're supposed to be called.~~ This has been fixed already.