### PR TITLE
Quick fix to sidebar profile viewer to allow icons and eicons to show up in it

### DIFF
--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -397,6 +397,10 @@
           display: none !important;
         }
 
+        .character-avatar.icon {
+          display: initial !important;
+        }
+
         #characterView {
           .card {
             border: none !important;


### PR DESCRIPTION
Long standing issue mentioned in https://github.com/Fchat-Horizon/Horizon/issues/276, icons and eicons didn't show up in the profile viewer on the sidebar. Was due to some wonky CSS rules and here's a wonky fix for it.

<img width="181" height="120" alt="2025-07-13 17 19 41" src="https://github.com/user-attachments/assets/7311c800-9d96-4748-aa4a-54abb3ab8ffd" /> <- Before and after -> <img width="193" height="189" alt="2025-07-13 17 17 58" src="https://github.com/user-attachments/assets/d4032432-8947-43a6-ab88-59d66f207d19" />

First image is icon link to my test profile, second image is an eicon called 'brittish cuisine' (I was too lazy to upload a test eicon)