### PR TITLE
EIcon Selector & Store Update: This app is actually held together with wet chalk and paper towels

### DIFF
--- a/bbcode/EIconSelector.vue
+++ b/bbcode/EIconSelector.vue
@@ -28,6 +28,7 @@
               v-model="search"
               ref="search"
               placeholder="Search eicons..."
+              @input="searchUpdateDebounce()"
               tabindex="0"
               @click.prevent.stop="setFocus()"
               @mousedown.prevent.stop
@@ -36,7 +37,7 @@
             <div class="btn-group search-buttons">
               <div
                 class="btn expressions"
-                @click.prevent.stop="runSearch('category:favorites')"
+                @click.prevent.stop="searchWithString('category:favorites')"
                 title="Favorites"
                 role="button"
                 tabindex="0"
@@ -46,7 +47,7 @@
 
               <div
                 class="btn expressions"
-                @click.prevent.stop="runSearch('category:expressions')"
+                @click.prevent.stop="searchWithString('category:expressions')"
                 title="Expressions"
                 role="button"
                 tabindex="0"
@@ -56,7 +57,7 @@
 
               <div
                 class="btn sexual"
-                @click.prevent.stop="runSearch('category:sexual')"
+                @click.prevent.stop="searchWithString('category:sexual')"
                 title="Sexual"
                 role="button"
                 tabindex="0"
@@ -66,7 +67,7 @@
 
               <div
                 class="btn bubbles"
-                @click.prevent.stop="runSearch('category:bubbles')"
+                @click.prevent.stop="searchWithString('category:bubbles')"
                 title="Speech bubbles"
                 role="button"
                 tabindex="0"
@@ -76,7 +77,7 @@
 
               <div
                 class="btn actions"
-                @click.prevent.stop="runSearch('category:symbols')"
+                @click.prevent.stop="searchWithString('category:symbols')"
                 title="Symbols"
                 role="button"
                 tabindex="0"
@@ -86,7 +87,7 @@
 
               <div
                 class="btn memes"
-                @click.prevent.stop="runSearch('category:memes')"
+                @click.prevent.stop="searchWithString('category:memes')"
                 title="Memes"
                 role="button"
                 tabindex="0"
@@ -96,7 +97,7 @@
 
               <div
                 class="btn random"
-                @click.prevent.stop="runSearch('category:random')"
+                @click.prevent.stop="searchWithString('category:random')"
                 title="Random"
                 role="button"
                 tabindex="0"
@@ -169,7 +170,7 @@
 
 <script lang="ts">
   import _ from 'lodash';
-  import { Component, Hook, Prop, Watch } from '@f-list/vue-ts';
+  import { Component, Hook, Prop } from '@f-list/vue-ts';
   // import Vue from 'vue';
   import log from 'electron-log'; //tslint:disable-line:match-default-export-name
   import { EIconStore } from '../learn/eicon/store';
@@ -204,23 +205,20 @@
         store = await EIconStore.getSharedStore();
 
         this.storeLoaded = true;
-        this.runSearch('');
+
+        this.searchWithString('category:favorites');
       } catch (err) {
         // don't break the client in case service is down
         log.error('eiconSelector.load.error', { err });
       }
     }
 
-    @Watch('search')
-    searchUpdate() {
-      this.searchUpdateDebounce();
+    searchWithString(s: string) {
+      this.search = s;
+      this.runSearch();
     }
 
-    runSearch(search?: string) {
-      if (search) {
-        this.search = search;
-      }
-
+    runSearch() {
       const s = this.search.toLowerCase().trim();
 
       if (s.substring(0, 9) === 'category:') {

--- a/bbcode/EIconSelector.vue
+++ b/bbcode/EIconSelector.vue
@@ -595,7 +595,7 @@
     async refreshIcons(): Promise<void> {
       this.refreshing = true;
 
-      await store?.update();
+      await store?.checkForUpdates();
       this.runSearch();
 
       this.refreshing = false;

--- a/bbcode/EIconSelector.vue
+++ b/bbcode/EIconSelector.vue
@@ -3,6 +3,7 @@
     action="Select EIcon"
     ref="dialog"
     :buttons="false"
+    @close="close"
     dialogClass="eicon-selector big"
   >
     <div class="eicon-selector-ui">
@@ -201,6 +202,7 @@
     async mounted(): Promise<void> {
       try {
         store = await EIconStore.getSharedStore();
+
         this.storeLoaded = true;
         this.runSearch('');
       } catch (err) {
@@ -225,15 +227,15 @@
         const category = s.substring(9).trim();
 
         if (category === 'random') {
-          this.results = (store?.random(250) || []).map(e => e.eicon);
+          this.results = store?.nextPage() || [];
         } else {
           this.results = this.getCategoryResults(category);
         }
       } else {
         if (s.length === 0) {
-          this.results = (store?.random(250) || []).map(e => e.eicon);
+          this.results = store?.nextPage() || [];
         } else {
-          this.results = _.take(store?.search(s), 250).map(e => e.eicon);
+          this.results = _.take(store?.search(s), 301).map(e => e.eicon);
         }
       }
     }
@@ -617,6 +619,10 @@
       void core.settingsStore.set('favoriteEIcons', core.state.favoriteEIcons);
 
       this.$forceUpdate();
+    }
+
+    close(): void {
+      store?.shuffle();
     }
   }
 </script>

--- a/bbcode/EIconSelector.vue
+++ b/bbcode/EIconSelector.vue
@@ -233,7 +233,7 @@
         if (s.length === 0) {
           this.results = store?.nextPage() || [];
         } else {
-          this.results = _.take(store?.search(s), 301).map(e => e.eicon);
+          this.results = store?.search(s).slice(0, 301) || [];
         }
       }
     }

--- a/learn/eicon/store.ts
+++ b/learn/eicon/store.ts
@@ -174,8 +174,17 @@ export class EIconStore {
     });
   }
 
-  random(count: number): EIconRecord[] {
-    return _.sampleSize(this.lookup, count);
+  random(count: number = 49): EIconRecord[] {
+    const r = Object.values(this.lookup);
+    const len = r.length;
+
+    // Fisher-Yates Shuffle
+    for (let cp = len - 1; len - cp < count; cp--) {
+      const np = Math.floor(Math.random() * (cp + 1));
+      [r[cp], r[np]] = [r[np], r[cp]];
+    }
+
+    return r.slice(-count);
   }
 
   private static sharedStore: EIconStore | undefined;

--- a/learn/eicon/store.ts
+++ b/learn/eicon/store.ts
@@ -107,7 +107,7 @@ export class EIconStore {
         asOfTimestamp: this.asOfTimestamp
       });
 
-      await this.update();
+      await this.checkForUpdates();
 
       log.verbose('eicons.loaded.update.remote', {
         records: this.lookup.length,
@@ -146,7 +146,12 @@ export class EIconStore {
     this.shuffle();
   }
 
-  async update(): Promise<void> {
+  async checkForUpdates(): Promise<void> {
+    if (this.asOfTimestamp === 0) await this.downloadAll();
+    else await this.update();
+  }
+
+  protected async update(): Promise<void> {
     log.verbose('eicons.update', { asOf: this.asOfTimestamp });
 
     const changes = await this.updater.fetchUpdates(this.asOfTimestamp);
@@ -217,7 +222,10 @@ export class EIconStore {
 
       await EIconStore.sharedStore.load();
 
-      setInterval(() => EIconStore.sharedStore!.update(), 60 * 60 * 1000);
+      setInterval(
+        () => EIconStore.sharedStore!.checkForUpdates(),
+        60 * 60 * 1000
+      );
     }
 
     return EIconStore.sharedStore;

--- a/learn/eicon/store.ts
+++ b/learn/eicon/store.ts
@@ -29,7 +29,6 @@ async function FisherYatesShuffle(arr: any[]): Promise<void> {
 
 export class EIconStore {
   protected lookup: string[] = [];
-  protected indices: string[] = [];
 
   protected asOfTimestamp = 0;
 
@@ -128,9 +127,9 @@ export class EIconStore {
 
     this.asOfTimestamp = data.asOfTimestamp;
 
-    this.updateIndices();
-
     await this.save();
+
+    this.shuffle();
   }
 
   async update(): Promise<void> {
@@ -160,11 +159,11 @@ export class EIconStore {
       asOf: this.asOfTimestamp
     });
 
-    this.updateIndices();
-
     if (changes.recordUpdates.length > 0) {
       await this.save();
     }
+
+    this.shuffle();
   }
 
   protected resortList(): void {
@@ -204,17 +203,12 @@ export class EIconStore {
     });
   }
 
-  private updateIndices(): void {
-    this.indices = this.lookup;
-    this.shuffle();
-  }
-
   async shuffle(): Promise<void> {
-    await FisherYatesShuffle(this.indices);
+    await FisherYatesShuffle(this.lookup);
   }
 
   nextPage(amount: number = 0): string[] {
-    return Rotate(this.indices, amount || EICON_PAGE_RESULTS_COUNT * 2);
+    return Rotate(this.lookup, amount || EICON_PAGE_RESULTS_COUNT * 2);
   }
 
   private static sharedStore: EIconStore | undefined;


### PR DESCRIPTION
A complete overhaul of the eicon store to account for its various inefficiencies.

It's formatted so that it could be rolled back one commit at a time should anything be found to be buggy .

There's still one change remaining that can be made: move the eicon store out of the renderer so it isn't duplicated per-tab. The issue would be maintaining low latency, as main->renderer communication is very slow and the eicon store is a fairly responsive feature. However, given the current eicon store has significantly less memory overhead than it previous did, is 1/3 the size, and you can only have 3 windows open - it's impossible to reach the attrocious levels of memory hogging that were previously on display, meaning further changes probably aren't worth the investment just yet.

## TLDR
* Significantly reduced memory usage
* Faster login & eicon random search
* Reduced disk writing and storage used

### Features:
* Significant heap memory savings by not letting vue build reactive components off of the store object.
* Cut size of eicon store by 2/3 by moving from object to array and discarding unused (and likely useless forever) per-eicon timestamps.
* Significantly increased responsiveness of random eicons by not creating and randomizing a 445,000 entry object everytime you search.
* The efficiency of the object shuffler is about the same as the lodash one; it probably used the same technique, but now we don't run it constantly. Additionally, we're not creating a brand-new object everytime, just doing it raw to the eicon array (which for most installs is already unsorted, as its incrementally updated). Random search time is reduced by ~85%.
* The db is downloaded anew if the timestamp or array from the file can't be read.
* Converting from the old format to new is handled.
* A handful of situations where searches were being run back to back (with no effect) were removed; this especially affected the response time of random eicon search as well as login time (as random was searched when you log in).
* File size reduced by 75%

#### Decisions you might question:
* Shifted a few log levels from info to verbose where they don't indicate anything meaningful to a normal user, but can still be useful when troubleshooting general performance concerns.
* Some deprecated functions (and lodash) were replaced with recent replacements.
* The default page is now your favorites.
* Searches return a few more eicons to reward users for the increased speed.
* Random searches return a reduced quantity so as not to punish the server for those just taking a gander.