### PR TITLE
Update notification rework (and in-app changelog)

### DIFF
--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -544,6 +544,8 @@ Once this process has started, do not interrupt it or your logs will get corrupt
   'status.crown': 'Rewarded',
   'changelog.version': 'Changelog for version {0}',
   'changelog.quitAndDownload': 'Quit and download',
+  'changelog.quitAndDownload.confirm':
+    'You are still connected to chat. \nAre you sure you want to exit and download the update right now?',
   'changelog.download': 'Download',
   'importer.importGeneral':
     'slimCat data has been detected on your computer.\nWould you like to import general settings?',

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -542,7 +542,8 @@ Once this process has started, do not interrupt it or your logs will get corrupt
   'status.idle': 'Idle',
   'status.offline': 'Offline',
   'status.crown': 'Rewarded',
-  'changelog.version': 'Changelog for version {0}',
+  'changelog.version': 'Changelog for {0}',
+  'changelog.compare': 'Horizon {0} is available, you are using {1}.',
   'changelog.quitAndDownload': 'Quit and download',
   'changelog.quitAndDownload.confirm':
     'You are still connected to chat. \nAre you sure you want to exit and download the update right now?',

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -542,6 +542,9 @@ Once this process has started, do not interrupt it or your logs will get corrupt
   'status.idle': 'Idle',
   'status.offline': 'Offline',
   'status.crown': 'Rewarded',
+  'changelog.version': 'Changelog for version {0}',
+  'changelog.quitAndDownload': 'Quit and download',
+  'changelog.download': 'Download',
   'importer.importGeneral':
     'slimCat data has been detected on your computer.\nWould you like to import general settings?',
   'importer.importCharacter': `slimCat data for this character has been detected on your computer.

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -32,7 +32,7 @@ const strings: { [key: string]: string | undefined } = {
   'consoleWarning.head': 'THIS IS THE DANGER ZONE.',
   'consoleWarning.body': `ANYTHING YOU WRITE OR PASTE IN HERE COULD BE USED TO STEAL YOUR PASSWORDS OR TAKE OVER YOUR ENTIRE COMPUTER. This is where happiness goes to die. If you aren't a developer or a special kind of daredevil, please get out of here!`,
   help: 'Help',
-  'help.fchat': 'Horizon Help and Changelog',
+  'help.fchat': 'Horizon Help',
   'help.feedback': 'Report a Bug / Suggest Something',
   'help.rules': 'F-List Rules',
   'help.faq': 'F-List FAQ',

--- a/electron/Changelog.vue
+++ b/electron/Changelog.vue
@@ -34,7 +34,7 @@
               {{ l('changelog.compare', updateVersion, currentVersion) }}
             </div>
             <div
-              class="logs-container bg-light"
+              class="logs-container border bg-light"
               v-html="changeLogText"
               ref="mdContainer"
             ></div>
@@ -83,6 +83,7 @@
   import FilterableSelect from '../components/FilterableSelect.vue';
   import Axios from 'axios';
   import markdownit from 'markdown-it';
+  import { alert } from '@mdit/plugin-alert';
   import electron from 'electron';
 
   type ReleaseInfo = {
@@ -92,9 +93,7 @@
   };
 
   const browserWindow = remote.getCurrentWindow();
-  @Component({
-    components: { tabs: Tabs, 'filterable-select': FilterableSelect }
-  })
+  @Component()
   export default class Changelog extends Vue {
     settings!: GeneralSettings;
     updateVersion!: string | undefined;
@@ -135,6 +134,7 @@
       let releaseInfo: ReleaseInfo = (await Axios.get<ReleaseInfo>(apiUrl))
         .data;
       let md = markdownit();
+      md.use(alert);
 
       const defaultRender =
         md.renderer.rules.link_open ||
@@ -228,10 +228,6 @@
     width: 100%;
   }
 
-  .tab-content {
-    overflow: auto;
-  }
-
   .modal-body {
     height: 100%;
     display: flex;
@@ -245,9 +241,43 @@
     margin-top: 1em;
     margin-bottom: 1em;
     padding: 1em;
+    border-radius: 10px;
+    a {
+      text-decoration: underline;
+    }
+
+    a:hover {
+      text-decoration: none;
+    }
   }
 
-  /*This override exists because we allow the user to resize the window, which potentially resizes the footer otherwise*/
+  .markdown-alert {
+    border-left: 2px solid;
+    padding-left: 10px;
+
+    .markdown-alert-title {
+      font-size: 1.25em;
+      font-weight: bold;
+    }
+  }
+
+  .markdown-alert-important {
+    border-color: var(--primary);
+  }
+
+  .markdown-alert-note {
+    border-color: var(--secondary);
+  }
+
+  .markdown-alert-tip {
+    border-color: var(--info);
+  }
+  .markdown-alert-caution {
+    border-color: var(--danger);
+  }
+  .markdown-alert-warning {
+    border-color: var(--warning);
+  } /*This override exists because we allow the user to resize the window, which potentially resizes the footer otherwise*/
   .modal-body .modal-footer {
     height: 52px;
     min-height: 52px;
@@ -277,47 +307,6 @@
   #windowButtons .btn {
     border-top: 0;
     font-size: 14px;
-  }
-
-  #window-browser-settings {
-    user-select: none;
-    .btn {
-      border: 0;
-      border-radius: 0;
-      padding: 0 18px;
-      display: flex;
-      align-items: center;
-      line-height: 1;
-      -webkit-app-region: no-drag;
-      flex-grow: 0;
-    }
-
-    .btn-default {
-      background: transparent;
-    }
-
-    h4 {
-      margin: 0 10px;
-      user-select: none;
-      cursor: default;
-      align-self: center;
-      -webkit-app-region: drag;
-    }
-
-    .fa {
-      line-height: inherit;
-    }
-  }
-
-  .warning {
-    border: 1px solid var(--warning);
-    padding: 10px;
-    margin-bottom: 20px;
-    border-radius: 3px;
-
-    div {
-      margin-top: 10px;
-    }
   }
 
   .disableWindowsHighContrast,

--- a/electron/Changelog.vue
+++ b/electron/Changelog.vue
@@ -12,9 +12,10 @@
           <div class="modal-header">
             <h4 class="modal-title" style="-webkit-app-region: drag">
               {{
-                updateVersion
-                  ? l('changelog.version', updateVersion)
-                  : l('help.changelog')
+                l(
+                  'changelog.version',
+                  updateVersion ? updateVersion : currentVersion
+                )
               }}
             </h4>
             <button
@@ -29,8 +30,11 @@
             </button>
           </div>
           <div class="modal-body">
+            <div v-if="updateVersion" class="version-compare">
+              {{ l('changelog.compare', updateVersion, currentVersion) }}
+            </div>
             <div
-              class="logs-container"
+              class="logs-container bg-light"
               v-html="changeLogText"
               ref="mdContainer"
             ></div>
@@ -94,6 +98,7 @@
   export default class Changelog extends Vue {
     settings!: GeneralSettings;
     updateVersion!: string | undefined;
+    currentVersion = process.env.APP_VERSION;
     isMaximized = false;
     l = l;
     platform = process.platform;
@@ -237,6 +242,9 @@
     height: 100%;
     width: 100%;
     overflow-y: scroll;
+    margin-top: 1em;
+    margin-bottom: 1em;
+    padding: 1em;
   }
 
   /*This override exists because we allow the user to resize the window, which potentially resizes the footer otherwise*/

--- a/electron/Changelog.vue
+++ b/electron/Changelog.vue
@@ -1,0 +1,313 @@
+<template>
+  <div
+    class="card-full"
+    style="display: flex; flex-direction: column; height: 100%"
+    :class="getThemeClass()"
+    @auxclick.prevent
+  >
+    <div v-html="styling"></div>
+    <div class="window-modal modal" :class="getThemeClass()" tabindex="-1">
+      <div class="modal-dialog modal-xl" style="height: 100vh">
+        <div class="modal-content" style="height: 100vh">
+          <div class="modal-header">
+            <h4 class="modal-title" style="-webkit-app-region: drag">
+              {{
+                updateVersion
+                  ? l('changelog.version', updateVersion)
+                  : l('help.changelog')
+              }}
+            </h4>
+            <button
+              type="button"
+              class="close"
+              aria-label="Close"
+              v-if="!isMac"
+              @click.stop="close()"
+              z-
+            >
+              <span class="fas fa-times"></span>
+            </button>
+          </div>
+          <div class="modal-body">
+            <div
+              class="logs-container"
+              v-html="changeLogText"
+              ref="mdContainer"
+            ></div>
+            <div class="modal-footer">
+              <button
+                type="button"
+                class="btn btn-secondary"
+                @click.stop="close()"
+              >
+                {{ l('action.close') }}
+              </button>
+              <button
+                v-if="updateVersion"
+                type="button"
+                class="btn btn-secondary"
+                @click.stop="close()"
+              >
+                {{ l('changelog.download') }}
+              </button>
+
+              <button
+                v-if="updateVersion"
+                type="button"
+                class="btn btn-primary"
+                @click.stop="submit()"
+              >
+                {{ l('changelog.quitAndDownload') }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+  import { Component, Hook } from '@f-list/vue-ts';
+  import * as remote from '@electron/remote';
+  import Vue from 'vue';
+  import l from '../chat/localize';
+  import { GeneralSettings } from './common';
+  import fs from 'fs';
+  import path from 'path';
+  import Tabs from '../components/tabs';
+  import FilterableSelect from '../components/FilterableSelect.vue';
+  import Axios from 'axios';
+  import markdownit from 'markdown-it';
+  import electron from 'electron';
+
+  type ReleaseInfo = {
+    html_url: string;
+    tag_name: string;
+    body: string;
+  };
+
+  const browserWindow = remote.getCurrentWindow();
+  @Component({
+    components: { tabs: Tabs, 'filterable-select': FilterableSelect }
+  })
+  export default class Changelog extends Vue {
+    settings!: GeneralSettings;
+    updateVersion!: string | undefined;
+    isMaximized = false;
+    l = l;
+    platform = process.platform;
+    isMac = process.platform === 'darwin';
+    hasCompletedUpgrades = false;
+    changeLogText: string = '';
+
+    get styling(): string {
+      try {
+        return `<style>${fs.readFileSync(path.join(__dirname, `themes/${this.settings.theme}.css`), 'utf8').toString()}</style>`;
+      } catch (e) {
+        if (
+          (<Error & { code: string }>e).code === 'ENOENT' &&
+          this.settings.theme !== 'default'
+        ) {
+          this.settings.theme = 'default';
+          return this.styling;
+        }
+        throw e;
+      }
+    }
+
+    @Hook('mounted')
+    async mounted(): Promise<void> {
+      const container = <HTMLElement>this.$refs['mdContainer'];
+      if (container) {
+        container.addEventListener('click', this.delegateLinkClick);
+      }
+      let apiUrl =
+        'https://api.github.com/repos/Fchat-Horizon/Horizon/releases/tags/' +
+        (this.updateVersion
+          ? this.updateVersion!
+          : 'v' + process.env.APP_VERSION);
+      let releaseInfo: ReleaseInfo = (await Axios.get<ReleaseInfo>(apiUrl))
+        .data;
+      let md = markdownit();
+
+      const defaultRender =
+        md.renderer.rules.link_open ||
+        function (tokens, idx, options, env, self) {
+          return self.renderToken(tokens, idx, options);
+        };
+
+      md.renderer.rules.link_open = function (tokens, idx, options, env, self) {
+        const token = tokens[idx];
+        token.attrPush(['data-action', 'openExternal']);
+        // Set href to "#" or "javascript:void(0)"
+        //const hrefIndex = token.attrIndex('href');
+        //if (hrefIndex >= 0) token.attrs![hrefIndex][1] = '#';
+        // Add onclick handler
+        return defaultRender(tokens, idx, options, env, self);
+      };
+      this.changeLogText = md.render(releaseInfo.body);
+    }
+
+    close(): void {
+      browserWindow.close();
+    }
+
+    externalUrlHandler(url: string) {
+      electron.ipcRenderer.send('open-url-externally', url);
+    }
+
+    delegateLinkClick(event: MouseEvent) {
+      const target = event.target as HTMLElement;
+      if (
+        target.tagName === 'A' &&
+        target.getAttribute('data-action') === 'openExternal'
+      ) {
+        event.preventDefault();
+        this.externalUrlHandler(target.getAttribute('href') || '#');
+      }
+    }
+
+    getThemeClass() {
+      // console.log('getThemeClassWindow', this.settings?.risingDisableWindowsHighContrast);
+
+      try {
+        // Hack!
+        if (process.platform === 'win32') {
+          if (this.settings?.risingDisableWindowsHighContrast) {
+            document
+              .querySelector('html')
+              ?.classList.add('disableWindowsHighContrast');
+          } else {
+            document
+              .querySelector('html')
+              ?.classList.remove('disableWindowsHighContrast');
+          }
+        }
+
+        return {
+          ['platform-' + this.platform]: true,
+          disableWindowsHighContrast:
+            this.settings?.risingDisableWindowsHighContrast || false
+        };
+      } catch (err) {
+        return {
+          ['platform-' + this.platform]: true
+        };
+      }
+    }
+
+    submit(): void {
+      this.close();
+    }
+  }
+</script>
+
+<style lang="scss">
+  .card-full .window-modal {
+    position: relative;
+    display: block;
+  }
+  .window-modal .modal-dialog {
+    margin: 0px;
+    max-width: 100%;
+  }
+
+  .modal-title {
+    width: 100%;
+  }
+
+  .tab-content {
+    overflow: auto;
+  }
+
+  .modal-body {
+    height: 100%;
+    display: flex;
+    flex-flow: column;
+  }
+
+  .logs-container {
+    height: 100%;
+    width: 100%;
+    overflow-y: scroll;
+  }
+
+  /*This override exists because we allow the user to resize the window, which potentially resizes the footer otherwise*/
+  .modal-body .modal-footer {
+    height: 52px;
+    min-height: 52px;
+  }
+
+  .card-full {
+    height: 100%;
+    left: 0;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: 100;
+  }
+
+  .card-body .form-group {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  .card-body .form-group .filters label {
+    display: list-item;
+    margin: 0;
+    margin-left: 5px;
+    list-style: none;
+  }
+
+  #windowButtons .btn {
+    border-top: 0;
+    font-size: 14px;
+  }
+
+  #window-browser-settings {
+    user-select: none;
+    .btn {
+      border: 0;
+      border-radius: 0;
+      padding: 0 18px;
+      display: flex;
+      align-items: center;
+      line-height: 1;
+      -webkit-app-region: no-drag;
+      flex-grow: 0;
+    }
+
+    .btn-default {
+      background: transparent;
+    }
+
+    h4 {
+      margin: 0 10px;
+      user-select: none;
+      cursor: default;
+      align-self: center;
+      -webkit-app-region: drag;
+    }
+
+    .fa {
+      line-height: inherit;
+    }
+  }
+
+  .warning {
+    border: 1px solid var(--warning);
+    padding: 10px;
+    margin-bottom: 20px;
+    border-radius: 3px;
+
+    div {
+      margin-top: 10px;
+    }
+  }
+
+  .disableWindowsHighContrast,
+  .disableWindowsHighContrast * {
+    forced-color-adjust: none;
+  }
+</style>

--- a/electron/Changelog.vue
+++ b/electron/Changelog.vue
@@ -46,7 +46,7 @@
                 v-if="updateVersion"
                 type="button"
                 class="btn btn-secondary"
-                @click.stop="close()"
+                @click.stop="goToDownload()"
               >
                 {{ l('changelog.download') }}
               </button>
@@ -55,7 +55,7 @@
                 v-if="updateVersion"
                 type="button"
                 class="btn btn-primary"
-                @click.stop="submit()"
+                @click.stop="closeAndDownload()"
               >
                 {{ l('changelog.quitAndDownload') }}
               </button>
@@ -197,8 +197,14 @@
       }
     }
 
-    submit(): void {
-      this.close();
+    goToDownload() {
+      this.externalUrlHandler(
+        'https://horizn.moe/download.html?ver=' + this.updateVersion
+      );
+    }
+
+    closeAndDownload(): void {
+      electron.ipcRenderer.send('update-and-exit', this.updateVersion);
     }
   }
 </script>

--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -11,18 +11,12 @@
       id="window-tabs"
     >
       <h4 style="padding: 2px 0">{{ l('title') }}</h4>
-      <div
-        class="btn"
-        :class="'btn-' + (hasUpdate ? 'warning' : 'light')"
-        @click="openMenu"
-        id="settings"
-      >
+      <div class="btn btn-light" @click="openMenu" id="settings">
         <i class="fa fa-cog"></i>
       </div>
       <div
         class="btn btn-outline-success"
-        :class="'btn-snowflake-' + (hasUpdate ? 'ready' : 'unavailable')"
-        id="update-darwin"
+        :class="'btn-download-' + (hasUpdate ? 'ready' : 'unavailable')"
         @click="openUpdatePage"
       >
         <i class="fa fa-arrow-down"></i>
@@ -199,6 +193,7 @@
     canOpenTab = true;
     l = l;
     hasUpdate = false;
+    updateVersion = '';
     platform = process.platform;
     lockTab = false;
     hasCompletedUpgrades = false;
@@ -250,8 +245,14 @@
       electron.ipcRenderer.on('open-tab', () => this.addTab());
       electron.ipcRenderer.on(
         'update-available',
-        (_e: Electron.IpcRendererEvent, available: boolean) =>
-          (this.hasUpdate = available)
+        (
+          _e: Electron.IpcRendererEvent,
+          updateAvailable: boolean,
+          version?: string
+        ) => {
+          this.hasUpdate = updateAvailable;
+          if (version) this.updateVersion = version;
+        }
       );
       electron.ipcRenderer.on('fix-logs', () =>
         this.activeTab!.view.webContents.send('fix-logs')
@@ -592,10 +593,7 @@
     }
 
     openUpdatePage(): void {
-      electron.ipcRenderer.send(
-        'open-url-externally',
-        'https://github.com/Fchat-Horizon/Horizon/releases'
-      );
+      electron.ipcRenderer.send('open-update-changelog', this.updateVersion);
     }
 
     getThemeClass() {
@@ -684,19 +682,17 @@
     font-size: 14px;
   }
 
-  #window-tabs .btn-snowflake-ready,
-  #window-tabs .btn-snowflake-unavailable {
-    display: none;
+  #window-tabs .btn-download-ready {
+    display: flex;
   }
 
+  #window-tabs .btn-download-unavailable {
+    display: none;
+  }
   .platform-darwin {
     #windowButtons .btn,
     #settings {
       display: none;
-    }
-
-    #window-tabs .btn-snowflake-ready {
-      display: flex;
     }
 
     #window-tabs {

--- a/electron/browser_windows.ts
+++ b/electron/browser_windows.ts
@@ -304,9 +304,9 @@ export function showAllWindows() {
   for (const w of windows) w.show();
 }
 
-export function toggleUpdateNotice(updateAvailable: boolean) {
+export function toggleUpdateNotice(updateAvailable: boolean, version?: string) {
   for (const w of windows)
-    w.webContents.send('update-available', updateAvailable);
+    w.webContents.send('update-available', updateAvailable, version);
 }
 
 export function createBrowserSettings(

--- a/electron/browser_windows.ts
+++ b/electron/browser_windows.ts
@@ -360,6 +360,59 @@ export function createBrowserSettings(
   return browserWindow;
 }
 
+export function createChangelogWindow(
+  settings: GeneralSettings,
+  shouldImportSettings: boolean,
+  parentWindow: electron.BrowserWindow,
+  updateVer?: string
+): electron.BrowserWindow | undefined {
+  let desiredHeight = 700;
+  let desiredWidth = 600;
+
+  const windowProperties: electron.BrowserWindowConstructorOptions = {
+    center: true,
+    show: false,
+    icon: process.platform === 'win32' ? winIcon : pngIcon,
+    frame: false,
+    width: desiredWidth,
+    minWidth: desiredWidth,
+    height: desiredHeight,
+    minHeight: desiredHeight,
+    resizable: true,
+    modal: true,
+    parent: parentWindow,
+    maximizable: false,
+    webPreferences: {
+      webviewTag: true,
+      nodeIntegration: true,
+      nodeIntegrationInWorker: true,
+      spellcheck: true,
+      enableRemoteModule: true,
+      contextIsolation: false,
+      partition: 'persist:fchat'
+    } as any
+  };
+
+  if (process.platform === 'darwin') {
+    windowProperties.titleBarStyle = 'hiddenInset';
+  }
+  const browserWindow = new electron.BrowserWindow(windowProperties);
+  remoteMain.enable(browserWindow.webContents);
+  browserWindow.loadFile(path.join(__dirname, 'changelog.html'), {
+    query: {
+      settings: JSON.stringify(settings),
+      import: shouldImportSettings ? 'true' : '',
+      updateVer: updateVer ? updateVer : ''
+    }
+  });
+
+  browserWindow.once('ready-to-show', () => {
+    browserWindow.show();
+  });
+
+  return browserWindow;
+}
+
 export function createAboutWindow(
   parentWindow: electron.BrowserWindow
 ): electron.BrowserWindow {

--- a/electron/changelog.html
+++ b/electron/changelog.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self' 'unsafe-inline'; img-src file: data: https://static.f-list.net; connect-src https://api.github.com https://horizn.moe"
+    />
+    <title>Horizon</title>
+    <link href="fa.css" rel="stylesheet" />
+  </head>
+  <body>
+    <div id="changelog"></div>
+    <script type="text/javascript" src="common.js"></script>
+    <script type="text/javascript" src="changelog.js"></script>
+  </body>
+</html>

--- a/electron/changelog.ts
+++ b/electron/changelog.ts
@@ -1,0 +1,29 @@
+import * as qs from 'querystring';
+import log from 'electron-log'; //tslint:disable-line:match-default-export-name
+
+import { GeneralSettings } from './common';
+import Changelog from './Changelog.vue';
+
+log.info('init.changelog');
+
+const params = <{ [key: string]: string | undefined }>(
+  qs.parse(window.location.search.substr(1))
+);
+const settings = <GeneralSettings>JSON.parse(params['settings']!);
+
+const updateVersion = params['updateVer'];
+
+const logLevel = process.env.NODE_ENV === 'production' ? 'info' : 'silly';
+
+log.transports.file.level = settings.risingSystemLogLevel || logLevel;
+log.transports.console.level = settings.risingSystemLogLevel || logLevel;
+log.transports.file.maxSize = 5 * 1024 * 1024;
+
+log.info('init.changelog.vue');
+
+new Changelog({
+  el: '#changelog',
+  data: { settings, updateVersion }
+});
+
+log.debug('init.changelog.vue.done');

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -74,6 +74,8 @@ const settingsDir = path.join(baseDir, 'data');
 fs.mkdirSync(settingsDir, { recursive: true });
 const settingsFile = path.join(settingsDir, 'settings');
 const settings = new GeneralSettings();
+//We need this, since displaying the changelog is done through a child window instead of an external link
+let showChangelogOnBoot = false;
 
 if (!fs.existsSync(settingsFile)) shouldImportSettings = true;
 else
@@ -204,15 +206,6 @@ export function openURLExternally(linkUrl: string): void {
   electron.shell.openExternal(linkUrl);
 }
 
-function showCurrentPatchNotes(): void {
-  //tslint:disable-next-line: no-floating-promises
-  openURLExternally(
-    'https://github.com/Fchat-Horizon/Horizon/blob/v' +
-      settings.version +
-      '/CHANGELOG.md'
-  );
-}
-
 let zoomLevel = settings.zoomLevel;
 
 function onReady(): void {
@@ -239,7 +232,7 @@ function onReady(): void {
       settings.host = defaultHost;
     settings.version = app.getVersion();
     setGeneralSettings(settings);
-    showCurrentPatchNotes();
+    showChangelogOnBoot = true;
   }
 
   // require('update-electron-app')(
@@ -650,7 +643,19 @@ function onReady(): void {
     openURLExternally(_url);
   });
 
-  browserWindows.createMainWindow(settings, shouldImportSettings, baseDir);
+  let window = browserWindows.createMainWindow(
+    settings,
+    shouldImportSettings,
+    baseDir
+  );
+  if (showChangelogOnBoot && window) {
+    browserWindows.createChangelogWindow(
+      settings,
+      shouldImportSettings,
+      window
+    );
+    showChangelogOnBoot = false;
+  }
 }
 
 // Twitter fix

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -542,6 +542,31 @@ function onReady(): void {
   electron.ipcMain.on('tab-closed', () => {
     browserWindows.tabClosedHandler();
   });
+
+  electron.ipcMain.on(
+    'update-and-exit',
+    (_event: IpcMainEvent, updateVersion: string) => {
+      if (characters.length > 0) {
+        const button = electron.dialog.showMessageBoxSync(
+          //Yes this could technically fail if this event is ever emitted from something that's not a user interaction.
+          electron.BrowserWindow.getFocusedWindow()!,
+          {
+            message: l('changelog.quitAndDownload.confirm'),
+            title: l('title'),
+            buttons: [l('confirmYes'), l('confirmNo')],
+            cancelId: 1
+          }
+        );
+        if (button !== 0) return;
+      }
+      openURLExternally(
+        'https://horizn.moe/download.html?ver=' + updateVersion
+      );
+      browserWindows.quitAllWindows();
+      app.quit();
+    }
+  );
+
   electron.ipcMain.on(
     'save-login',
     (_event: IpcMainEvent, account: string, host: string, proxy: string) => {

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -504,9 +504,30 @@ function onReady(): void {
                 : 'developmentVersion',
               process.env.APP_VERSION || app.getVersion()
             ),
-            click: showCurrentPatchNotes
+            click: (
+              _m: electron.MenuItem,
+              w: electron.BrowserWindow,
+              _e: KeyboardEvent
+            ) => {
+              browserWindows.createChangelogWindow(settings, false, w);
+            }
+          },
+          {
+            label: 'test update menu',
+            click: (
+              _m: electron.MenuItem,
+              w: electron.BrowserWindow,
+              _e: KeyboardEvent
+            ) => {
+              browserWindows.createChangelogWindow(
+                settings,
+                false,
+                w,
+                'v1.32.1'
+              );
+            }
           }
-        ]
+        ] as MenuItemConstructorOptions[]
       }
     ])
   );

--- a/electron/package.json
+++ b/electron/package.json
@@ -90,6 +90,7 @@
     ]
   },
   "dependencies": {
+    "@mdit/plugin-alert": "^0.22.2",
     "markdown-it": "^14.1.0"
   }
 }

--- a/electron/package.json
+++ b/electron/package.json
@@ -88,5 +88,8 @@
     "onlyBuiltDependencies": [
       "electron"
     ]
+  },
+  "dependencies": {
+    "markdown-it": "^14.1.0"
   }
 }

--- a/electron/pnpm-lock.yaml
+++ b/electron/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    dependencies:
+      markdown-it:
+        specifier: ^14.1.0
+        version: 14.1.0
     devDependencies:
       commander:
         specifier: ^13.1.0
@@ -492,6 +496,10 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.1:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
@@ -804,6 +812,9 @@ packages:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
 
+  linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
@@ -845,6 +856,10 @@ packages:
     resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
 
+  markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+
   matcher@3.0.0:
     resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
     engines: {node: '>=10'}
@@ -852,6 +867,9 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -1052,6 +1070,10 @@ packages:
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
 
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1251,6 +1273,9 @@ packages:
     resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -1996,6 +2021,8 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  entities@4.5.0: {}
+
   env-paths@2.2.1: {}
 
   err-code@2.0.3: {}
@@ -2353,6 +2380,10 @@ snapshots:
     dependencies:
       readable-stream: 2.3.8
 
+  linkify-it@5.0.0:
+    dependencies:
+      uc.micro: 2.1.0
+
   lodash.defaults@4.2.0: {}
 
   lodash.difference@4.5.0: {}
@@ -2402,12 +2433,23 @@ snapshots:
       - bluebird
       - supports-color
 
+  markdown-it@14.1.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
   matcher@3.0.0:
     dependencies:
       escape-string-regexp: 4.0.0
     optional: true
 
   math-intrinsics@1.1.0: {}
+
+  mdurl@2.0.0: {}
 
   mime-db@1.52.0: {}
 
@@ -2596,6 +2638,8 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
+
+  punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
 
@@ -2811,6 +2855,8 @@ snapshots:
     optional: true
 
   typescript@5.8.2: {}
+
+  uc.micro@2.1.0: {}
 
   undici-types@6.21.0: {}
 

--- a/electron/pnpm-lock.yaml
+++ b/electron/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@mdit/plugin-alert':
+        specifier: ^0.22.2
+        version: 0.22.2(markdown-it@14.1.0)
       markdown-it:
         specifier: ^14.1.0
         version: 14.1.0
@@ -73,6 +76,14 @@ packages:
     resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
     engines: {node: '>= 10.0.0'}
 
+  '@mdit/plugin-alert@0.22.2':
+    resolution: {integrity: sha512-n2oVSeg3yeZBCjqfAqbnJxeu4PGq+CXwUWsiwrrARj39z23QZ62FbgL5WGNyP/WFnDAeHMedLDYtipC9OgIOgA==}
+    peerDependencies:
+      markdown-it: ^14.1.0
+    peerDependenciesMeta:
+      markdown-it:
+        optional: true
+
   '@npmcli/fs@2.1.2':
     resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -112,6 +123,15 @@ packages:
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -1465,6 +1485,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@mdit/plugin-alert@0.22.2(markdown-it@14.1.0)':
+    dependencies:
+      '@types/markdown-it': 14.1.2
+    optionalDependencies:
+      markdown-it: 14.1.0
+
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
@@ -1506,6 +1532,15 @@ snapshots:
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 22.14.1
+
+  '@types/linkify-it@5.0.0': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/ms@2.1.0': {}
 

--- a/electron/webpack.config.js
+++ b/electron/webpack.config.js
@@ -85,6 +85,11 @@ const mainConfig = {
         path.join(__dirname, 'settings.html'),
         path.join(__dirname, 'build', 'tray@2x.png')
       ],
+      changelog: [
+        path.join(__dirname, 'changelog.ts'),
+        path.join(__dirname, 'changelog.html'),
+        path.join(__dirname, 'build', 'tray@2x.png')
+      ],
       about: [
         path.join(__dirname, 'about.ts'),
         path.join(__dirname, 'about.html'),

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@types/bluebird": "3.5.42",
     "@types/file-loader": "^5.0.4",
     "@types/lodash": "4.14.162",
+    "@types/markdown-it": "^14.1.2",
     "@types/node": "16.18.126",
     "@types/node-fetch": "^2.6.12",
     "@types/qs": "^6.14.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,6 +71,9 @@ importers:
       '@types/lodash':
         specifier: 4.14.162
         version: 4.14.162
+      '@types/markdown-it':
+        specifier: ^14.1.2
+        version: 14.1.2
       '@types/node':
         specifier: 16.18.32
         version: 16.18.32
@@ -594,8 +597,17 @@ packages:
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
+  '@types/linkify-it@5.0.0':
+    resolution: {integrity: sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==}
+
   '@types/lodash@4.14.162':
     resolution: {integrity: sha512-alvcho1kRUnnD1Gcl4J+hK0eencvzq9rmzvFPRmP5rPHx9VVsJj6bKLTATPVf9ktgv4ujzh7T+XWKp+jhuODig==}
+
+  '@types/markdown-it@14.1.2':
+    resolution: {integrity: sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==}
+
+  '@types/mdurl@2.0.0':
+    resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
 
   '@types/minimatch@5.1.2':
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
@@ -5899,7 +5911,16 @@ snapshots:
     dependencies:
       '@types/node': 16.18.32
 
+  '@types/linkify-it@5.0.0': {}
+
   '@types/lodash@4.14.162': {}
+
+  '@types/markdown-it@14.1.2':
+    dependencies:
+      '@types/linkify-it': 5.0.0
+      '@types/mdurl': 2.0.0
+
+  '@types/mdurl@2.0.0': {}
 
   '@types/minimatch@5.1.2':
     optional: true

--- a/scss/themes/_chat.scss
+++ b/scss/themes/_chat.scss
@@ -21,6 +21,7 @@
 @import '~bootstrap/scss/modal';
 @import '~bootstrap/scss/popover';
 @import '~bootstrap/scss/utilities/background';
+@import '~bootstrap/scss/utilities/borders';
 @import '~bootstrap/scss/utilities/display';
 @import '~bootstrap/scss/utilities/flex';
 @import '~bootstrap/scss/utilities/sizing';


### PR DESCRIPTION
Closes #256 
Closes #121 

<img width="1498" alt="Screenshot 2025-07-08 at 16 44 09" src="https://github.com/user-attachments/assets/5b3e78dc-91d7-4f31-8602-559f1cbb6714" />


The modal dialog can be used for both update notifications (if a version string is passed), or to just show info about the current version. The info is pulled from the GitHub release.


Todo:

- [x] Changelog modal w/ parsed markdown
- [x] Handle external URLs
- [x] Change the update notification to the more subtle one used on MacOS
- [x] Update download links to lead people to Horizon's website instead of GitHub releases
- [x] Get rid of test menu entry for the update checker
- [x] Update ``showCurrentChangelog()``
- [x] Cleanup
- [x] Debate if we want the arrow thing to disappear/ become more subtle if the user chooses to dismiss it.