### PR TITLE
Fix portrait URL extraction when multiple links appear on the same line

### DIFF
--- a/learn/profile-cache.ts
+++ b/learn/profile-cache.ts
@@ -212,11 +212,11 @@ export class ProfileCache extends AsyncCache<CharacterCacheRecord> {
     }
 
     // * We should check for both:
+    //  [url=https://some.domain.ext/path/to/image.png]Horizon Portrait[/url]
     //  [url=https://some.domain.ext/path/to/image.png]Rising Portrait[/url]
-    //  [url=https://some.domain.ext/path/to/image.png]Rising Portrait[/url]
-    // * Despite our name change, we should REMAIN COMPATABLE!
+    // * Despite our name change, we should REMAIN COMPATIBLE!
     const match = description.match(
-      /\[url=(.*?)]\s*?(Rising|Horizon)\s*?Portrait\s*?\[\/url]/i
+      /\[url=([^]]*?)]\s*?(Rising|Horizon)\s*?Portrait\s*?\[\/url]/i
     );
 
     if (match && match[1]) {

--- a/learn/profile-cache.ts
+++ b/learn/profile-cache.ts
@@ -216,7 +216,7 @@ export class ProfileCache extends AsyncCache<CharacterCacheRecord> {
     //  [url=https://some.domain.ext/path/to/image.png]Rising Portrait[/url]
     // * Despite our name change, we should REMAIN COMPATIBLE!
     const match = description.match(
-      /\[url=([^]]*?)]\s*?(Rising|Horizon)\s*?Portrait\s*?\[\/url]/i
+      /\[url=([^\]]*?)]\s*?(Rising|Horizon)\s*?Portrait\s*?\[\/url]/i
     );
 
     if (match && match[1]) {


### PR DESCRIPTION
This change ensures that the URL extraction continues to function properly if there are other links on the same line.

```node
> const description = '[url=https://example.com]Some other thing[/url] | [url=https://i.imgur.com/abcde.jpg]Horizon Portrait[/url]'
undefined
> let match = description.match(/\[url=(.*?)]\s*?(Rising|Horizon)\s*?Portrait\s*?\[\/url]/i)
[...]
> match[1]
'https://example.com]Some other thing[/url] | [url=https://i.imgur.com/abcde.jpg'
> match = description.match(/\[url=([^\]]*?)\]\s*?(Rising|Horizon)\s*?Portrait\s*?\[\/url\]/i)
[...]
> match[1]
'https://i.imgur.com/abcde.jpg'
```