### PR TITLE
Fixes icon bbcode linking to improperly capitalised profile

### DIFF
--- a/bbcode/Editor.vue
+++ b/bbcode/Editor.vue
@@ -126,6 +126,7 @@
   import { default as IconView } from './IconView.vue';
   import { default as EIconSelector } from './EIconSelector.vue';
   import Modal from '../components/Modal.vue';
+  import { Character } from '../fchat';
 
   @Component({
     components: {
@@ -160,7 +161,7 @@
     readonly invalid!: boolean;
 
     @Prop({ default: null })
-    readonly characterName: string | null = null;
+    readonly characterName: Character | null = null;
 
     @Prop({ default: 'normal' })
     readonly type: 'normal' | 'big' = 'normal';

--- a/bbcode/IconView.vue
+++ b/bbcode/IconView.vue
@@ -1,6 +1,6 @@
 <template>
   <a
-    :href="`${Utils.siteDomain}c/${character}`"
+    :href="`${Utils.siteDomain}c/${character.name}`"
     target="_blank"
     @mouseover.prevent="show()"
     @mouseenter.prevent="show()"
@@ -9,10 +9,10 @@
     @click.right.passive="dismiss(true)"
     @click.left.passive="dismiss(true)"
     ><img
-      :src="getAvatarUrl()"
+      :src="characterImage(character.name)"
       class="character-avatar icon"
-      :title="character"
-      :alt="character"
+      :title="character.name"
+      :alt="character.name"
       v-once
   /></a>
 </template>
@@ -23,13 +23,15 @@
   import { EventBus } from '../chat/preview/event-bus';
   import * as Utils from '../site/utils';
   import { characterImage } from '../chat/common';
+  import { Character } from '../fchat';
 
   @Component
   export default class IconView extends Vue {
     Utils = Utils;
+    characterImage = characterImage;
 
     @Prop({ required: true })
-    readonly character!: string;
+    readonly character!: Character;
 
     @Hook('mounted')
     mounted(): void {
@@ -47,11 +49,7 @@
     }
 
     getCharacterUrl(): string {
-      return `flist-character://${this.character}`;
-    }
-
-    getAvatarUrl(): string {
-      return characterImage(this.character);
+      return `flist-character://${this.character.name}`;
     }
 
     dismiss(force: boolean = false): void {

--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -589,7 +589,7 @@
     editorMemo: string = '';
     memoManager?: MemoManager;
 
-    ownName?: string;
+    ownName?: Character;
 
     @Hook('beforeMount')
     async onBeforeMount(): Promise<void> {
@@ -713,7 +713,7 @@
 
     updateOwnName(): void {
       this.ownName = core.state.settings.risingShowPortraitNearInput
-        ? core.characters.ownCharacter?.name
+        ? core.characters.ownCharacter
         : undefined;
     }
 

--- a/chat/bbcode.ts
+++ b/chat/bbcode.ts
@@ -52,7 +52,12 @@ export default class BBCodeParser extends CoreBBCodeParser {
         const el = parser.createElement('span');
         parent.appendChild(root);
         root.appendChild(el);
-        const view = new IconView({ el, propsData: { character: content } });
+        const view = new IconView({
+          el,
+          propsData: {
+            character: core.characters.get(content)
+          }
+        });
 
         this.cleanup.push(view);
         return root;


### PR DESCRIPTION
Quick fix for when user inputs an improperly capitalised version of the name of a profile when using the icon bbcode.
Fixes the profile preview opening to a version with the capitalisation they used at the top, presents the proper capitalisation. Also fixes the text on hover of icon too in the same circumstance.