### PR TITLE
Fixes duplicate icons for gender icons after FontAwesome update

### DIFF
--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -69,7 +69,7 @@
         case 'Female':
           return 'fa-fw fa-venus';
         case 'Shemale':
-          return 'fa-fw fa-transgender';
+          return 'fa-fw fa-mars-and-venus';
         case 'Herm':
           return 'fa-fw fa-mercury';
         case 'Male-Herm':
@@ -77,7 +77,7 @@
         case 'Cunt-boy':
           return 'fa-fw fa-mars-stroke-h';
         case 'Transgender':
-          return 'fa-fw fa-transgender-alt';
+          return 'fa-fw fa-transgender';
       }
     }
 


### PR DESCRIPTION
Transgender and Shemale have the same icon currently, FontAwesome 6 renamed transgender to mars-and-venus and transgender-alt to transgender. 

It didn't inherently break things due to some backwards compatibility allowing transgender-alt to still load but as transgender instead.

This is a quick fix for that, tested and functional!