### PR TITLE
Moves some dupe BBCode to core.

### DIFF
--- a/bbcode/core.ts
+++ b/bbcode/core.ts
@@ -4,6 +4,10 @@ import {
   BBCodeSimpleTag,
   BBCodeTextTag
 } from './parser';
+import * as Utils from '../site/utils';
+import { default as IconView } from '../bbcode/IconView.vue';
+import UrlTagView from './UrlTagView.vue';
+import core from '../chat/core';
 
 const urlFormat = '((?:https?|ftps?|irc)://[^\\s/$.?#"\']+\\.[^\\s"]+)';
 export const findUrlRegex = new RegExp(`(\\[url[=\\]]\\s*)?${urlFormat}`, 'gi');
@@ -67,6 +71,7 @@ export function analyzeUrlTag(
 }
 
 export class CoreBBCodeParser extends BBCodeParser {
+  cleanup: Vue[] = [];
   /*tslint:disable-next-line:typedef*/ //https://github.com/palantir/tslint/issues/711
   constructor(public makeLinksClickable = true) {
     super();
@@ -76,41 +81,81 @@ export class CoreBBCodeParser extends BBCodeParser {
     this.addTag(new BBCodeSimpleTag('s', 'del'));
     this.addTag(new BBCodeSimpleTag('noparse', 'span', [], []));
     this.addTag(
-      new BBCodeSimpleTag('sub', 'sub', [], ['b', 'i', 'u', 's', 'color'])
+      new BBCodeSimpleTag(
+        'sub',
+        'sub',
+        [],
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
+      )
     );
     this.addTag(
-      new BBCodeSimpleTag('sup', 'sup', [], ['b', 'i', 'u', 's', 'color'])
+      new BBCodeSimpleTag(
+        'sup',
+        'sup',
+        [],
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
+      )
     );
-
     this.addTag(
-      new BBCodeTextTag('url', (parser, parent, param, content) => {
-        const tagData = analyzeUrlTag(parser, param, content);
-        const element = parser.createElement('span');
+      new BBCodeTextTag('icon', (parser, parent, param, content) => {
+        if (param.length > 0)
+          parser.warning('Unexpected parameter on icon tag.');
+        const uregex = /^[a-zA-Z0-9_\-\s]+$/;
+        if (!uregex.test(content)) return;
+        const root = parser.createElement('span');
+        const el = parser.createElement('span');
+        parent.appendChild(root);
+        root.appendChild(el);
+        const view = new IconView({
+          el,
+          propsData: {
+            character: core.characters.get(content)
+          }
+        });
 
-        parent.appendChild(element);
+        this.cleanup.push(view);
+        return root;
+      })
+    );
+    this.addTag(
+      new BBCodeTextTag('eicon', (parser, parent, param, content) => {
+        if (param.length > 0)
+          parser.warning('Unexpected parameter on eicon tag.');
+        const uregex = /^[a-zA-Z0-9_\-\s]+$/;
+        if (!uregex.test(content)) return;
+        let extension = '.gif';
+        if (!Utils.settings.animateEicons) extension = '.png';
+        const img = parser.createElement('img');
+        img.src = `${Utils.staticDomain}images/eicon/${content.toLowerCase()}${extension}`;
+        img.title = img.alt = content;
+        img.className = 'character-avatar icon';
+        parent.appendChild(img);
+        return img;
+      })
+    );
+    this.addTag(
+      new BBCodeTextTag('url', (parser, parent, _, content) => {
+        const tagData = analyzeUrlTag(parser, _, content);
+        const root = parser.createElement('span');
+
+        parent.appendChild(root);
 
         if (!tagData.success) {
-          element.textContent = tagData.textContent;
+          root.textContent = tagData.textContent;
           return;
         }
 
-        const fa = parser.createElement('i');
-        fa.className = 'fa fa-link';
-        element.appendChild(fa);
-        const a = parser.createElement('a');
-        a.href = tagData.url as string;
-        a.rel = 'nofollow noreferrer noopener';
-        a.target = '_blank';
-        a.className = 'user-link';
-        a.title = tagData.url as string;
-        a.textContent = tagData.textContent;
-        element.appendChild(a);
-        const span = document.createElement('span');
-        span.className = 'link-domain bbcode-pseudo';
-        span.textContent = ` [${tagData.domain}]`;
-        element.appendChild(span);
+        const view = new UrlTagView({
+          el: root,
+          propsData: {
+            url: tagData.url,
+            text: tagData.textContent,
+            domain: tagData.domain
+          }
+        });
+        this.cleanup.push(view);
 
-        return element;
+        return root;
       })
     );
     this.addTag(

--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -2,11 +2,8 @@ import Vue from 'vue';
 import { BBCodeElement } from './core';
 import { InlineDisplayMode, InlineImage } from '../interfaces';
 import * as Utils from '../site/utils';
-import { analyzeUrlTag, CoreBBCodeParser } from './core';
+import { CoreBBCodeParser } from './core';
 import { BBCodeCustomTag, BBCodeSimpleTag, BBCodeTextTag } from './parser';
-import UrlTagView from './UrlTagView.vue';
-import { default as IconView } from '../bbcode/IconView.vue';
-import core from '../chat/core';
 
 const usernameRegex = /^[a-zA-Z0-9_\-\s]+$/;
 
@@ -98,22 +95,6 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
       new BBCodeSimpleTag(
         'small',
         'span',
-        ['smallText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
-      )
-    );
-    this.addTag(
-      new BBCodeSimpleTag(
-        'sub',
-        'sub',
-        ['smallText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
-      )
-    );
-    this.addTag(
-      new BBCodeSimpleTag(
-        'sup',
-        'sup',
         ['smallText'],
         ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
       )
@@ -230,50 +211,6 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
       })
     );
     this.addTag(
-      new BBCodeTextTag('icon', (parser, parent, param, content) => {
-        if (param !== '') parser.warning('Unexpected parameter on icon tag.');
-        if (!usernameRegex.test(content)) return;
-
-        const root = parser.createElement('span');
-        const el = parser.createElement('span');
-        parent.appendChild(root);
-        root.appendChild(el);
-        const view = new IconView({
-          el,
-          propsData: { character: core.characters.get(content) }
-        });
-
-        this.cleanup.push(view);
-        return root;
-
-        // const a = parser.createElement('a');
-        // a.href = `${Utils.siteDomain}c/${content}`;
-        // a.target = '_blank';
-        // const img = parser.createElement('img');
-        // img.src = `${Utils.staticDomain}images/avatar/${content.toLowerCase()}.png`;
-        // img.className = 'character-avatar icon';
-        // img.title = img.alt = content;
-        // a.appendChild(img);
-        // parent.appendChild(a);
-        // return a;
-      })
-    );
-    this.addTag(
-      new BBCodeTextTag('eicon', (parser, parent, param, content) => {
-        if (param !== '') parser.warning('Unexpected parameter on eicon tag.');
-
-        if (!usernameRegex.test(content)) return;
-        let extension = '.gif';
-        if (!Utils.settings.animateEicons) extension = '.png';
-        const img = parser.createElement('img');
-        img.src = `${Utils.staticDomain}images/eicon/${content.toLowerCase()}${extension}`;
-        img.className = 'character-avatar icon';
-        img.title = img.alt = content;
-        parent.appendChild(img);
-        return img;
-      })
-    );
-    this.addTag(
       new BBCodeTextTag('img', (p, parent, param, content) => {
         const parser = <StandardBBCodeParser>p;
         if (typeof parser.inlines === 'undefined') {
@@ -319,34 +256,6 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
           parent.appendChild(el);
         } else parent.appendChild((element = parser.createInline(inline)));
         return element;
-      })
-    );
-
-    this.addTag(
-      new BBCodeTextTag('url', (parser, parent, _, content) => {
-        const tagData = analyzeUrlTag(parser, _, content);
-        const root = parser.createElement('span');
-
-        parent.appendChild(root);
-
-        // root.appendChild(el);
-
-        if (!tagData.success) {
-          root.textContent = tagData.textContent;
-          return;
-        }
-
-        const view = new UrlTagView({
-          el: root,
-          propsData: {
-            url: tagData.url,
-            text: tagData.textContent,
-            domain: tagData.domain
-          }
-        });
-        this.cleanup.push(view);
-
-        return root;
       })
     );
   }

--- a/chat/bbcode.ts
+++ b/chat/bbcode.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import { BBCodeElement, CoreBBCodeParser, analyzeUrlTag } from '../bbcode/core';
+import { BBCodeElement, CoreBBCodeParser } from '../bbcode/core';
 //tslint:disable-next-line:match-default-export-name
 import BaseEditor from '../bbcode/Editor.vue';
 import { BBCodeTextTag, BBCodeCustomTag } from '../bbcode/parser';
@@ -7,8 +7,6 @@ import ChannelView from './ChannelTagView.vue';
 // import {characterImage} from './common';
 import core from './core';
 // import {Character} from './interfaces';
-import { default as UrlView } from '../bbcode/UrlTagView.vue';
-import { default as IconView } from '../bbcode/IconView.vue';
 import UserView from './UserView.vue';
 
 export class Editor extends BaseEditor {
@@ -56,55 +54,6 @@ export default class BBCodeParser extends CoreBBCodeParser {
       })
     );
     this.addTag(
-      new BBCodeTextTag('icon', (parser, parent, param, content) => {
-        if (param.length > 0)
-          parser.warning('Unexpected parameter on icon tag.');
-        const uregex = /^[a-zA-Z0-9_\-\s]+$/;
-        if (!uregex.test(content)) return;
-
-        const root = parser.createElement('span');
-        const el = parser.createElement('span');
-        parent.appendChild(root);
-        root.appendChild(el);
-        const view = new IconView({
-          el,
-          propsData: {
-            character: core.characters.get(content)
-          }
-        });
-
-        this.cleanup.push(view);
-        return root;
-
-        /* const img = parser.createElement('img');
-            img.src = characterImage(content);
-            img.style.cursor = 'pointer';
-            img.className = 'character-avatar icon';
-            img.title = img.alt = content;
-            (<HTMLImageElement & {character: Character}>img).character = core.characters.get(content);
-            parent.appendChild(img);
-            return img; */
-      })
-    );
-    this.addTag(
-      new BBCodeTextTag('eicon', (parser, parent, param, content) => {
-        if (param.length > 0)
-          parser.warning('Unexpected parameter on eicon tag.');
-        const uregex = /^[a-zA-Z0-9_\-\s]+$/;
-        if (!uregex.test(content)) return;
-        const extension =
-          core.connection.isOpen && !core.state.settings.animatedEicons
-            ? 'png'
-            : 'gif';
-        const img = parser.createElement('img');
-        img.src = `https://static.f-list.net/images/eicon/${content.toLowerCase()}.${extension}`;
-        img.title = img.alt = content;
-        img.className = 'character-avatar icon';
-        parent.appendChild(img);
-        return img;
-      })
-    );
-    this.addTag(
       new BBCodeTextTag('session', (parser, parent, param, content) => {
         const root = parser.createElement('span');
         const el = parser.createElement('span');
@@ -129,34 +78,6 @@ export default class BBCodeParser extends CoreBBCodeParser {
           propsData: { id: content, text: content }
         });
         this.cleanup.push(view);
-        return root;
-      })
-    );
-
-    this.addTag(
-      new BBCodeTextTag('url', (parser, parent, _, content) => {
-        const tagData = analyzeUrlTag(parser, _, content);
-
-        const root = parser.createElement('span');
-        // const el = parser.createElement('span');
-        parent.appendChild(root);
-        // root.appendChild(el);
-
-        if (!tagData.success) {
-          root.textContent = tagData.textContent;
-          return;
-        }
-
-        const view = new UrlView({
-          el: root,
-          propsData: {
-            url: tagData.url,
-            text: tagData.textContent,
-            domain: tagData.domain
-          }
-        });
-        this.cleanup.push(view);
-
         return root;
       })
     );


### PR DESCRIPTION
Sub, sup, icon, eicon, and url now only exist in core as the duplicate versions spread out among the three different kinds of bbcode styles was redundant. They differed primarily in how certain data was grabbed _sometimes_.

User was left in place as the profile/chat versions display differently but I can pull that in if it is wanted, it'd likely produce a visual difference in profiles if it is though.

I haven't tested this extensively (though I'm probably gonna be running it for the next few days and should see if anything is screwed) but my little testing so far shows everything displaying properly where it should.

Primary reason to do this is just ease of maintanence in future, means you don't have to go change two versions of the exact same thing and deal with their micro-differences should those things require changing for any reason.