### PR TITLE
Quick fix to make inline data properly update in profile viewer when cache expires

### DIFF
--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -91,7 +91,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'big',
         'span',
         ['bigText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
       )
     );
     this.addTag(
@@ -99,7 +99,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'small',
         'span',
         ['smallText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
       )
     );
     this.addTag(
@@ -107,7 +107,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'sub',
         'sub',
         ['smallText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
       )
     );
     this.addTag(
@@ -115,7 +115,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'sup',
         'sup',
         ['smallText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
       )
     );
     this.addTag(new BBCodeSimpleTag('indent', 'div', ['indentText']));
@@ -139,7 +139,8 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
           'big',
           'sub',
           'hr',
-          'img'
+          'img',
+          'eicon'
         ]
       )
     );

--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -570,6 +570,8 @@
 
         this.character = character;
 
+        standardParser.inlines = this.character.character.inlines;
+
         this.updateMatches();
 
         // No awaits on these on purpose:


### PR DESCRIPTION
Just slots in the line to update the available inlines into the refreshCharacter() function from load(), shouldn't cause issues since all the same data in there should be available. 

Refresh just makes sure it comes new rather than from the cache and this makes sure that includes the inline data it already collects is just stored properly.