### PR TITLE
Switches scroll bars to Chrome native ones

### DIFF
--- a/scss/themes/_chat.scss
+++ b/scss/themes/_chat.scss
@@ -39,27 +39,3 @@
     --#{$varName}: #{$value};
   }
 }
-
-* {
-  &::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 8px $card-border-color;
-    border-radius: 10px;
-  }
-
-  &::-webkit-scrollbar {
-    width: 12px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.8);
-    background-color: $gray-300;
-    &:hover {
-      background-color: $gray-500;
-    }
-
-    &:active {
-      background-color: $gray-700;
-    }
-  }
-}

--- a/scss/themes/chat/dark dimmed.scss
+++ b/scss/themes/chat/dark dimmed.scss
@@ -8,30 +8,6 @@
 // Apply variables to theme.
 @import '../chat';
 
-* {
-  &::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 2px $card-border-color;
-    border-radius: 10px;
-  }
-
-  &::-webkit-scrollbar {
-    width: 12px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.8);
-    background-color: $gray-300;
-    &:hover {
-      background-color: $gray-500;
-    }
-
-    &:active {
-      background-color: $gray-700;
-    }
-  }
-}
-
 .colorblindMode {
   @import '../colorblind';
   @import '../../rising';

--- a/scss/themes/chat/dark.scss
+++ b/scss/themes/chat/dark.scss
@@ -8,30 +8,6 @@
 // Apply variables to theme.
 @import '../chat';
 
-* {
-  &::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 2px $card-border-color;
-    border-radius: 10px;
-  }
-
-  &::-webkit-scrollbar {
-    width: 12px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.8);
-    background-color: $gray-300;
-    &:hover {
-      background-color: $gray-500;
-    }
-
-    &:active {
-      background-color: $gray-700;
-    }
-  }
-}
-
 .colorblindMode {
   @import '../colorblind';
   @import '../../rising';

--- a/scss/themes/chat/default.scss
+++ b/scss/themes/chat/default.scss
@@ -8,30 +8,6 @@
 // Apply variables to theme.
 @import '../chat';
 
-* {
-  &::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 2px $card-border-color;
-    border-radius: 10px;
-  }
-
-  &::-webkit-scrollbar {
-    width: 12px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.8);
-    background-color: $gray-300;
-    &:hover {
-      background-color: $gray-500;
-    }
-
-    &:active {
-      background-color: $gray-700;
-    }
-  }
-}
-
 .colorblindMode {
   @import '../colorblind';
   @import '../../rising';

--- a/scss/themes/chat/dracula.scss
+++ b/scss/themes/chat/dracula.scss
@@ -22,30 +22,6 @@ $orange-color: $dracula-orange;
 // Apply variables to theme.
 @import '../chat';
 
-* {
-  &::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 2px $card-border-color;
-    border-radius: 10px;
-  }
-
-  &::-webkit-scrollbar {
-    width: 12px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.8);
-    background-color: $gray-300;
-    &:hover {
-      background-color: $gray-500;
-    }
-
-    &:active {
-      background-color: $gray-700;
-    }
-  }
-}
-
 $genders: (
   'shemale': $dracula-purple,
   'herm': color.scale($dracula-purple, $saturation: -0.36%, $lightness: -10.78%),

--- a/scss/themes/chat/light.scss
+++ b/scss/themes/chat/light.scss
@@ -8,30 +8,6 @@
 // Apply variables to theme.
 @import '../chat';
 
-* {
-  &::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 2px $gray-500;
-    border-radius: 10px;
-  }
-
-  &::-webkit-scrollbar {
-    width: 12px;
-  }
-
-  &::-webkit-scrollbar-thumb {
-    border-radius: 10px;
-    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.8);
-    background-color: $gray-800;
-    &:hover {
-      background-color: $gray-600;
-    }
-
-    &:active {
-      background-color: $gray-500;
-    }
-  }
-}
-
 .colorblindMode {
   @import '../colorblind';
   @import '../../rising';

--- a/scss/themes/variables/_dark_derived.scss
+++ b/scss/themes/variables/_dark_derived.scss
@@ -4,3 +4,7 @@ $blue-color: #06f;
 .blackNameText {
   @include text-outline($gray-600);
 }
+
+:root {
+  color-scheme: dark;
+}

--- a/scss/themes/variables/_default_derived.scss
+++ b/scss/themes/variables/_default_derived.scss
@@ -8,4 +8,8 @@
   @include text-outline($gray-600);
 }
 
+:root {
+  color-scheme: dark;
+}
+
 $blue-color: #06f;

--- a/scss/themes/variables/_dracula_derived.scss
+++ b/scss/themes/variables/_dracula_derived.scss
@@ -4,3 +4,7 @@ $blue-color: $blue-color;
 .blackNameText {
   @include text-outline($gray-600);
 }
+
+:root {
+  color-scheme: dark;
+}

--- a/scss/themes/variables/_light_derived.scss
+++ b/scss/themes/variables/_light_derived.scss
@@ -2,3 +2,7 @@
 .whiteNameText {
   @include text-outline($gray-600);
 }
+
+:root {
+  color-scheme: light;
+}


### PR DESCRIPTION
This also sets a global CSS color scheme for all themes– in this case so that the scrollbar's gutter (which is only visible when you manually drag the thumb) respects whether or not the theme is light or dark, rather than consult the OS's color scheme setting, but in the future this will be useful if we do things like move certain dialog windows into global modal dialogs.

https://github.com/user-attachments/assets/99a8b0c9-3aaf-47b2-abdb-31f41e75405b

I wasn't a big fan of the custom ones we had because I felt they were too obnoxiously visible. These are a lot more subtle (and they're also more in line with the browser experience anyway).

