### PR TITLE
Bunch of profile viewer BBCode fixes

### DIFF
--- a/bbcode/core.ts
+++ b/bbcode/core.ts
@@ -89,20 +89,6 @@ export class CoreBBCodeParser extends BBCodeParser {
     this.addTag(
       new BBCodeSimpleTag('sup', 'sup', [], ['b', 'i', 'u', 's', 'color'])
     );
-    this.addTag(
-      new BBCodeCustomTag('color', (parser, parent, param) => {
-        const cregex =
-          /^(red|blue|white|yellow|pink|gray|green|orange|purple|black|brown|cyan)$/;
-        if (!cregex.test(param)) {
-          parser.warning('Invalid color parameter provided.');
-          return undefined;
-        }
-        const el = parser.createElement('span');
-        el.className = `${param}Text`;
-        parent.appendChild(el);
-        return el;
-      })
-    );
 
     this.addTag(
       new BBCodeTextTag('url', (parser, parent, param, content) => {

--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -104,7 +104,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
     this.addTag(
       new BBCodeSimpleTag(
         'sub',
-        'span',
+        'sub',
         ['smallText'],
         ['url', 'i', 'u', 'b', 'color', 's', 'hr']
       )
@@ -112,7 +112,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
     this.addTag(
       new BBCodeSimpleTag(
         'sup',
-        'span',
+        'sup',
         ['smallText'],
         ['url', 'i', 'u', 'b', 'color', 's', 'hr']
       )

--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -29,7 +29,27 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
 
   constructor() {
     super();
-    const hrTag = new BBCodeSimpleTag('hr', 'hr', [], []);
+    const hrTag = new BBCodeSimpleTag(
+      'hr',
+      'hr',
+      [],
+      [
+        'collapse',
+        'justify',
+        'center',
+        'left',
+        'right',
+        'url',
+        'i',
+        'u',
+        'b',
+        'color',
+        's',
+        'big',
+        'sub',
+        'hr'
+      ]
+    );
     hrTag.noClosingTag = true;
     this.addTag(hrTag);
     this.addTag(
@@ -70,7 +90,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'big',
         'span',
         ['bigText'],
-        ['url', 'i', 'u', 'b', 'color', 's']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr']
       )
     );
     this.addTag(
@@ -78,7 +98,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'small',
         'span',
         ['smallText'],
-        ['url', 'i', 'u', 'b', 'color', 's']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr']
       )
     );
     this.addTag(
@@ -86,7 +106,15 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'sub',
         'span',
         ['smallText'],
-        ['url', 'i', 'u', 'b', 'color', 's']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr']
+      )
+    );
+    this.addTag(
+      new BBCodeSimpleTag(
+        'sup',
+        'span',
+        ['smallText'],
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr']
       )
     );
     this.addTag(new BBCodeSimpleTag('indent', 'div', ['indentText']));
@@ -108,7 +136,8 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
           'color',
           's',
           'big',
-          'sub'
+          'sub',
+          'hr'
         ]
       )
     );

--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -49,6 +49,23 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
     this.addTag(new BBCodeSimpleTag('center', 'span', ['centerText']));
     this.addTag(new BBCodeSimpleTag('justify', 'span', ['justifyText']));
     this.addTag(
+      new BBCodeCustomTag('color', (parser, parent, param) => {
+        const cregex =
+          /^(red|blue|white|yellow|pink|gray|green|orange|purple|black|brown|cyan)$/;
+        if (!cregex.test(param)) {
+          parser.warning('Invalid color parameter provided.');
+          const el = parser.createElement('span');
+          el.className = `Text`;
+          parent.appendChild(el);
+          return el;
+        }
+        const el = parser.createElement('span');
+        el.className = `${param}Text`;
+        parent.appendChild(el);
+        return el;
+      })
+    );
+    this.addTag(
       new BBCodeSimpleTag(
         'big',
         'span',

--- a/chat/bbcode.ts
+++ b/chat/bbcode.ts
@@ -2,7 +2,7 @@ import Vue from 'vue';
 import { BBCodeElement, CoreBBCodeParser, analyzeUrlTag } from '../bbcode/core';
 //tslint:disable-next-line:match-default-export-name
 import BaseEditor from '../bbcode/Editor.vue';
-import { BBCodeTextTag } from '../bbcode/parser';
+import { BBCodeTextTag, BBCodeCustomTag } from '../bbcode/parser';
 import ChannelView from './ChannelTagView.vue';
 // import {characterImage} from './common';
 import core from './core';
@@ -20,6 +20,20 @@ export default class BBCodeParser extends CoreBBCodeParser {
 
   constructor() {
     super();
+    this.addTag(
+      new BBCodeCustomTag('color', (parser, parent, param) => {
+        const cregex =
+          /^(red|blue|white|yellow|pink|gray|green|orange|purple|black|brown|cyan)$/;
+        if (!cregex.test(param)) {
+          parser.warning('Invalid color parameter provided.');
+          return undefined;
+        }
+        const el = parser.createElement('span');
+        el.className = `${param}Text`;
+        parent.appendChild(el);
+        return el;
+      })
+    );
     this.addTag(
       new BBCodeTextTag('user', (parser, parent, param, content) => {
         if (param.length > 0)


### PR DESCRIPTION
Fixes a good few things.

- Color tags that were done incorrectly did not parse in profile viewer but did on website
- HR tags would often break if near other things or inside certain other bits of bbcode
- sub has been broken in profile viewer (it's barely distinguishable from normal text)

All these are fixed, viewable profiles should go up a lot. This does not account for incorrect color bbcode in chat to keep parity with the main client.