### PR TITLE
Inlines now don't render in profile viewer if it cannot find an actual inline

### DIFF
--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -278,19 +278,31 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         const parser = <StandardBBCodeParser>p;
         if (typeof parser.inlines === 'undefined') {
           parser.warning('This page does not support inline images.');
-          return undefined;
+          const el = parser.createElement('span');
+          el.className = `Text`;
+          el.innerText = ``;
+          parent.appendChild(el);
+          return el;
         }
         const displayMode = Utils.settings.inlineDisplayMode;
         if (!/^\d+$/.test(param)) {
           parser.warning('img tag parameters must be numbers.');
-          return undefined;
+          const el = parser.createElement('span');
+          el.className = `Text`;
+          el.innerText = ``;
+          parent.appendChild(el);
+          return el;
         }
         const inline = parser.inlines[param];
         if (typeof inline !== 'object') {
           parser.warning(
             `Could not find an inline image with id ${param} It will not be visible.`
           );
-          return undefined;
+          const el = parser.createElement('span');
+          el.className = `Text`;
+          el.innerText = ``;
+          parent.appendChild(el);
+          return el;
         }
         inline.name = content;
         let element: HTMLElement;


### PR DESCRIPTION
This is also site functionality that's not mirrored by the client so far, it makes both of the other inline errors blank too. This iteration is actually somewhat inconsistent with the site since guestbook shows erroring inlines on the site but will now not show them in the client when they are broken. IMO, that's not too big of a deal.

This one I'll say is a maybe to add since inlines not being found can be a good indicator you need to refresh profiles and this only really matters if someone deletes an inline on the site but doesn't remove the bbcode.