### PR TITLE
EIcon Store episode 3: Return of the Robust Structure Checking

### DIFF
--- a/learn/eicon/store.ts
+++ b/learn/eicon/store.ts
@@ -108,7 +108,7 @@ export class EIconStore {
    * error is caught, logged, and ignored.
    */
   private async save(): Promise<void> {
-    if (this.lookup.length) {
+    if (this.lookup.length > 0 && this.asOfTimestamp > 0) {
       log.info('eicons.save', {
         records: this.lookup.length,
         asOfTimestamp: this.asOfTimestamp,
@@ -260,8 +260,8 @@ export class EIconStore {
    * Check for eicon db updates using the most efficient method.
    */
   async checkForUpdates(): Promise<void> {
-    if (this.asOfTimestamp === 0) await this.downloadAll();
-    else await this.update();
+    if (this.lookup.length > 0 && this.asOfTimestamp > 0) await this.update();
+    else await this.downloadAll();
   }
 
   /**


### PR DESCRIPTION
Implements:
* A more robust store check to avoid saving a bad store or to redownload the whole store in case of irregularity
* Privitize members that shouldn't be accessed publicly
* TSDoc notes - In the vscode tooltip, they display fine - but they may need additional formatting depending on what their final form is supposed to be. To know how to adjust them further, I'd have to see them displayed in the intended format.
* Move the hardcoded update check to the top of the page for easier reference