### PR TITLE
Font Awesome v6 Upgrade

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -41,37 +41,37 @@
       </div>
       <div style="clear: both">
         <a href="#" @click.prevent="showSearch()" class="btn"
-          ><span class="fas fa-search"></span>
+          ><span class="fas fa-fw fa-search"></span>
           {{ l('characterSearch.open') }}</a
         >
       </div>
       <div>
         <a href="#" @click.prevent="showSettings()" class="btn"
-          ><span class="fas fa-cog"></span> {{ l('settings.open') }}</a
+          ><span class="fas fa-fw fa-cog"></span> {{ l('settings.open') }}</a
         >
       </div>
       <div>
         <a href="#" @click.prevent="showRecent()" class="btn"
-          ><span class="fas fa-history"></span>
+          ><span class="fas fa-fw fa-history"></span>
           {{ l('chat.recentConversations') }}</a
         >
       </div>
 
       <div>
         <a href="#" @click.prevent="showAdCenter()" class="btn"
-          ><span class="fas fa-ad"></span> Ad Editor</a
+          ><span class="fas fa-fw fa-ad"></span> Ad Editor</a
         >
       </div>
 
       <div>
         <a href="#" @click.prevent="showAdLauncher()" class="btn"
-          ><span class="fas fa-play"></span> Post Ads</a
+          ><span class="fas fa-fw fa-play"></span> Post Ads</a
         >
 
         <span v-show="adsAreRunning()" class="adControls">
           <span
             aria-label="Stop All Ads"
-            class="fas fa-stop"
+            class="fas fa-fw fa-stop"
             @click.prevent="stopAllAds()"
           ></span>
         </span>
@@ -79,7 +79,7 @@
 
       <div>
         <a href="#" @click.prevent="showProfileAnalyzer()" class="btn"
-          ><span class="fas fa-user-md"></span> Profile Helper</a
+          ><span class="fas fa-fw fa-user-md"></span> Profile Helper</a
         >
       </div>
 

--- a/chat/UserMenu.vue
+++ b/chat/UserMenu.vue
@@ -102,7 +102,7 @@
         class="list-group-item list-group-item-action"
         :class="{ disabled: !hasAdLogs() }"
       >
-        <span class="far fa-fw fa-ad"></span>Show ad log
+        <span class="fa fa-fw fa-ad"></span>Show ad log
       </a>
       <a
         tabindex="-1"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@electron/remote": "^2.1.2",
     "@f-list/fork-ts-checker-webpack-plugin": "^3.1.1",
     "@f-list/vue-ts": "^1.0.3",
-    "@fortawesome/fontawesome-free": "^5.15.4",
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "@types/bluebird": "3.5.32",
     "@types/file-loader": "^5.0.4",
     "@types/lodash": "4.14.162",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,8 +60,8 @@ importers:
         specifier: ^1.0.3
         version: 1.0.3
       '@fortawesome/fontawesome-free':
-        specifier: ^5.15.4
-        version: 5.15.4
+        specifier: ^6.7.2
+        version: 6.7.2
       '@types/bluebird':
         specifier: 3.5.32
         version: 3.5.32
@@ -333,8 +333,8 @@ packages:
   '@f-list/vue-ts@1.0.3':
     resolution: {integrity: sha512-OnxqlnF4eq5OAswgyONoDXM+n1RF7bhdShi71BKyRDnsDVL9Skg8T/yiWsx80kvZ8ku8xfChrlLSFAwZMFwoaw==}
 
-  '@fortawesome/fontawesome-free@5.15.4':
-    resolution: {integrity: sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==}
+  '@fortawesome/fontawesome-free@6.7.2':
+    resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
 
   '@gar/promisify@1.1.3':
@@ -5665,7 +5665,7 @@ snapshots:
       typescript: 3.9.10
       vue: 2.6.12
 
-  '@fortawesome/fontawesome-free@5.15.4': {}
+  '@fortawesome/fontawesome-free@6.7.2': {}
 
   '@gar/promisify@1.1.3': {}
 

--- a/scss/package.json
+++ b/scss/package.json
@@ -5,7 +5,7 @@
   "description": "F-Chat Themes",
   "license": "MIT",
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^5.15.1",
+    "@fortawesome/fontawesome-free": "^6.7.2",
     "sass-embedded": "^1.85.1"
   },
   "scripts": {

--- a/scss/pnpm-lock.yaml
+++ b/scss/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@fortawesome/fontawesome-free':
-        specifier: ^5.15.1
-        version: 5.15.4
+        specifier: ^6.7.2
+        version: 6.7.2
       sass-embedded:
         specifier: ^1.85.0
         version: 1.85.1
@@ -24,8 +24,8 @@ packages:
   '@bufbuild/protobuf@2.2.3':
     resolution: {integrity: sha512-tFQoXHJdkEOSwj5tRIZSPNUuXK3RaR7T1nUrPgbYX1pUbvqqaaZAsfo+NXBPsz5rZMSKVFrgK1WL8Q/MSLvprg==}
 
-  '@fortawesome/fontawesome-free@5.15.4':
-    resolution: {integrity: sha512-eYm8vijH/hpzr/6/1CJ/V/Eb1xQFW2nnUKArb3z+yUWv7HTwj6M7SP957oMjfZjAHU6qpoNc2wQvIxBLWYa/Jg==}
+  '@fortawesome/fontawesome-free@6.7.2':
+    resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
 
   bootstrap@4.6.2:
@@ -204,7 +204,7 @@ snapshots:
 
   '@bufbuild/protobuf@2.2.3': {}
 
-  '@fortawesome/fontawesome-free@5.15.4': {}
+  '@fortawesome/fontawesome-free@6.7.2': {}
 
   bootstrap@4.6.2(jquery@3.7.1)(popper.js@1.16.1):
     dependencies:


### PR DESCRIPTION
Considering this a big 'maybe' PR since the style of the fonts changed in a way that some might not like. The upgrade itself was pretty straightforward and all the existing icons seem to work without any changes. It Just Works™️

In the screenshots below, the most notable change that might be contentious is the way they changed the ad icon. The text within the icon is smaller, so it's a little harder to read. It's little changes like this overall, but nothing _too_ jarring.

Left is v5, right is v6.
![image](https://github.com/user-attachments/assets/3d69aa28-7d4c-42cf-aa87-f7a627984d46)


Also fixed #151 since the ad we were trying to use for the 'Show ad log' button was from the pro plan- we're only using the free plan. That commit can be merged without the v6 upgrade commit if we want to hold off.