### PR TITLE
Formatting parity for bbcode in profiles

### DIFF
--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -118,7 +118,9 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
           'color',
           's',
           'big',
+          'small',
           'sub',
+          'sup',
           'hr',
           'img',
           'eicon'

--- a/scss/_bbcode.scss
+++ b/scss/_bbcode.scss
@@ -46,13 +46,12 @@
   color: $black-color;
 }
 
-/* Tweak these to be consistent with how bootstrap does sizing. */
 span.bigText {
-  font-size: $font-size-lg;
+  font-size: 1.4em;
 }
 
 span.smallText {
-  font-size: $font-size-sm;
+  font-size: 0.8em;
 }
 
 span.leftText {
@@ -141,5 +140,11 @@ div.indentText {
 
   a.user-link {
     color: var(--linkForcedColor);
+  }
+
+  // [heading] tags are rendered as h2
+  h2 {
+    font-weight: $font-weight-bold;
+    font-size: 1.17rem;
   }
 }

--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -1056,6 +1056,20 @@
   .character-description .bbcode {
     white-space: pre-line !important;
 
+    // [sub] and [sup] tags behave slightly differently on profiles and in chat
+    sub {
+      vertical-align: baseline;
+    }
+
+    sup {
+      vertical-align: top;
+    }
+
+    sub,
+    sup {
+      line-height: 1.5;
+    }
+
     blockquote {
       margin: 0;
       background-color: var(--characterImageWrapperBg);


### PR DESCRIPTION
I noticed a few visual discrepancies with how tags that change the text size behave in the profile viewer VS F-list. The attached changes aim to fix these.

- Allow `[small]` and `[sup]` tags within `[heading]`s
- Use the same `font-size` value for `[big]` and `[small]` as the site. These are expressed in `em` since they're supposed to scale with the parent component (namely `[heading]`)
- Update the styles for `h2` elements within bbcode components (`heading` gets translated to `h2` in Horizon's implementation) to match the site's
- Tweak styles for `sup` and `sub` elements only inside the profile viewer. There are minor differences with how these get rendered in the chat VS on profiles.

I created the **Vitaly Carapathian** test profile to verify the changes for various valid tag combinations. I'll attach screenshots here as well.

<img width="1289" height="624" alt="image" src="https://github.com/user-attachments/assets/66bc4462-8f7d-490d-a2c8-4e4685071c71" />

*Website, Windows/Chrome, Default theme*

<img width="1867" height="876" alt="image" src="https://github.com/user-attachments/assets/40145dfc-1166-4841-9f19-8519b051339c" />

*Horizon current stable release, default theme*

<img width="1878" height="736" alt="image" src="https://github.com/user-attachments/assets/8be3ffd5-d93a-40ab-9b95-91538ac996d1" />

*Dev build for this branch, default theme*