### PR TITLE
Set character card header z-index to be dimmed on modals

### DIFF
--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -1047,7 +1047,7 @@
   .character-card-header {
     position: sticky;
     top: -1rem;
-    z-index: 10000;
+    z-index: 1000;
     background: var(--headerBackgroundMaskColor) !important;
   }
 


### PR DESCRIPTION
Fixes #282

Only change to header behaviour is that hover popover of kinks now appear above the header, instead of below. Due to popver z-index being 1060 and modal ones being 1040, hence why the header's z-index must be lower. 

Before:
<img width="237" height="163" alt="Screenshot 2025-07-21 205421" src="https://github.com/user-attachments/assets/9fa23b0e-7027-4006-b1b9-f70edf2932dc" />

After:
<img width="242" height="178" alt="Screenshot 2025-07-21 205435" src="https://github.com/user-attachments/assets/7b11a6a8-7b19-4185-b311-f2a7c365b3db" />
