### PR TITLE
fix: Event listener deduplication

### DIFF
--- a/chat/preview/event-bus.ts
+++ b/chat/preview/event-bus.ts
@@ -69,7 +69,7 @@ class EventBusManager {
 
     this.eventCallbacks[eventName] = _.filter(
       this.eventCallbacks[eventName],
-      cb => cb.toString() !== callback.toString()
+      cb => cb !== callback
     );
   }
 


### PR DESCRIPTION
Reverting this change from a previous commit (c1e53c7). Technically this doesn't actually do anything, so it *could* be removed, but it's harmless to leave it like this (and evidently breaks some things if you try to make it do what it's meant to) and I'm not sure if there are any other implications. And it feels a bit strange to leave this function totally blank.

Closes #172.