### PR TITLE
Fixes img BBCode in guestbook in profile viewer

### DIFF
--- a/site/character_page/guestbook_post.vue
+++ b/site/character_page/guestbook_post.vue
@@ -82,16 +82,24 @@
 </template>
 
 <script lang="ts">
-  import { Component, Prop } from '@f-list/vue-ts';
+  import { Component, Hook, Prop } from '@f-list/vue-ts';
   import Vue from 'vue';
   import CharacterLink from '../../components/character_link.vue';
   import DateDisplay from '../../components/date_display.vue';
   import * as Utils from '../utils';
   import { methods } from './data_store';
   import { Character, GuestbookPost } from './interfaces';
+  import { StandardBBCodeParser } from '../../bbcode/standard';
+  import { BBCodeView } from '../../bbcode/view';
+
+  const standardParser = new StandardBBCodeParser();
 
   @Component({
-    components: { 'date-display': DateDisplay, 'character-link': CharacterLink }
+    components: {
+      'date-display': DateDisplay,
+      'character-link': CharacterLink,
+      bbcode: BBCodeView(standardParser)
+    }
   })
   export default class GuestbookPostView extends Vue {
     @Prop({ required: true })
@@ -110,6 +118,13 @@
 
     get avatarUrl(): string {
       return Utils.avatarURL(this.post.character.name);
+    }
+
+    @Hook('beforeMount')
+    beforeMount(): void {
+      standardParser.inlines = this.character.character.inlines;
+
+      // console.log('mounted');
     }
 
     async deletePost(): Promise<void> {


### PR DESCRIPTION
Quick fix to make img bbcode work in guestbook in the profile viewer as it does on site, can only utilise inlines present in the profile you're looking at. Should be less jank than my earlier attempts and function well, so far testing seems positive with it.