### PR TITLE
Refactor character state management

### DIFF
--- a/fchat/interfaces.ts
+++ b/fchat/interfaces.ts
@@ -315,10 +315,6 @@ export namespace Character {
     readonly ownCharacter: Character;
     readonly friends: ReadonlyArray<Character>;
     readonly bookmarks: ReadonlyArray<Character>;
-    readonly ignoreList: ReadonlyArray<string>;
-    readonly opList: ReadonlyArray<string>;
-    readonly friendList: ReadonlyArray<string>;
-    readonly bookmarkList: ReadonlyArray<string>;
 
     readonly ownProfile: CharacterProfile;
 


### PR DESCRIPTION
Fixes #143 

- Replaced `ignoreList` / `opList` / `friendList` / `bookmarkList` with string sets to make retrieval and removal more efficient
- Sets only contain lowercase names so all lookups can be made in a case-insensitive manner
- Removed the lists from the public interface, as they don't seem to be accessed from outside the class.