### PR TITLE
Removes big from bbcode core, makes it no longer work in chat

### DIFF
--- a/bbcode/core.ts
+++ b/bbcode/core.ts
@@ -79,14 +79,6 @@ export class CoreBBCodeParser extends BBCodeParser {
       new BBCodeSimpleTag('sub', 'sub', [], ['b', 'i', 'u', 's', 'color'])
     );
     this.addTag(
-      new BBCodeSimpleTag(
-        'big',
-        'span',
-        ['bigText'],
-        ['b', 'i', 'u', 's', 'color']
-      )
-    );
-    this.addTag(
       new BBCodeSimpleTag('sup', 'sup', [], ['b', 'i', 'u', 's', 'color'])
     );
     this.addTag(


### PR DESCRIPTION
This was a change made in Rising and I'm not wholly sure why but putting it here so we have bbcode function parity with the base client.