### PR TITLE
Open Conversation and Join Channel quick fixes

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -856,6 +856,8 @@
       font-size: 90%;
       margin-left: 0.2em;
       margin-top: 0.25em;
+      -webkit-user-drag: none;
+      -webkit-app-region: no-drag;
     }
 
     .glowing {

--- a/chat/PmPartnerAdder.vue
+++ b/chat/PmPartnerAdder.vue
@@ -3,7 +3,6 @@
     action="Open Conversation"
     ref="dialog"
     @submit="submit"
-    style="width: 98%"
     dialogClass="ads-dialog"
     buttonText="Open"
   >


### PR DESCRIPTION
The Open Conversation and Join Channel buttons are no longer draggable- they'll be stuck in place at the bottom of their respective sections.

Also fixed the Open Conversation modal from eating the conversation view (vore joke here or something idk)

Closes #153, closes #164.