### PR TITLE
Development mode indicators

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -54,7 +54,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       PR_VERSION: ${{ needs.set-version.outputs.version }}
-      APP_VERSION: 'Pr #$PR_VERSION'
+      APP_VERSION: Pr #${{ needs.set-version.outputs.version }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -54,7 +54,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       PR_VERSION: ${{ needs.set-version.outputs.version }}
-      APP_VERSION: Pr #${{ needs.set-version.outputs.version }}
+      APP_VERSION: PR_${{ needs.set-version.outputs.version }}
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -54,6 +54,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     env:
       PR_VERSION: ${{ needs.set-version.outputs.version }}
+      APP_VERSION: 'Pr #$PR_VERSION'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
@@ -94,21 +95,21 @@ jobs:
         run: |
           # Execute Linux build script
           chmod +x electron/release-scripts/linux.sh
-          electron/release-scripts/linux.sh "$PR_VERSION" "$GITHUB_WORKSPACE/release_artifacts/linux/$PR_VERSION"
+          electron/release-scripts/linux-dev.sh "$PR_VERSION" "$GITHUB_WORKSPACE/release_artifacts/linux/$PR_VERSION"
 
       - name: Run Build Script (macOS)
         if: matrix.os == 'macos-latest'
         run: |
           # Execute macOS build script
           chmod +x electron/release-scripts/macos.sh
-          electron/release-scripts/macos.sh "$PR_VERSION" "$GITHUB_WORKSPACE/release_artifacts/macos/$PR_VERSION"
+          electron/release-scripts/macos-dev.sh "$PR_VERSION" "$GITHUB_WORKSPACE/release_artifacts/macos/$PR_VERSION"
 
       - name: Run Build Script (Windows)
         if: matrix.os == 'windows-latest'
         shell: pwsh
         run: |
           # Execute Windows build script
-          .\electron\release-scripts\windows.ps1 -ReleaseVersion "$env:PR_VERSION" -ReleasePath "$env:GITHUB_WORKSPACE\release_artifacts\windows\$env:PR_VERSION"
+          .\electron\release-scripts\windows-dev.ps1 -ReleaseVersion "$env:PR_VERSION" -ReleasePath "$env:GITHUB_WORKSPACE\release_artifacts\windows\$env:PR_VERSION"
 
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -45,6 +45,7 @@ const strings: { [key: string]: string | undefined } = {
   title: 'F-Chat',
   'title.connected': 'F-Chat ({0})',
   version: 'Version {0}',
+  developmentVersion: 'Development build [{0}]',
   filter: 'Type to filter...',
   confirmYes: 'Yes',
   confirmNo: 'No',

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -861,7 +861,12 @@ function onReady(): void {
               )
           },
           {
-            label: l('version', app.getVersion()),
+            label: l(
+              process.env.NODE_ENV !== 'development'
+                ? 'version'
+                : 'developmentVersion',
+              process.env.APP_VERSION || app.getVersion()
+            ),
             click: showCurrentPatchNotes
           }
         ]

--- a/electron/package.json
+++ b/electron/package.json
@@ -73,8 +73,11 @@
     "startDebugMain": "ELECTRON_ENABLE_LOGGING=1 electron --serve --inspect-brk=9229 .",
     "startDebugRender": "ELECTRON_ENABLE_LOGGING=1 electron --remote-debugging-port=9229 .",
     "build:win": "mkdir -p dist && (node ../webpack production && electron-builder --win nsis --arm64 --x64) | tee dist/build.log",
+    "build:dev:win": "mkdir -p dist && (node ../webpack development && electron-builder --win nsis --arm64 --x64) | tee dist/build.log",
     "build:mac": "mkdir -p dist && (node ../webpack production && electron-builder --mac dmg --universal) | tee dist/build.log",
-    "build:linux": "mkdir -p dist && (node ../webpack production && electron-builder --linux deb tar.gz AppImage --arm64 --x64) | tee dist/build.log"
+    "build:dev:mac": "mkdir -p dist && (node ../webpack development && electron-builder --mac dmg --universal) | tee dist/build.log",
+    "build:linux": "mkdir -p dist && (node ../webpack production && electron-builder --linux deb tar.gz AppImage --arm64 --x64) | tee dist/build.log",
+    "build:dev:linux": "mkdir -p dist && (node ../webpack development && electron-builder --linux deb tar.gz AppImage --arm64 --x64) | tee dist/build.log"
   },
   "devDependencies": {
     "commander": "^13.1.0",

--- a/electron/release-scripts/linux-dev.sh
+++ b/electron/release-scripts/linux-dev.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+
+# & Usage: ./linux.sh RELEASE_VERSION [RELEASE_PATH]
+# ** RELEASE_VERSION: The version string for the release.
+#    RELEASE_PATH (optional): The directory where release artifacts will be stored.
+#       ^ The github action will automatically set the release path— Do not fret!
+
+# * Parse arguments
+RELEASE_VERSION="$1"
+RELEASE_PATH="${2:-$(pwd)/release_artifacts/linux/$RELEASE_VERSION}"
+
+if [ -z "$RELEASE_VERSION" ]; then
+  echo "Usage: $0 RELEASE_VERSION [RELEASE_PATH]"
+  exit 1
+fi
+
+# & Sets our paths
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DIST_PATH="$REPO_ROOT/electron/dist/"
+
+# & Ensure we're at the root of the repo
+cd "$REPO_ROOT"
+
+# This is handled by our CI.
+# // # & Ensure we're on the 'main' branch and up-to-date
+# // git checkout main
+# // git pull
+
+# & Install dependencies
+pnpm install
+
+# & Clean previous builds
+rm -rf "$DIST_PATH"
+
+# & Build the project
+cd electron
+rm -rf app dist
+pnpm install
+pnpm build:dev:linux
+
+# & Prepare release directory
+mkdir -p "$RELEASE_PATH"
+
+# & Copy artifacts for release
+cp "$DIST_PATH"/*.tar.gz "$RELEASE_PATH"/ 2>/dev/null || true
+cp "$DIST_PATH"/*.pacman "$RELEASE_PATH"/ 2>/dev/null || true
+cp "$DIST_PATH"/*.deb "$RELEASE_PATH"/ 2>/dev/null || true
+cp "$DIST_PATH"/*.AppImage "$RELEASE_PATH"/ 2>/dev/null || true

--- a/electron/release-scripts/macos-dev.sh
+++ b/electron/release-scripts/macos-dev.sh
@@ -1,0 +1,45 @@
+#!/bin/bash -e
+
+# Usage: ./macos.sh RELEASE_VERSION [RELEASE_PATH]
+# ** RELEASE_VERSION: The version string for the release.
+#    RELEASE_PATH (optional): The directory where release artifacts will be stored.
+#       ^ The github action will automatically set the release path— Do not fret!
+
+# * Parse arguments
+RELEASE_VERSION="$1"
+RELEASE_PATH="${2:-$(pwd)/release_artifacts/macos/$RELEASE_VERSION}"
+
+if [ -z "$RELEASE_VERSION" ]; then
+  echo "Usage: $0 RELEASE_VERSION [RELEASE_PATH]"
+  exit 1
+fi
+
+# & Sets our paths
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+DIST_PATH="$REPO_ROOT/electron/dist"
+
+# & Ensure we're at the root of the repo
+cd "$REPO_ROOT"
+
+# This is handled by our CI.
+# // # & Ensure we're on the 'main' branch and up-to-date
+# // git checkout main
+# // git pull
+
+# & Install dependencies
+pnpm install
+
+# & Clean previous builds
+rm -rf "$DIST_PATH"
+
+# & Build the project
+cd electron
+rm -rf app dist
+pnpm install
+pnpm build:dev:mac
+
+# & Prepare release directory
+mkdir -p "$RELEASE_PATH"
+
+# & Copy artifacts
+cp "$DIST_PATH"/*.dmg "$RELEASE_PATH"/ 2>/dev/null || true

--- a/electron/release-scripts/windows-dev.ps1
+++ b/electron/release-scripts/windows-dev.ps1
@@ -1,0 +1,70 @@
+#!/usr/bin/env pwsh
+
+<#
+.SYNOPSIS
+Windows build script for F-Chat Horizon.
+
+.PARAMETER ReleaseVersion
+The version string for the release.
+
+.PARAMETER ReleasePath
+(Optional) The directory where release artifacts will be stored.
+
+.EXAMPLE
+.\windows.ps1 -ReleaseVersion "v1.0.0" -ReleasePath "C:\path\to\release\artifacts\windows\v1.0.0"
+#>
+
+# ! This script requires Git, Node.js, pnpm, and PowerShell Core to be installed.
+
+Param(
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseVersion,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ReleasePath = "$(Get-Location)\release_artifacts\windows\$ReleaseVersion"
+)
+
+# defaults:
+#  The default ReleasePath is "$(Get-Location)\release_artifacts\windows\$ReleaseVersion"
+
+# state: Enforce strict mode and stop on errors
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+# Set variables
+# * $RepoRoot: Root directory of the repository
+$RepoRoot = (git rev-parse --show-toplevel)
+# * $DistPath: Path to the distribution directory
+$DistPath = "$RepoRoot\electron\dist"
+
+# Navigate to repository root
+Set-Location $RepoRoot
+
+# This is handled by our CI.
+# // # & Ensure we're on the 'main' branch and up-to-date
+# // git checkout main
+# // git pull
+
+# Install dependencies
+pnpm install
+
+# Clean previous builds
+# ! This will delete the entire $DistPath directory
+Remove-Item -Recurse -Force $DistPath -ErrorAction SilentlyContinue
+
+# Build the project
+Set-Location electron
+# ! Removing 'app' and 'dist' directories to ensure a clean build
+Remove-Item -Recurse -Force app, dist -ErrorAction SilentlyContinue
+pnpm install
+pnpm build:dev:win
+
+# Prepare release directory
+# * Create release directory if it doesn't exist
+New-Item -ItemType Directory -Path $ReleasePath -Force | Out-Null
+
+# Copy artifacts
+# * Copy built executables to the release directory
+Copy-Item "$DistPath\*.exe" -Destination "$ReleasePath\" -ErrorAction SilentlyContinue
+
+# TODO: Allow specifying the branch to build from

--- a/electron/webpack.config.js
+++ b/electron/webpack.config.js
@@ -6,6 +6,10 @@ const OptimizeCssAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const VueLoaderPlugin = require('vue-loader/lib/plugin');
 const vueTransformer = require('@f-list/vue-ts/transform').default;
 const CopyPlugin = require('copy-webpack-plugin');
+const webpack = require('webpack');
+const packageJson = require('./package.json');
+const { DefinePlugin } = require('webpack');
+const APP_VERSION = process.env.APP_VERSION || 'Version Unknown';
 
 const mainConfig = {
     entry: [
@@ -52,6 +56,9 @@ const mainConfig = {
         tslint: path.join(__dirname, '../tslint.json'),
         tsconfig: './tsconfig-main.json',
         ignoreLintWarnings: true
+      }),
+      new DefinePlugin({
+        'process.env.APP_VERSION': JSON.stringify(APP_VERSION)
       })
     ],
     resolve: {
@@ -158,6 +165,9 @@ const mainConfig = {
         tsconfig: './tsconfig-renderer.json',
         vue: true,
         ignoreLintWarnings: true
+      }),
+      new DefinePlugin({
+        'process.env.APP_VERSION': JSON.stringify(APP_VERSION)
       }),
       new VueLoaderPlugin(),
       new CopyPlugin({
@@ -296,6 +306,9 @@ const storeWorkerEndpointConfig = _.assign(_.cloneDeep(mainConfig), {
       tsconfig: './tsconfig-renderer.json',
       vue: true,
       ignoreLintWarnings: true
+    }),
+    new DefinePlugin({
+      'process.env.APP_VERSION': JSON.stringify(APP_VERSION)
     })
   ]
 });


### PR DESCRIPTION
I broke the formatting for the PR version override inside the GitHub Actions file, but I'll get to that later

<img width="262" alt="image" src="https://github.com/user-attachments/assets/d69d8818-aed1-4444-b313-f398272cfdfb" />

But aside from that, this just gives a few extra indicators that the app is in development mode and gets rid of some minor grievances while running dev mode locally.