### PR TITLE
Bootstrap 5 migration

### DIFF
--- a/bbcode/EIconSelector.vue
+++ b/bbcode/EIconSelector.vue
@@ -14,7 +14,7 @@
       >
         <strong>Loading...</strong>
         <div
-          class="spinner-border ml-auto"
+          class="spinner-border ms-auto"
           role="status"
           aria-hidden="true"
         ></div>

--- a/bbcode/EIconSelector.vue
+++ b/bbcode/EIconSelector.vue
@@ -704,7 +704,7 @@
           margin-left: -1px;
 
           .btn {
-            border-bottom: 1px solid var(--secondary);
+            border-bottom: 1px solid var(--bs-secondary);
           }
 
           .expressions {
@@ -744,8 +744,8 @@
             position: relative;
 
             &:hover {
-              background-color: var(--light) !important;
-              border: solid 1px var(--light) !important;
+              background-color: var(--bs-light) !important;
+              border: solid 1px var(--bs-light) !important;
 
               .favorite-toggle {
                 visibility: visible !important;
@@ -763,10 +763,10 @@
               visibility: hidden;
 
               i {
-                color: var(--gray-dark);
+                color: var(--bs-secondary-text-emphasis);
                 opacity: 0.85;
                 -webkit-text-stroke-width: thin;
-                -webkit-text-stroke-color: var(--light);
+                -webkit-text-stroke-color: var(--bs-secondary-color);
 
                 &:hover {
                   opacity: 1;
@@ -777,7 +777,7 @@
                 visibility: visible;
 
                 i {
-                  color: var(--green);
+                  color: var(--bs-success);
                   opacity: 1;
 
                   &:hover {

--- a/bbcode/Editor.vue
+++ b/bbcode/Editor.vue
@@ -80,9 +80,7 @@
         aria-label="Close"
         style="margin-left: 10px"
         @click="showToolbar = false"
-      >
-        &times;
-      </button>
+      ></button>
     </div>
     <div
       class="bbcode-editor-text-area bg-light"
@@ -545,7 +543,7 @@
   .bbcode-toolbar {
     .toolbar-buttons {
       .btn.toggled {
-        background-color: var(--secondary) !important;
+        background-color: var(--bs-secondary) !important;
       }
     }
 
@@ -555,7 +553,7 @@
       left: 94px;
       line-height: 1;
       z-index: 1000;
-      background-color: var(--input-bg);
+      background-color: var(--bs-body-bg);
 
       .btn-group {
         display: block;
@@ -568,7 +566,7 @@
           padding: 0 !important;
           margin-right: -1px !important;
           margin-bottom: -1px !important;
-          border: 1px solid var(--secondary);
+          border: 1px solid var(--bs-secondary);
           width: 1.3rem;
           height: 1.3rem;
 
@@ -577,7 +575,7 @@
           }
 
           &:hover {
-            border-color: var(--gray-dark) !important;
+            border-color: var(--bs-gray-800) !important;
           }
 
           &.red {

--- a/bbcode/Editor.vue
+++ b/bbcode/Editor.vue
@@ -548,15 +548,21 @@
     }
 
     .color-selector {
-      max-width: 145px;
+      max-width: 150px;
       top: -57px;
       left: 94px;
       line-height: 1;
       z-index: 1000;
       background-color: var(--bs-body-bg);
+      position: absolute;
+
+      .popover-body {
+        padding: 0px;
+      }
 
       .btn-group {
         display: block;
+        margin: 10px 13px 10px 13px;
       }
 
       .btn {

--- a/bbcode/Editor.vue
+++ b/bbcode/Editor.vue
@@ -76,7 +76,7 @@
       </div>
       <button
         type="button"
-        class="close"
+        class="btn-close"
         aria-label="Close"
         style="margin-left: 10px"
         @click="showToolbar = false"

--- a/chat/ChannelList.vue
+++ b/chat/ChannelList.vue
@@ -16,11 +16,9 @@
       ></tabs>
       <div style="display: flex; flex-direction: column">
         <div class="input-group" style="padding: 10px 0; flex-shrink: 0">
-          <div class="input-group-prepend">
-            <div class="input-group-text">
-              <span class="fas fa-search"></span>
-            </div>
-          </div>
+          <span class="input-group-text">
+            <span class="fas fa-search"></span>
+          </span>
           <input
             class="form-control"
             style="flex: 1; margin-right: 10px"
@@ -76,11 +74,9 @@
           </div>
         </div>
         <div class="input-group" style="padding: 10px 0; flex-shrink: 0">
-          <div class="input-group-prepend">
-            <div class="input-group-text">
-              <span class="fas fa-plus"></span>
-            </div>
-          </div>
+          <span class="input-group-text">
+            <span class="fas fa-plus"></span>
+          </span>
           <input
             class="form-control"
             style="flex: 1; margin-right: 10px"

--- a/chat/CharacterSearch.vue
+++ b/chat/CharacterSearch.vue
@@ -929,7 +929,7 @@
       margin-bottom: 0;
       padding-top: 0;
       padding-bottom: 0;
-      background-color: var(--secondary);
+      background-color: var(--bs-secondary);
 
       &:hover {
         background-color: var(--blue);

--- a/chat/CharacterSearchHistory.vue
+++ b/chat/CharacterSearchHistory.vue
@@ -9,7 +9,7 @@
   >
     <form class="search-history" v-if="history.length > 0">
       <div
-        class="form-row"
+        class="row"
         v-for="(search, index) in history"
         :class="{ 'selected-row': index === selectedSearch }"
       >
@@ -32,7 +32,7 @@
               class="fas"
               :class="{ 'fa-check-circle': index === selectedSearch }"
           /></span>
-          <label class="custom-control-label" :for="'search_history_' + index">
+          <label class="form-check-label" :for="'search_history_' + index">
             {{ describeSearch(search) }}
           </label>
           <span class="content-action" @click="removeSearchHistoryEntry(index)"

--- a/chat/Chat.vue
+++ b/chat/Chat.vue
@@ -27,7 +27,7 @@
       </h3>
       <div class="card-body">
         <h4 class="card-title">{{ l('login.selectCharacter') }}</h4>
-        <select v-model="selectedCharacter" class="form-control custom-select">
+        <select v-model="selectedCharacter" class="form-select form-select">
           <option v-for="character in ownCharacters" :value="character">
             {{ character.name }}
           </option>

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -862,23 +862,23 @@
         /*}*/
 
         .offline {
-          color: var(--text-muted);
+          color: var(--bs-tertiary-color);
         }
 
         .online {
-          color: var(--success);
+          color: var(--bs-success);
         }
 
         .away {
-          color: var(--warning);
+          color: var(--bs-warning);
         }
         .dnd {
-          color: var(--danger);
+          color: var(--bs-danger);
         }
 
         .fa-comment,
         .fa-comment-dots {
-          color: var(--black);
+          color: inherit;
         }
 
         /*.fa-eye {*/
@@ -896,10 +896,6 @@
       &:last-child img {
         border-bottom-left-radius: 4px;
       }
-    }
-
-    .list-group-item-danger:not(.active) {
-      color: color-yiq(theme-color('danger'));
     }
   }
 

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -149,7 +149,7 @@
             @click.prevent="conversation.show()"
             :class="getClasses(conversation)"
             :data-character="conversation.character.name"
-            data-touch="false"
+            data-bs-touch="false"
             class="list-group-item list-group-item-action item-private"
             :key="conversation.key"
             @click.middle.prevent.stop="conversation.close()"

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -31,11 +31,11 @@
           >
             <h5
               style="margin: 0; line-height: 1.65rem"
-              class="sidebarUserInfo-name p-2"
+              class="sidebarUserInfo-name"
             >
               {{ ownCharacter.name }}
             </h5>
-            <span class="p-2">
+            <span>
               <i
                 class="fas fa-fw"
                 :class="getStatusIcon(ownCharacter.status)"

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -822,7 +822,7 @@
   .list-group.conversation-nav {
     //padding-top: 8px;
     .fas.active {
-      color: var(--success);
+      color: var(--bs-success);
     }
 
     .list-group-item {
@@ -842,7 +842,7 @@
           padding-right: 0;
         }
         &:hover:not(.active) {
-          color: var(--dark);
+          color: var(--bs-dark);
         }
       }
       &.item-private {
@@ -941,10 +941,6 @@
       font-size: 2em;
       height: 30px;
     }
-
-    .list-group-item-danger:not(.active) {
-      color: color-yiq(theme-color('danger'));
-    }
   }
 
   #sidebar {
@@ -982,7 +978,7 @@
       margin-top: 3px;
 
       span {
-        color: var(--danger);
+        color: var(--bs-danger);
         cursor: pointer;
 
         &:hover {

--- a/chat/CommandHelp.vue
+++ b/chat/CommandHelp.vue
@@ -26,9 +26,9 @@
       </div>
     </div>
     <div class="input-group" style="padding: 10px 0; flex-shrink: 0">
-      <div class="input-group-prepend">
-        <div class="input-group-text"><span class="fas fa-search"></span></div>
-      </div>
+      <span class="input-group-text">
+        <span class="fas fa-search"></span>
+      </span>
       <input class="form-control" v-model="filter" :placeholder="l('filter')" />
     </div>
   </modal>

--- a/chat/ConversationSettings.vue
+++ b/chat/ConversationSettings.vue
@@ -8,12 +8,12 @@
     :buttonText="l('conversationSettings.save')"
     iconClass="fas fa-gear"
   >
-    <div class="form-group">
+    <div class="mb-3">
       <label class="control-label" :for="'notify' + conversation.key">{{
         l('conversationSettings.notify')
       }}</label>
       <select
-        class="form-control"
+        class="form-select"
         :id="'notify' + conversation.key"
         v-model="notify"
       >
@@ -28,12 +28,12 @@
         </option>
       </select>
     </div>
-    <div class="form-group">
+    <div class="mb-3">
       <label class="control-label" :for="'highlight' + conversation.key">{{
         l('settings.highlight')
       }}</label>
       <select
-        class="form-control"
+        class="form-select"
         :id="'highlight' + conversation.key"
         v-model="highlight"
       >
@@ -48,7 +48,7 @@
         </option>
       </select>
     </div>
-    <div class="form-group">
+    <div class="mb-3">
       <label class="control-label" for="defaultHighlights">
         <input
           type="checkbox"
@@ -58,7 +58,7 @@
         {{ l('settings.defaultHighlights') }}
       </label>
     </div>
-    <div class="form-group">
+    <div class="mb-3">
       <label class="control-label" :for="'highlightWords' + conversation.key">{{
         l('settings.highlightWords')
       }}</label>
@@ -68,7 +68,7 @@
         v-model="highlightWords"
       />
     </div>
-    <div class="form-group">
+    <div class="mb-3">
       <label class="control-label" :for="'highlightUsers' + conversation.key">{{
         l('settings.highlightUsers.conversation')
       }}</label>
@@ -78,12 +78,12 @@
         v-model="horizonHighlightUsers"
       />
     </div>
-    <div class="form-group">
+    <div class="mb-3">
       <label class="control-label" :for="'joinMessages' + conversation.key">{{
         l('settings.joinMessages')
       }}</label>
       <select
-        class="form-control"
+        class="form-select"
         :id="'joinMessages' + conversation.key"
         v-model="joinMessages"
       >

--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -237,9 +237,9 @@
       </a>
     </div>
     <div class="search input-group" v-show="showSearch">
-      <div class="input-group-prepend">
-        <div class="input-group-text"><span class="fas fa-search"></span></div>
-      </div>
+      <span class="input-group-text">
+        <span class="fas fa-search"></span>
+      </span>
       <input
         v-model="searchInput"
         @keydown.esc="hideSearch()"

--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -118,9 +118,9 @@
       ></message-view>
     </div>
     <div class="input-group" style="flex-shrink: 0">
-      <div class="input-group-prepend">
-        <div class="input-group-text"><span class="fas fa-search"></span></div>
-      </div>
+      <span class="input-group-text">
+        <span class="fas fa-search"></span>
+      </span>
       <input
         class="form-control"
         v-model="filter"

--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -21,13 +21,13 @@
         ></span>
       </div>
     </template>
-    <div class="form-group row" style="flex-shrink: 0" v-show="showFilters">
+    <div class="mb-3 row" style="flex-shrink: 0" v-show="showFilters">
       <label for="character" class="col-sm-2 col-form-label">{{
         l('logs.character')
       }}</label>
       <div :class="canZip ? 'col-sm-8 col-10 col-xl-9' : 'col-sm-10'">
         <select
-          class="form-control"
+          class="form-select"
           v-model="selectedCharacter"
           id="character"
           @change="loadCharacter"
@@ -46,7 +46,7 @@
         </button>
       </div>
     </div>
-    <div class="form-group row" style="flex-shrink: 0" v-show="showFilters">
+    <div class="mb-3 row" style="flex-shrink: 0" v-show="showFilters">
       <label class="col-sm-2 col-form-label">{{
         l('logs.conversation')
       }}</label>
@@ -76,13 +76,13 @@
         </button>
       </div>
     </div>
-    <div class="form-group row" style="flex-shrink: 0" v-show="showFilters">
+    <div class="mb-3 row" style="flex-shrink: 0" v-show="showFilters">
       <label for="date" class="col-sm-2 col-form-label">{{
         l('logs.date')
       }}</label>
       <div class="col-sm-8 col-10 col-xl-9">
         <select
-          class="form-control"
+          class="form-select"
           v-model="selectedDate"
           id="date"
           @change="loadMessages"

--- a/chat/ManageChannel.vue
+++ b/chat/ManageChannel.vue
@@ -8,7 +8,7 @@
     @open="onOpen"
   >
     <div
-      class="form-group"
+      class="mb-3"
       v-show="isChannelOwner && channel.id.substr(0, 4) === 'adh-'"
     >
       <label class="control-label" for="isPublic">
@@ -16,17 +16,17 @@
         {{ l('manageChannel.isPublic') }}
       </label>
     </div>
-    <div class="form-group" v-show="isChannelOwner">
+    <div class="mb-3" v-show="isChannelOwner">
       <label class="control-label" for="mode">{{
         l('manageChannel.mode')
       }}</label>
-      <select v-model="mode" class="form-control" id="mode">
+      <select v-model="mode" class="form-select" id="mode">
         <option v-for="mode in modes" :value="mode">
           {{ l('channel.mode.' + mode) }}
         </option>
       </select>
     </div>
-    <div class="form-group">
+    <div class="mb-3">
       <label>{{ l('manageChannel.description') }}</label>
       <bbcode-editor
         classes="form-control"

--- a/chat/QuickJump.vue
+++ b/chat/QuickJump.vue
@@ -438,12 +438,12 @@
           position: relative;
 
           &:hover {
-            background-color: var(--primary);
+            background-color: var(--bs-primary);
             color: var(--textColor);
           }
 
           &.selected {
-            background-color: var(--primary);
+            background-color: var(--bs-primary);
             padding-left: 12px;
             font-weight: 600;
           }
@@ -502,7 +502,7 @@
           &.selected {
             padding-left: 12px;
             font-weight: 600;
-            background-color: var(--primary);
+            background-color: var(--bs-primary);
             opacity: 1;
           }
 

--- a/chat/QuickJump.vue
+++ b/chat/QuickJump.vue
@@ -391,7 +391,8 @@
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 1050;
+    //1 above the bootstrap 5 modal z-index (which used to be 1040)
+    z-index: 1051;
     display: flex;
     align-items: flex-start;
     justify-content: center;

--- a/chat/QuickJump.vue
+++ b/chat/QuickJump.vue
@@ -31,7 +31,7 @@
 
             <span class="result-name"
               >{{ result.name }}
-              <span v-show="hasMentions(result)" class="badge badge-warning"
+              <span v-show="hasMentions(result)" class="badge text-bg-warning"
                 >!</span
               ></span
             >

--- a/chat/ReportDialog.vue
+++ b/chat/ReportDialog.vue
@@ -9,7 +9,7 @@
     <div class="alert alert-danger" v-show="error">{{ error }}</div>
     <div ref="caption"></div>
     <br />
-    <div class="form-group">
+    <div class="mb-3">
       <h6>{{ l('chat.report.conversation') }}</h6>
       <p>{{ conversation }}</p>
       <h6>{{ l('chat.report.reporting') }}</h6>

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -1276,7 +1276,7 @@
     padding: 5px;
     border-radius: 0 5px 5px 5px;
     background: var(--input-bg);
-    border-color: var(--secondary);
+    border-color: var(--bs-secondary);
   }
 
   #settings .bbcode-editor {

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -33,7 +33,7 @@
         </div>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="disallowedTags">{{
           l('settings.disallowedTags')
         }}</label>
@@ -43,7 +43,7 @@
           v-model="disallowedTags"
         />
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="clickOpensMessage">
           <input
             type="checkbox"
@@ -53,31 +53,31 @@
           {{ l('settings.clickOpensMessage') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="enterSend">
           <input type="checkbox" id="enterSend" v-model="enterSend" />
           {{ l('settings.enterSend') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="showAvatars">
           <input type="checkbox" id="showAvatars" v-model="showAvatars" />
           {{ l('settings.showAvatars') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="colorBookmarks">
           <input type="checkbox" id="colorBookmarks" v-model="colorBookmarks" />
           {{ l('settings.colorBookmarks') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="animatedEicons">
           <input type="checkbox" id="animatedEicons" v-model="animatedEicons" />
           {{ l('settings.animatedEicons') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="idleTimer">{{
           l('settings.idleTimer')
         }}</label>
@@ -90,7 +90,7 @@
           max="1440"
         />
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="messageSeparators">
           <input
             type="checkbox"
@@ -100,25 +100,25 @@
           {{ l('settings.messageSeparators') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="bbCodeBar">
           <input type="checkbox" id="bbCodeBar" v-model="bbCodeBar" />
           {{ l('settings.bbCodeBar') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="logMessages">
           <input type="checkbox" id="logMessages" v-model="logMessages" />
           {{ l('settings.logMessages') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="logAds">
           <input type="checkbox" id="logAds" v-model="logAds" />
           {{ l('settings.logAds') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="fontSize">{{
           l('settings.fontSize')
         }}</label>
@@ -133,13 +133,13 @@
       </div>
     </div>
     <div v-show="selectedTab === '1'">
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="playSound">
           <input type="checkbox" id="playSound" v-model="playSound" />
           {{ l('settings.playSound') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="alwaysNotify">
           <input
             type="checkbox"
@@ -150,19 +150,19 @@
           {{ l('settings.alwaysNotify') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="notifications">
           <input type="checkbox" id="notifications" v-model="notifications" />
           {{ l('settings.notifications') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="highlight">
           <input type="checkbox" id="highlight" v-model="highlight" />
           {{ l('settings.highlight') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="highlightWords">{{
           l('settings.highlightWords')
         }}</label>
@@ -172,7 +172,7 @@
           v-model="highlightWords"
         />
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="horizonHighlightUsers">{{
           l('settings.highlightUsers')
         }}</label>
@@ -183,19 +183,19 @@
         />
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="eventMessages">
           <input type="checkbox" id="eventMessages" v-model="eventMessages" />
           {{ l('settings.eventMessages') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="joinMessages">
           <input type="checkbox" id="joinMessages" v-model="joinMessages" />
           {{ l('settings.joinMessages') }}
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="showNeedsReply">
           <input type="checkbox" id="showNeedsReply" v-model="showNeedsReply" />
           {{ l('settings.showNeedsReply') }}
@@ -205,7 +205,7 @@
     <div v-show="selectedTab === '2'">
       <h5>Matching</h5>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingAdScore">
           <input type="checkbox" id="risingAdScore" v-model="risingAdScore" />
           Colorize ads, profiles, and names of compatible and incompatible
@@ -213,7 +213,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingComparisonInUserMenu">
           <input
             type="checkbox"
@@ -224,7 +224,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingComparisonInSearch">
           <input
             type="checkbox"
@@ -235,7 +235,7 @@
         </label>
       </div>
 
-      <!--            <div class="form-group">-->
+      <!--            <div class="mb-3">-->
       <!--                <label class="control-label" for="hideProfileComparisonSummary">-->
       <!--                    <input type="checkbox" id="hideProfileComparisonSummary" :checked="!hideProfileComparisonSummary" @input="hideProfileComparisonSummary = !$event.target.checked"/>-->
       <!--                    Show quick match results at the top of the character profile-->
@@ -244,7 +244,7 @@
 
       <h5>Preview</h5>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingLinkPreview">
           <input
             type="checkbox"
@@ -255,7 +255,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingCharacterPreview">
           <input
             type="checkbox"
@@ -268,7 +268,7 @@
 
       <h5>Profile</h5>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingAutoCompareKinks">
           <input
             type="checkbox"
@@ -279,7 +279,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingAutoExpandCustomKinks">
           <input
             type="checkbox"
@@ -292,7 +292,7 @@
 
       <h5>Draft Messages</h5>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="horizonCacheDraftMessages">
           <input
             type="checkbox"
@@ -303,7 +303,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="horizonSaveDraftMessagesToDiskTimer">
           {{ l('settings.horizonSaveDraftMessagesToDiskTimer') }}
         </label>
@@ -319,7 +319,7 @@
 
       <h5>Misc</h5>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingShowUnreadOfflineCount">
           <input
             type="checkbox"
@@ -329,7 +329,7 @@
           Show unread note and offline message counts at the bottom right corner
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="horizonNotifyFriendSignIn">
           <input
             type="checkbox"
@@ -339,7 +339,7 @@
           Notify when friends or bookmarks sign in.
         </label>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingColorblindMode">
           <input
             type="checkbox"
@@ -350,7 +350,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingShowPortraitNearInput">
           <input
             type="checkbox"
@@ -361,7 +361,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingShowPortraitInMessage">
           <input
             type="checkbox"
@@ -372,7 +372,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingShowHighQualityPortraits">
           <input
             type="checkbox"
@@ -383,7 +383,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="horizonShowCustomCharacterColors">
           <input
             type="checkbox"
@@ -394,7 +394,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="horizonShowGenderMarker">
           <input
             type="checkbox"
@@ -405,7 +405,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="horizonGenderMarkerOrigColor">
           <input
             type="checkbox"
@@ -420,7 +420,7 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="horizonChangeOfflineColor">
           <input
             type="checkbox"
@@ -431,12 +431,12 @@
         </label>
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingCharacterTheme">
           Override UI theme (for this character only)
           <select
             id="risingCharacterTheme"
-            class="form-control"
+            class="form-select"
             v-model="risingCharacterTheme"
             style="flex: 1; margin-right: 10px"
           >
@@ -467,7 +467,7 @@
 
       <h5>Visibility</h5>
 
-      <div class="form-group filters">
+      <div class="mb-3 filters">
         <label class="control-label" for="risingFilter.hideAds">
           <input
             type="checkbox"
@@ -538,7 +538,7 @@
         </label>
       </div>
 
-      <div class="form-group filters">
+      <div class="mb-3 filters">
         <label class="control-label" for="risingFilter.penalizeMatches">
           <input
             type="checkbox"
@@ -559,9 +559,9 @@
       </div>
 
       <h5>Character Age Match</h5>
-      <div class="form-group">Leave empty for no limit.</div>
+      <div class="mb-3">Leave empty for no limit.</div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="risingFilter.minAge"
           >Characters younger than (years)</label
         >
@@ -586,7 +586,7 @@
       </div>
 
       <h5>Type Match</h5>
-      <div class="form-group filters">
+      <div class="mb-3 filters">
         <label
           class="control-label"
           :for="'risingFilter.smartFilters.' + key"
@@ -603,7 +603,7 @@
       </div>
 
       <h5>Automatic Replies</h5>
-      <div class="form-group filters">
+      <div class="mb-3 filters">
         <label class="control-label" for="risingFilter.autoReply">
           <input
             type="checkbox"
@@ -635,7 +635,7 @@
         >
         </editor>
 
-        <div class="form-group">
+        <div class="mb-3">
           You will still see messages unless you have the "Hide private channel
           messages" option above selected. Even then, if they send a second
           message it will bypass the restriction and show you their message.
@@ -644,13 +644,13 @@
       </div>
 
       <h5>Exception List</h5>
-      <div class="form-group">
+      <div class="mb-3">
         Filters and automatic replies are not applied to these character names.
         Separate names with a linefeed. Friends and bookmarked characters bypass
         filtering automatically.
       </div>
 
-      <div class="form-group">
+      <div class="mb-3">
         <textarea
           class="form-control"
           :value="getExceptionList()"
@@ -677,7 +677,7 @@
       <div style="display: flex; padding-top: 10px">
         <select
           id="import"
-          class="form-control"
+          class="form-select"
           v-model="importCharacter"
           style="flex: 1; margin-right: 10px"
         >

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -1063,11 +1063,11 @@
     }
   }
   #settings .warning {
-    border: 1px solid var(--warning);
+    border: 1px solid var(--bs-warning);
   }
 
   #settings .info {
-    border: 1px solid var(--info);
+    border: 1px solid var(--bs-info);
   }
 
   #settings .bbcode-preview {

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -44,38 +44,69 @@
         />
       </div>
       <div class="mb-3">
-        <label class="control-label" for="clickOpensMessage">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="clickOpensMessage"
             v-model="clickOpensMessage"
           />
-          {{ l('settings.clickOpensMessage') }}
-        </label>
+          <label class="form-check-label" for="clickOpensMessage">
+            {{ l('settings.clickOpensMessage') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="enterSend">
-          <input type="checkbox" id="enterSend" v-model="enterSend" />
-          {{ l('settings.enterSend') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="enterSend"
+            v-model="enterSend"
+          />
+          <label class="form-check-label" for="enterSend">
+            {{ l('settings.enterSend') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="showAvatars">
-          <input type="checkbox" id="showAvatars" v-model="showAvatars" />
-          {{ l('settings.showAvatars') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="showAvatars"
+            v-model="showAvatars"
+          />
+          <label class="form-check-label" for="showAvatars">
+            {{ l('settings.showAvatars') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="colorBookmarks">
-          <input type="checkbox" id="colorBookmarks" v-model="colorBookmarks" />
-          {{ l('settings.colorBookmarks') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="colorBookmarks"
+            v-model="colorBookmarks"
+          />
+          <label class="form-check-label" for="colorBookmarks">
+            {{ l('settings.colorBookmarks') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="animatedEicons">
-          <input type="checkbox" id="animatedEicons" v-model="animatedEicons" />
-          {{ l('settings.animatedEicons') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="animatedEicons"
+            v-model="animatedEicons"
+          />
+          <label class="form-check-label" for="animatedEicons">
+            {{ l('settings.animatedEicons') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
         <label class="control-label" for="idleTimer">{{
@@ -91,32 +122,56 @@
         />
       </div>
       <div class="mb-3">
-        <label class="control-label" for="messageSeparators">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="messageSeparators"
             v-model="messageSeparators"
           />
-          {{ l('settings.messageSeparators') }}
-        </label>
+          <label class="form-check-label" for="messageSeparators">
+            {{ l('settings.messageSeparators') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="bbCodeBar">
-          <input type="checkbox" id="bbCodeBar" v-model="bbCodeBar" />
-          {{ l('settings.bbCodeBar') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="bbCodeBar"
+            v-model="bbCodeBar"
+          />
+          <label class="form-check-label" for="bbCodeBar">
+            {{ l('settings.bbCodeBar') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="logMessages">
-          <input type="checkbox" id="logMessages" v-model="logMessages" />
-          {{ l('settings.logMessages') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="logMessages"
+            v-model="logMessages"
+          />
+          <label class="form-check-label" for="logMessages">
+            {{ l('settings.logMessages') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="logAds">
-          <input type="checkbox" id="logAds" v-model="logAds" />
-          {{ l('settings.logAds') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="logAds"
+            v-model="logAds"
+          />
+          <label class="form-check-label" for="logAds">
+            {{ l('settings.logAds') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
         <label class="control-label" for="fontSize">{{
@@ -134,33 +189,57 @@
     </div>
     <div v-show="selectedTab === '1'">
       <div class="mb-3">
-        <label class="control-label" for="playSound">
-          <input type="checkbox" id="playSound" v-model="playSound" />
-          {{ l('settings.playSound') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="playSound"
+            v-model="playSound"
+          />
+          <label class="form-check-label" for="playSound">
+            {{ l('settings.playSound') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="alwaysNotify">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="alwaysNotify"
             v-model="alwaysNotify"
             :disabled="!playSound"
           />
-          {{ l('settings.alwaysNotify') }}
-        </label>
+          <label class="form-check-label" for="alwaysNotify">
+            {{ l('settings.alwaysNotify') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="notifications">
-          <input type="checkbox" id="notifications" v-model="notifications" />
-          {{ l('settings.notifications') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="notifications"
+            v-model="notifications"
+          />
+          <label class="form-check-label" for="notifications">
+            {{ l('settings.notifications') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="highlight">
-          <input type="checkbox" id="highlight" v-model="highlight" />
-          {{ l('settings.highlight') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="highlight"
+            v-model="highlight"
+          />
+          <label class="form-check-label" for="highlight">
+            {{ l('settings.highlight') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
         <label class="control-label" for="highlightWords">{{
@@ -184,55 +263,89 @@
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="eventMessages">
-          <input type="checkbox" id="eventMessages" v-model="eventMessages" />
-          {{ l('settings.eventMessages') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="eventMessages"
+            v-model="eventMessages"
+          />
+          <label class="form-check-label" for="eventMessages">
+            {{ l('settings.eventMessages') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="joinMessages">
-          <input type="checkbox" id="joinMessages" v-model="joinMessages" />
-          {{ l('settings.joinMessages') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="joinMessages"
+            v-model="joinMessages"
+          />
+          <label class="form-check-label" for="joinMessages">
+            {{ l('settings.joinMessages') }}
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="showNeedsReply">
-          <input type="checkbox" id="showNeedsReply" v-model="showNeedsReply" />
-          {{ l('settings.showNeedsReply') }}
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="showNeedsReply"
+            v-model="showNeedsReply"
+          />
+          <label class="form-check-label" for="showNeedsReply">
+            {{ l('settings.showNeedsReply') }}
+          </label>
+        </div>
       </div>
     </div>
     <div v-show="selectedTab === '2'">
       <h5>Matching</h5>
 
       <div class="mb-3">
-        <label class="control-label" for="risingAdScore">
-          <input type="checkbox" id="risingAdScore" v-model="risingAdScore" />
-          Colorize ads, profiles, and names of compatible and incompatible
-          characters
-        </label>
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="risingAdScore"
+            v-model="risingAdScore"
+          />
+          <label class="form-check-label" for="risingAdScore">
+            Colorize ads, profiles, and names of compatible and incompatible
+            characters
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="risingComparisonInUserMenu">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingComparisonInUserMenu"
             v-model="risingComparisonInUserMenu"
           />
-          Show quick match results in the right click character menu
-        </label>
+          <label class="form-check-label" for="risingComparisonInUserMenu">
+            Show quick match results in the right click character menu
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="risingComparisonInSearch">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingComparisonInSearch"
             v-model="risingComparisonInSearch"
           />
-          Show quick match results in the search results
-        </label>
+          <label class="form-check-label" for="risingComparisonInSearch">
+            Show quick match results in the search results
+          </label>
+        </div>
       </div>
 
       <!--            <div class="mb-3">-->
@@ -245,62 +358,77 @@
       <h5>Preview</h5>
 
       <div class="mb-3">
-        <label class="control-label" for="risingLinkPreview">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingLinkPreview"
             v-model="risingLinkPreview"
           />
-          Show a link/image preview when the mouse hovers over a link
-        </label>
+          <label class="form-check-label" for="risingLinkPreview">
+            Show a link/image preview when the mouse hovers over a link
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="risingCharacterPreview">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingCharacterPreview"
             v-model="risingCharacterPreview"
           />
-          Show a character preview when the mouse hovers over a character name
-        </label>
+          <label class="form-check-label" for="risingCharacterPreview">
+            Show a character preview when the mouse hovers over a character name
+          </label>
+        </div>
       </div>
 
       <h5>Profile</h5>
 
       <div class="mb-3">
-        <label class="control-label" for="risingAutoCompareKinks">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingAutoCompareKinks"
             v-model="risingAutoCompareKinks"
           />
-          Automatically compare kinks when viewing a character profile
-        </label>
+          <label class="form-check-label" for="risingAutoCompareKinks">
+            Automatically compare kinks when viewing a character profile
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="risingAutoExpandCustomKinks">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingAutoExpandCustomKinks"
             v-model="risingAutoExpandCustomKinks"
           />
-          Automatically expand custom kinks
-        </label>
+          <label class="form-check-label" for="risingAutoExpandCustomKinks">
+            Automatically expand custom kinks
+          </label>
+        </div>
       </div>
 
       <h5>Draft Messages</h5>
 
       <div class="mb-3">
-        <label class="control-label" for="horizonCacheDraftMessages">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="horizonCacheDraftMessages"
             v-model="horizonCacheDraftMessages"
           />
-          {{ l('settings.horizonCacheDraftMessages') }}
-        </label>
+          <label class="form-check-label" for="horizonCacheDraftMessages">
+            {{ l('settings.horizonCacheDraftMessages') }}
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
@@ -320,94 +448,123 @@
       <h5>Misc</h5>
 
       <div class="mb-3">
-        <label class="control-label" for="risingShowUnreadOfflineCount">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingShowUnreadOfflineCount"
             v-model="risingShowUnreadOfflineCount"
           />
-          Show unread note and offline message counts at the bottom right corner
-        </label>
+          <label class="form-check-label" for="risingShowUnreadOfflineCount">
+            Show unread note and offline message counts at the bottom right
+            corner
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="horizonNotifyFriendSignIn">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="horizonNotifyFriendSignIn"
             v-model="horizonNotifyFriendSignIn"
           />
-          Notify when friends or bookmarks sign in.
-        </label>
+          <label class="form-check-label" for="horizonNotifyFriendSignIn">
+            Notify when friends or bookmarks sign in.
+          </label>
+        </div>
       </div>
       <div class="mb-3">
-        <label class="control-label" for="risingColorblindMode">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingColorblindMode"
             v-model="risingColorblindMode"
           />
-          Colorblind mode
-        </label>
+          <label class="form-check-label" for="risingColorblindMode">
+            Colorblind mode
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="risingShowPortraitNearInput">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingShowPortraitNearInput"
             v-model="risingShowPortraitNearInput"
           />
-          Show character portrait by text input
-        </label>
+          <label class="form-check-label" for="risingShowPortraitNearInput">
+            Show character portrait by text input
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="risingShowPortraitInMessage">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingShowPortraitInMessage"
             v-model="risingShowPortraitInMessage"
           />
-          Show character portrait with each message
-        </label>
+          <label class="form-check-label" for="risingShowPortraitInMessage">
+            Show character portrait with each message
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="risingShowHighQualityPortraits">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingShowHighQualityPortraits"
             v-model="risingShowHighQualityPortraits"
           />
-          Show high-quality portraits
-        </label>
+          <label class="form-check-label" for="risingShowHighQualityPortraits">
+            Show high-quality portraits
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="horizonShowCustomCharacterColors">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="horizonShowCustomCharacterColors"
             v-model="horizonShowCustomCharacterColors"
           />
-          Show custom character name colors
-        </label>
+          <label
+            class="form-check-label"
+            for="horizonShowCustomCharacterColors"
+          >
+            Show custom character name colors
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="horizonShowGenderMarker">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="horizonShowGenderMarker"
             v-model="horizonShowGenderMarker"
           />
-          Show a gender icon on everyone
-        </label>
+          <label class="form-check-label" for="horizonShowGenderMarker">
+            Show a gender icon on everyone
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="horizonGenderMarkerOrigColor">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="horizonGenderMarkerOrigColor"
             v-model="horizonGenderMarkerOrigColor"
@@ -415,20 +572,25 @@
               !horizonShowGenderMarker || !horizonShowCustomCharacterColors
             "
           />
-          Make gender icon use the original gender color instead of the custom
-          name color
-        </label>
+          <label class="form-check-label" for="horizonGenderMarkerOrigColor">
+            Make gender icon use the original gender color instead of the custom
+            name color
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
-        <label class="control-label" for="horizonChangeOfflineColor">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="horizonChangeOfflineColor"
             v-model="horizonChangeOfflineColor"
           />
-          Make color in chat change to grey when a user goes offline
-        </label>
+          <label class="form-check-label" for="horizonChangeOfflineColor">
+            Make color in chat change to grey when a user goes offline
+          </label>
+        </div>
       </div>
 
       <div class="mb-3">
@@ -468,94 +630,124 @@
       <h5>Visibility</h5>
 
       <div class="mb-3 filters">
-        <label class="control-label" for="risingFilter.hideAds">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.hideAds"
             v-model="risingFilter.hideAds"
           />
-          Hide <b>ads</b> from matching characters
-        </label>
+          <label class="form-check-label" for="risingFilter.hideAds">
+            Hide <b>ads</b> from matching characters
+          </label>
+        </div>
 
-        <label class="control-label" for="risingFilter.hideSearchResults">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.hideSearchResults"
             v-model="risingFilter.hideSearchResults"
           />
-          Hide matching characters from <b>search results</b>
-        </label>
+          <label class="form-check-label" for="risingFilter.hideSearchResults">
+            Hide matching characters from <b>search results</b>
+          </label>
+        </div>
 
-        <label class="control-label" for="risingFilter.hideChannelMembers">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.hideChannelMembers"
             v-model="risingFilter.hideChannelMembers"
           />
-          Hide matching characters from <b>channel members lists</b>
-        </label>
+          <label class="form-check-label" for="risingFilter.hideChannelMembers">
+            Hide matching characters from <b>channel members lists</b>
+          </label>
+        </div>
 
-        <label
-          class="control-label"
-          for="risingFilter.hidePublicChannelMessages"
-        >
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.hidePublicChannelMessages"
             v-model="risingFilter.hidePublicChannelMessages"
           />
-          Hide <b>public channel messages</b> from matching characters
-        </label>
+          <label
+            class="form-check-label"
+            for="risingFilter.hidePublicChannelMessages"
+          >
+            Hide <b>public channel messages</b> from matching characters
+          </label>
+        </div>
 
-        <label
-          class="control-label"
-          for="risingFilter.hidePrivateChannelMessages"
-        >
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.hidePrivateChannelMessages"
             v-model="risingFilter.hidePrivateChannelMessages"
           />
-          Hide <b>private channel messages</b> from matching characters
-        </label>
+          <label
+            class="form-check-label"
+            for="risingFilter.hidePrivateChannelMessages"
+          >
+            Hide <b>private channel messages</b> from matching characters
+          </label>
+        </div>
 
-        <label class="control-label" for="risingFilter.hidePrivateMessages">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.hidePrivateMessages"
             v-model="risingFilter.hidePrivateMessages"
           />
-          Hide <b>private messages</b> (PMs) from matching characters
-        </label>
+          <label
+            class="form-check-label"
+            for="risingFilter.hidePrivateMessages"
+          >
+            Hide <b>private messages</b> (PMs) from matching characters
+          </label>
+        </div>
 
-        <label class="control-label" for="risingFilter.showFilterIcon">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.showFilterIcon"
             v-model="risingFilter.showFilterIcon"
           />
-          Show <b>filter icon</b> on matching characters
-        </label>
+          <label class="form-check-label" for="risingFilter.showFilterIcon">
+            Show <b>filter icon</b> on matching characters
+          </label>
+        </div>
       </div>
 
       <div class="mb-3 filters">
-        <label class="control-label" for="risingFilter.penalizeMatches">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.penalizeMatches"
             v-model="risingFilter.penalizeMatches"
           />
-          Penalize <b>match scores</b> for matching characters
-        </label>
+          <label class="form-check-label" for="risingFilter.penalizeMatches">
+            Penalize <b>match scores</b> for matching characters
+          </label>
+        </div>
 
-        <label class="control-label" for="risingFilter.rewardNonMatches">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.rewardNonMatches"
             v-model="risingFilter.rewardNonMatches"
           />
-          Increase <b>match scores</b> for non-matching characters
-        </label>
+          <label class="form-check-label" for="risingFilter.rewardNonMatches">
+            Increase <b>match scores</b> for non-matching characters
+          </label>
+        </div>
       </div>
 
       <h5>Character Age Match</h5>
@@ -587,42 +779,50 @@
 
       <h5>Type Match</h5>
       <div class="mb-3 filters">
-        <label
-          class="control-label"
-          :for="'risingFilter.smartFilters.' + key"
-          v-for="(value, key) in smartFilterTypes"
-        >
+        <div class="form-check" v-for="(value, key) in smartFilterTypes">
           <input
+            class="form-check-input"
             type="checkbox"
             :id="'risingFilter.smartFilters.' + key"
             v-bind:checked="getSmartFilter(key)"
             @change="v => setSmartFilter(key, v)"
           />
-          {{ value.name }}
-        </label>
+          <label
+            class="form-check-label"
+            :for="'risingFilter.smartFilters.' + key"
+          >
+            {{ value.name }}
+          </label>
+        </div>
       </div>
 
       <h5>Automatic Replies</h5>
       <div class="mb-3 filters">
-        <label class="control-label" for="risingFilter.autoReply">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.autoReply"
             v-model="risingFilter.autoReply"
           />
-          Send an automatic 'no thank you' response to matching characters if
-          they message you
-        </label>
+          <label class="form-check-label" for="risingFilter.autoReply">
+            Send an automatic 'no thank you' response to matching characters if
+            they message you
+          </label>
+        </div>
 
-        <label class="control-label" for="risingFilter.autoReplyCustom">
+        <div class="form-check">
           <input
+            class="form-check-input"
             type="checkbox"
             id="risingFilter.autoReplyCustom"
             v-model="risingFilter.autoReplyCustom"
             :disabled="!risingFilter.autoReply"
           />
-          Use a custom message defined below instead of the default message
-        </label>
+          <label class="form-check-label" for="risingFilter.autoReplyCustom">
+            Use a custom message defined below instead of the default message
+          </label>
+        </div>
 
         <editor
           v-model="risingFilter.autoReplyCustomMessage"

--- a/chat/StatusPicker.vue
+++ b/chat/StatusPicker.vue
@@ -10,7 +10,7 @@
   >
     <form class="status-picker" v-if="history.length > 0">
       <div
-        class="form-row"
+        class="row"
         v-for="(historicStatus, index) in history"
         :class="{ 'selected-row': index === selectedStatus }"
       >
@@ -33,7 +33,7 @@
               class="fas"
               :class="{ 'fa-check-circle': index === selectedStatus }"
           /></span>
-          <label class="custom-control-label" :for="'history_status_' + index">
+          <label class="form-check-label" :for="'history_status_' + index">
             <bbcode :text="historicStatus"></bbcode>
           </label>
           <span class="content-action" @click="removeStatusHistoryEntry(index)"

--- a/chat/StatusSwitcher.vue
+++ b/chat/StatusSwitcher.vue
@@ -6,7 +6,7 @@
     dialogClass="w-100 modal-70 statusEditor"
     :iconClass="getStatusIcon(status)"
   >
-    <div class="form-group" id="statusSelector">
+    <div class="mb-3" id="statusSelector">
       <label class="control-label">{{ l('chat.setStatus.status') }}</label>
       <dropdown linkClass="custom-select">
         <span slot="title"
@@ -24,7 +24,7 @@
         </a>
       </dropdown>
     </div>
-    <div class="form-group">
+    <div class="mb-3">
       <label class="control-label">{{ l('chat.setStatus.message') }}</label>
       <editor id="text" v-model="text" classes="form-control" maxlength="255">
         <div class="bbcode-editor-controls">
@@ -32,7 +32,7 @@
         </div>
       </editor>
     </div>
-    <div class="form-group">
+    <div class="mb-3">
       <button
         type="button"
         @click="showStatusPicker"

--- a/chat/StatusSwitcher.vue
+++ b/chat/StatusSwitcher.vue
@@ -8,7 +8,7 @@
   >
     <div class="mb-3" id="statusSelector">
       <label class="control-label">{{ l('chat.setStatus.status') }}</label>
-      <dropdown linkClass="custom-select">
+      <dropdown linkClass="form-select">
         <span slot="title"
           ><span class="fa fa-fw" :class="getStatusIcon(status)"></span
           >{{ l('status.' + status) }}</span

--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -79,11 +79,9 @@
         </div>
       </div>
       <div class="input-group" style="margin-top: 5px; flex-shrink: 0">
-        <div class="input-group-prepend">
-          <div class="input-group-text">
-            <span class="fas fa-search"></span>
-          </div>
-        </div>
+        <span class="input-group-text">
+          <span class="fas fa-search"></span>
+        </span>
         <input
           class="form-control"
           v-model="filter"

--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -343,7 +343,7 @@
 
     .profile {
       .profile-button {
-        border: 1px var(--secondary) solid;
+        border: 1px var(--bs-secondary) solid;
         padding-top: 0.25rem;
         padding-bottom: 0.25rem;
         min-height: 2rem;

--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -378,7 +378,7 @@
       }
 
       .row.character-page {
-        display: block;
+        display: flex;
         margin-right: 0;
         margin-left: 0;
 

--- a/chat/ads/AdCenter.vue
+++ b/chat/ads/AdCenter.vue
@@ -155,7 +155,7 @@
       padding: 5px;
       border-radius: 0 5px 5px 5px;
       background: var(--input-bg);
-      border-color: var(--secondary);
+      border-color: var(--bs-secondary);
     }
 
     .bbcode-editor {

--- a/chat/ads/AdCenter.vue
+++ b/chat/ads/AdCenter.vue
@@ -8,7 +8,7 @@
     :buttonText="'Save'"
     iconClass="fas fa-file-pen"
   >
-    <div class="form-group ad-list" v-for="(ad, index) in ads">
+    <div class="mb-3 ad-list" v-for="(ad, index) in ads">
       <label :for="'adm-content-' + index" class="control-label"
         >Ad #{{ index + 1 }}
         <a v-if="index > 0" @click="moveAdUp(index)" title="Move Up"

--- a/chat/ads/AdLauncher.vue
+++ b/chat/ads/AdLauncher.vue
@@ -13,7 +13,7 @@
     <div v-if="hasAds()">
       <h5>Ad Tags</h5>
       <div style="padding-bottom: 1em">
-        <div class="form-group">
+        <div class="mb-3">
           <p>Serve ads that match any one of these tags:</p>
 
           <label
@@ -35,7 +35,7 @@
       </div>
 
       <h5>Target Channels</h5>
-      <div class="form-group">
+      <div class="mb-3">
         <p>Serve ads on these channels:</p>
 
         <p v-if="channels.length === 0">
@@ -67,7 +67,7 @@
       </div>
 
       <h5>Post Order</h5>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="adOrderRandom">
           <input
             type="radio"
@@ -89,11 +89,11 @@
       </div>
 
       <h5>Campaign</h5>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label" for="timeoutMinutes"> Timeout </label>
 
         <select
-          class="form-control"
+          class="form-select"
           v-model="timeoutMinutes"
           id="timeoutMinutes"
         >

--- a/chat/ads/ConversationAdSettings.vue
+++ b/chat/ads/ConversationAdSettings.vue
@@ -192,7 +192,7 @@
       padding: 5px;
       border-radius: 0 5px 5px 5px;
       background: var(--input-bg);
-      border-color: var(--secondary);
+      border-color: var(--bs-secondary);
     }
 
     .bbcode-editor {

--- a/chat/ads/ConversationAdSettings.vue
+++ b/chat/ads/ConversationAdSettings.vue
@@ -31,14 +31,14 @@
       </p>
     </div>
 
-    <div class="form-group">
+    <div class="mb-3">
       <label class="control-label" for="randomOrder">
         <input type="checkbox" v-model="randomOrder" id="randomOrder" />
         Serve ads in random order
       </label>
     </div>
 
-    <div class="form-group ad-list" v-for="(ad, index) in ads">
+    <div class="mb-3 ad-list" v-for="(ad, index) in ads">
       <label :for="'ad' + conversation.key + '-' + index" class="control-label"
         >Ad #{{ index + 1 }}
         <a v-if="index > 0" @click="moveAdUp(index)" title="Move Up"

--- a/chat/preview/CharacterPreview.vue
+++ b/chat/preview/CharacterPreview.vue
@@ -506,7 +506,7 @@
     overflow: hidden;
     opacity: 0.95;
     border-radius: 0 5px 5px 5px;
-    border: 1px solid var(--secondary);
+    border: 1px solid var(--bs-secondary);
 
     .unicorn {
       margin-left: 8px;

--- a/components/FilterableSelect.vue
+++ b/components/FilterableSelect.vue
@@ -1,13 +1,10 @@
 <template>
-  <dropdown
-    class="filterable-select"
-    linkClass="custom-select"
-    :keepOpen="true"
-  >
+  <dropdown class="filterable-select" linkClass="form-select" :keepOpen="true">
     <template slot="title" v-if="multiple">{{ label }}</template>
     <slot v-else slot="title" :option="selected">{{ label }}</slot>
 
-    <div style="padding: 10px">
+    <div class="p-2">
+      <!-- changed from style="padding: 10px" to utility class -->
       <input
         v-model="filter"
         class="form-control"
@@ -15,15 +12,20 @@
         @mousedown.stop
       />
     </div>
-    <div class="hidden-scrollbar dropdown-items">
+    <div class="overflow-auto dropdown-items">
+      <!-- added overflow-auto class -->
       <template v-if="multiple">
         <a
           href="#"
           @click.stop="select(option)"
           v-for="option in filtered"
-          class="dropdown-item"
+          class="dropdown-item d-flex align-items-center"
         >
-          <input type="checkbox" :checked="isSelected(option)" />
+          <input
+            type="checkbox"
+            class="form-check-input me-2"
+            :checked="isSelected(option)"
+          />
           <slot :option="option">{{ option }}</slot>
         </a>
       </template>
@@ -115,17 +117,11 @@
   .filterable-select {
     .dropdown-items {
       max-height: 200px;
-      overflow-y: auto;
     }
 
     button {
       display: flex;
-      text-align: left;
-    }
-
-    input[type='checkbox'] {
-      vertical-align: text-bottom;
-      margin-right: 5px;
+      text-align: start; /* changed from left to start */
     }
   }
 </style>

--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -21,15 +21,15 @@
               <i v-if="iconClass" :class="iconClass" class="fa-fw"></i>
               <slot name="title">{{ action }}</slot>
             </h5>
-            <button
+            <a
               type="button"
-              class="btn-close"
+              class="btn-close btn"
               @click="hide"
               aria-label="Close"
               v-show="!keepOpen"
             >
-              &times;
-            </button>
+              <i class="fa fa-times fa-lg"></i>
+            </a>
           </div>
           <div
             class="modal-body hidden-scrollbar"

--- a/components/Modal.vue
+++ b/components/Modal.vue
@@ -23,7 +23,7 @@
             </h5>
             <button
               type="button"
-              class="close"
+              class="btn-close"
               @click="hide"
               aria-label="Close"
               v-show="!keepOpen"

--- a/components/character_select.vue
+++ b/components/character_select.vue
@@ -1,5 +1,5 @@
 <template>
-  <select :value="value" @change="emit">
+  <select :value="value" @change="emit" class="form-select">
     <option v-for="character in characters" :value="character.id">
       {{ character.name }}
     </option>

--- a/components/form_group.vue
+++ b/components/form_group.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="form-group">
+  <div class="mb-3">
     <label v-if="label && id" :for="id">{{ label }}</label>
     <slot
       :cls="{ 'is-invalid': hasErrors, 'is-valid': valid }"

--- a/components/form_group_inputgroup.vue
+++ b/components/form_group_inputgroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="form-group">
+  <div class="mb-3">
     <label v-if="label && id" :for="id">{{ label }}</label>
     <div class="input-group">
       <slot :cls="{ 'is-invalid': hasErrors, 'is-valid': valid }"></slot>

--- a/electron/Changelog.vue
+++ b/electron/Changelog.vue
@@ -20,7 +20,7 @@
             </h4>
             <button
               type="button"
-              class="close"
+              class="btn-close"
               aria-label="Close"
               v-if="!isMac"
               @click.stop="close()"

--- a/electron/Changelog.vue
+++ b/electron/Changelog.vue
@@ -262,21 +262,21 @@
   }
 
   .markdown-alert-important {
-    border-color: var(--primary);
+    border-color: var(--bs-primary);
   }
 
   .markdown-alert-note {
-    border-color: var(--secondary);
+    border-color: var(--bs-secondary);
   }
 
   .markdown-alert-tip {
-    border-color: var(--info);
+    border-color: var(--bs-info);
   }
   .markdown-alert-caution {
-    border-color: var(--danger);
+    border-color: var(--bs-danger);
   }
   .markdown-alert-warning {
-    border-color: var(--warning);
+    border-color: var(--bs-warning);
   } /*This override exists because we allow the user to resize the window, which potentially resizes the footer otherwise*/
   .modal-body .modal-footer {
     height: 52px;

--- a/electron/Index.vue
+++ b/electron/Index.vue
@@ -193,14 +193,14 @@
             @click="prevProfile"
             :disabled="!prevProfileAvailable()"
           >
-            <i class="fas fa-arrow-left"></i>
+            <i class="fas fa-arrow-left fa-lg"></i>
           </button>
           <button
             class="btn"
             @click="nextProfile"
             :disabled="!nextProfileAvailable()"
           >
-            <i class="fas fa-arrow-right"></i>
+            <i class="fas fa-arrow-right fa-lg"></i>
           </button>
         </div>
       </template>
@@ -911,9 +911,12 @@
 
       .profile-title-right {
         float: right;
-        top: -7px;
+        top: 0px;
         right: 0;
         position: absolute;
+        .btn {
+          border: none;
+        }
       }
 
       .status-text {

--- a/electron/Index.vue
+++ b/electron/Index.vue
@@ -55,7 +55,7 @@
           <div class="alert alert-danger" v-show="error">
             {{ error }}
           </div>
-          <div class="form-group">
+          <div class="mb-3">
             <label class="control-label" for="account">{{
               l('login.account')
             }}</label>
@@ -67,7 +67,7 @@
               :disabled="loggingIn"
             />
           </div>
-          <div class="form-group">
+          <div class="mb-3">
             <label class="control-label" for="password">{{
               l('login.password')
             }}</label>
@@ -80,7 +80,7 @@
               :disabled="loggingIn"
             />
           </div>
-          <div class="form-group" v-show="showAdvanced">
+          <div class="mb-3" v-show="showAdvanced">
             <label class="control-label" for="host">{{
               l('login.host')
             }}</label>
@@ -116,19 +116,19 @@
               </div>
             </div>
           </div>
-          <div class="form-group">
+          <div class="mb-3">
             <label for="advanced"
               ><input type="checkbox" id="advanced" v-model="showAdvanced" />
               {{ l('login.advanced') }}</label
             >
           </div>
-          <div class="form-group">
+          <div class="mb-3">
             <label for="save"
               ><input type="checkbox" id="save" v-model="saveLogin" />
               {{ l('login.save') }}</label
             >
           </div>
-          <div class="form-group" style="margin: 0; text-align: right">
+          <div class="mb-3" style="margin: 0; text-align: right">
             <button
               class="btn btn-primary"
               @click="login"
@@ -213,9 +213,9 @@
       iconClass="fas fa-file-half-dashed"
     >
       <span style="white-space: pre-wrap">{{ l('fixLogs.text') }}</span>
-      <div class="form-group">
+      <div class="mb-3">
         <label class="control-label">{{ l('fixLogs.character') }}</label>
-        <select id="import" class="form-control" v-model="fixCharacter">
+        <select id="import" class="form-select" v-model="fixCharacter">
           <option v-for="character in fixCharacters" :value="character">
             {{ character }}
           </option>

--- a/electron/Settings.vue
+++ b/electron/Settings.vue
@@ -209,15 +209,12 @@
                         @click="browseForLogDir()"
                         v-model="settings.logDirectory"
                       />
-
-                      <div class="input-group-append">
-                        <button
-                          class="btn btn-outline-secondary"
-                          @click="browseForLogDir()"
-                        >
-                          <span class="far fa-fw fa-folder-open"></span>
-                        </button>
-                      </div></div
+                      <button
+                        class="btn btn-outline-secondary"
+                        @click="browseForLogDir()"
+                      >
+                        <span class="far fa-fw fa-folder-open"></span>
+                      </button></div
                   ></label>
                 </div>
                 <h5>{{ l('settings.behavior.window') }}</h5>
@@ -331,23 +328,18 @@
                       id="browserPath"
                       v-model="settings.browserPath"
                     />
-
-                    <div class="input-group-append">
-                      <button
-                        class="btn btn-outline-secondary"
-                        @click.prevent.stop="browseForPath()"
-                      >
-                        <span class="far fa-fw fa-folder-open"></span>
-                      </button>
-                      <button
-                        class="btn btn-outline-danger"
-                        @click.prevent.stop="browserReset()"
-                      >
-                        <span
-                          class="fa-solid fa-fw fa-arrow-rotate-right"
-                        ></span>
-                      </button>
-                    </div></div
+                    <button
+                      class="btn btn-outline-secondary"
+                      @click.prevent.stop="browseForPath()"
+                    >
+                      <span class="far fa-fw fa-folder-open"></span>
+                    </button>
+                    <button
+                      class="btn btn-outline-danger"
+                      @click.prevent.stop="browserReset()"
+                    >
+                      <span class="fa-solid fa-fw fa-arrow-rotate-right"></span>
+                    </button></div
                 ></label>
 
                 <label class="control-label label-full" for="browserArgs">

--- a/electron/Settings.vue
+++ b/electron/Settings.vue
@@ -17,7 +17,7 @@
             </h5>
             <button
               type="button"
-              class="close"
+              class="btn-close"
               aria-label="Close"
               v-if="!isMac"
               @click.stop="close()"
@@ -50,7 +50,7 @@
                 <h5>
                   {{ l('settings.updates') }}
                 </h5>
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label" for="updatecheck">
                     <input
                       type="checkbox"
@@ -60,7 +60,7 @@
                     {{ l('settings.updateCheck') }}
                   </label>
                 </div>
-                <div class="form-group" v-if="settings.updateCheck">
+                <div class="mb-3" v-if="settings.updateCheck">
                   <label class="control-label" for="beta">
                     <input type="checkbox" id="beta" v-model="settings.beta" />
                     {{ l('settings.beta') }}
@@ -76,19 +76,19 @@
                 <h5>
                   {{ l('settings.theme') }}
                 </h5>
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label" for="beta">
                     <input type="checkbox" disabled id="themeSystemSync" />
                     {{ l('settings.theme.sync') }}
                   </label>
                 </div>
 
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label" for="theme" style="width: 20ch">
                     {{ l('settings.theme') }}
                     <!--<select
                       id="theme"
-                      class="custom-select"
+                      class="form-select"
                       v-model="settings.theme"
                       style="flex: 1; margin-right: 10px"
                     >
@@ -109,7 +109,7 @@
                   </label>
                 </div>
 
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label" for="themeVanillaBbcode">
                     <input
                       v-model="settings.horizonVanillaTextColors"
@@ -126,7 +126,7 @@
                   {{ l('settings.spellcheck.language') }}
                 </h5>
                 <!--On MacOS, Electron uses the OS' native spell checker as of version 35.2.0 -->
-                <div class="form-group" v-if="!isMac">
+                <div class="mb-3" v-if="!isMac">
                   <label
                     class="control-label"
                     for="spellCheckLang"
@@ -152,12 +152,12 @@
                   </label>
                 </div>
 
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label" for="displayLanguage">
                     {{ l('settings.displayLanguage') }}
                     <select
                       id="displayLanguage"
-                      class="custom-select"
+                      class="form-select"
                       style="flex: 1; margin-right: 10px"
                       disabled
                     >
@@ -185,7 +185,7 @@
                 style="height: 100%; width: 100%"
               >
                 <h5>{{ l('user.profile') }}</h5>
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label" for="profileViewer">
                     <input
                       type="checkbox"
@@ -197,7 +197,7 @@
                 </div>
 
                 <h5>{{ l('settings.behavior.chat') }}</h5>
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label label-full" for="logDir">
                     {{ l('settings.logDir') }}
 
@@ -221,7 +221,7 @@
                   ></label>
                 </div>
                 <h5>{{ l('settings.behavior.window') }}</h5>
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label" for="closeToTray">
                     <input
                       type="checkbox"
@@ -238,7 +238,7 @@
                 class="card-body settings-content"
                 style="height: 100%; width: 100%"
               >
-                <div class="form-group" v-if="isWindows">
+                <div class="mb-3" v-if="isWindows">
                   <label
                     class="control-label"
                     for="risingDisableWindowsHighContrast"
@@ -266,7 +266,7 @@
                 <h5>
                   {{ l('settings.system') }}
                 </h5>
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label" for="hwAcceleration">
                     <input
                       type="checkbox"
@@ -276,7 +276,7 @@
                     {{ l('settings.hwAcceleration') }}
                   </label>
                 </div>
-                <div class="form-group">
+                <div class="mb-3">
                   <!--We do this one slightly differently because we 
                 cannot and will not make ElectronLogger.LogType reactive -->
                   <label class="control-label" for="systemLogLevel">
@@ -284,7 +284,7 @@
                     <div class="input-group">
                       <select
                         id="systemLogLevel"
-                        class="form-control custom-select"
+                        class="form-select form-select"
                         style="flex: 1; margin-right: 10px"
                         v-model="settings.risingSystemLogLevel"
                       >
@@ -367,7 +367,7 @@
                   {{ l('settings.customCss') }}
                 </h5>
 
-                <div class="form-group">
+                <div class="mb-3">
                   <label class="control-label" for="customCssEnabled">
                     <input
                       type="checkbox"

--- a/electron/Settings.vue
+++ b/electron/Settings.vue
@@ -15,7 +15,7 @@
               <i class="fa-solid fa-fw fa-gear"></i>
               {{ l('settings.action') }}
             </h5>
-            <button
+            <a
               type="button"
               class="btn-close"
               aria-label="Close"
@@ -24,7 +24,7 @@
               z-
             >
               <span class="fas fa-times"></span>
-            </button>
+            </a>
           </div>
           <div class="modal-body">
             <tabs

--- a/electron/Settings.vue
+++ b/electron/Settings.vue
@@ -710,7 +710,7 @@
   }
 
   .warning {
-    border: 1px solid var(--warning);
+    border: 1px solid var(--bs-warning);
     padding: 10px;
     margin-bottom: 20px;
     border-radius: 3px;

--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -87,15 +87,15 @@
           <i class="fa fa-cog"> </i>
         </span>
 
-        <i
-          class="far fa-window-minimize btn btn-light"
-          @click.stop="minimize()"
-        ></i>
-        <i
-          class="far btn btn-light"
-          :class="'fa-window-' + (isMaximized ? 'restore' : 'maximize')"
-          @click="maximize()"
-        ></i>
+        <span class="btn btn-light" @click.stop="minimize()">
+          <i class="far fa-window-minimize"></i>
+        </span>
+        <span class="btn btn-light" @click="maximize()">
+          <i
+            class="far"
+            :class="'fa-window-' + (isMaximized ? 'restore' : 'maximize')"
+          ></i>
+        </span>
         <span class="btn btn-light" @click.stop="close()">
           <i class="fa fa-times fa-lg"></i>
         </span>

--- a/learn/dictionary/WordDefinition.vue
+++ b/learn/dictionary/WordDefinition.vue
@@ -147,7 +147,7 @@
         small {
           display: block;
           margin-bottom: 1.2em;
-          color: var(--secondary);
+          color: var(--bs-secondary);
         }
       }
     }

--- a/mobile/Index.vue
+++ b/mobile/Index.vue
@@ -8,15 +8,15 @@
                     <div class="alert alert-danger" v-show="error">
                         {{error}}
                     </div>
-                    <div class="form-group">
+                    <div class="mb-3">
                         <label class="control-label" for="account">{{l('login.account')}}</label>
                         <input class="form-control" id="account" v-model="settings.account" @keypress.enter="login()" :disabled="loggingIn"/>
                     </div>
-                    <div class="form-group">
+                    <div class="mb-3">
                         <label class="control-label" for="password">{{l('login.password')}}</label>
                         <input class="form-control" type="password" id="password" v-model="settings.password" @keypress.enter="login()" :disabled="loggingIn"/>
                     </div>
-                    <div class="form-group" v-show="showAdvanced">
+                    <div class="mb-3" v-show="showAdvanced">
                         <label class="control-label" for="host">{{l('login.host')}}</label>
                         <div class="input-group">
                             <input class="form-control" id="host" v-model="settings.host" @keypress.enter="login()" :disabled="loggingIn"/>
@@ -25,21 +25,21 @@
                             </div>
                         </div>
                     </div>
-                    <div class="form-group">
+                    <div class="mb-3">
                         <label class="control-label" for="theme">{{l('settings.theme')}}</label>
-                        <select class="form-control custom-select" id="theme" v-model="settings.theme">
+                        <select class="form-select form-select" id="theme" v-model="settings.theme">
                             <option>default</option>
                             <option>dark</option>
                             <option>light</option>
                         </select>
                     </div>
-                    <div class="form-group">
+                    <div class="mb-3">
                         <label for="advanced"><input type="checkbox" id="advanced" v-model="showAdvanced"/> {{l('login.advanced')}}</label>
                     </div>
-                    <div class="form-group">
+                    <div class="mb-3">
                         <label for="save"><input type="checkbox" id="save" v-model="saveLogin"/> {{l('login.save')}}</label>
                     </div>
-                    <div class="form-group" style="text-align:right">
+                    <div class="mb-3" style="text-align:right">
                         <button class="btn btn-primary" @click="login()" :disabled="loggingIn">
                             {{l(loggingIn ? 'login.working' : 'login.submit')}}
                         </button>

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "async": "^0.9.2",
     "axios": "^0.30.0",
     "bluebird": "~3.7.2",
-    "bootstrap": "^4.6.2",
+    "bootstrap": "^5.3.7",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.2.7",
     "date-fns": "2.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,8 +107,8 @@ importers:
         specifier: ~3.7.2
         version: 3.7.2
       bootstrap:
-        specifier: ^4.6.2
-        version: 4.6.2(jquery@3.7.1)(popper.js@1.16.1)
+        specifier: ^5.3.7
+        version: 5.3.7(@popperjs/core@2.11.8)
       copy-webpack-plugin:
         specifier: ^6.4.1
         version: 6.4.1(bluebird@3.7.2)(webpack@5.99.9)
@@ -282,8 +282,8 @@ packages:
     resolution: {integrity: sha512-8OLQgDScAOHXnAz2cV+RfzzNMipuLVBz2biuAJFMV9bfkNf393je3VM8CLkjQodW5+iWsSJdSgSWT6rsZoXHPw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@7.28.1':
-    resolution: {integrity: sha512-x0LvFTekgSX+83TI28Y9wYPUfzrnl2aT5+5QLnO6v7mSJYtEEevuDRN0F0uSHRk1G1IWZC43o00Y0xDDrpBGPQ==}
+  '@babel/types@7.28.2':
+    resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
     engines: {node: '>=6.9.0'}
 
   '@bufbuild/protobuf@2.5.2':
@@ -554,6 +554,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
 
   '@remusao/guess-url-type@1.3.0':
     resolution: {integrity: sha512-SNSJGxH5ckvxb3EUHj4DqlAm/bxNxNv2kx/AESZva/9VfcBokwKNS+C4D1lQdWIDM1R3d3UG+xmVzlkNG8CPTQ==}
@@ -1082,11 +1085,10 @@ packages:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
-  bootstrap@4.6.2:
-    resolution: {integrity: sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==}
+  bootstrap@5.3.7:
+    resolution: {integrity: sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==}
     peerDependencies:
-      jquery: 1.9.1 - 3
-      popper.js: ^1.16.1
+      '@popperjs/core': ^2.11.8
 
   bplist-creator@0.0.8:
     resolution: {integrity: sha512-Za9JKzD6fjLC16oX2wsXfc+qBEhJBJB1YPInoAQpMLhDuj5aVOv1baGeIQSq1Fr3OCqzvsoQcSBSwGId/Ja2PA==}
@@ -2321,6 +2323,10 @@ packages:
 
   form-data@4.0.3:
     resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
+    engines: {node: '>= 6'}
+
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -3693,10 +3699,6 @@ packages:
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
-
-  popper.js@1.16.1:
-    resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
-    deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5179,7 +5181,7 @@ snapshots:
 
   '@babel/parser@7.28.0':
     dependencies:
-      '@babel/types': 7.28.1
+      '@babel/types': 7.28.2
     optional: true
 
   '@babel/runtime@7.27.6': {}
@@ -5189,7 +5191,7 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
 
-  '@babel/types@7.28.1':
+  '@babel/types@7.28.2':
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
@@ -5553,6 +5555,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@popperjs/core@2.11.8': {}
 
   '@remusao/guess-url-type@1.3.0': {}
 
@@ -6060,7 +6064,7 @@ snapshots:
       ejs: 3.1.10
       electron-builder-squirrel-windows: 25.1.8(bluebird@3.7.2)(dmg-builder@26.0.12)(supports-color@10.0.0)
       electron-publish: 25.1.7(supports-color@10.0.0)
-      form-data: 4.0.3
+      form-data: 4.0.4
       fs-extra: 10.1.0
       hosted-git-info: 4.1.0
       is-ci: 3.0.1
@@ -6334,10 +6338,9 @@ snapshots:
   boolean@3.2.0:
     optional: true
 
-  bootstrap@4.6.2(jquery@3.7.1)(popper.js@1.16.1):
+  bootstrap@5.3.7(@popperjs/core@2.11.8):
     dependencies:
-      jquery: 3.7.1
-      popper.js: 1.16.1
+      '@popperjs/core': 2.11.8
 
   bplist-creator@0.0.8:
     dependencies:
@@ -7848,6 +7851,14 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  form-data@4.0.4:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
+      mime-types: 2.1.35
+
   forwarded@0.2.0: {}
 
   fresh@0.5.2: {}
@@ -9304,8 +9315,6 @@ snapshots:
       '@xmldom/xmldom': 0.8.10
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
-
-  popper.js@1.16.1: {}
 
   possible-typed-array-names@1.1.0: {}
 

--- a/scss/_bbcode_editor.scss
+++ b/scss/_bbcode_editor.scss
@@ -11,7 +11,7 @@
 .bbcode-toolbar {
   align-items: flex-start;
   flex-wrap: nowrap;
-  @media (max-width: breakpoint-max(xs)) {
+  @include media-breakpoint-down(md) {
     background: $text-background-color;
     padding: 10px;
     position: absolute;
@@ -24,8 +24,8 @@
       border-radius: $btn-border-radius !important;
     }
   }
-  @media (min-width: breakpoint-min(sm)) {
-    .close {
+  @include media-breakpoint-up(md) {
+    .btn-close {
       display: none;
     }
     .btn {
@@ -38,7 +38,7 @@
 }
 
 .bbcode-btn {
-  @media (min-width: breakpoint-min(sm)) {
+  @include media-breakpoint-up(md) {
     display: none;
   }
 }
@@ -49,7 +49,7 @@
   float: right;
   order: 1;
   justify-content: flex-end;
-  @media (max-width: breakpoint-max(xs)) {
+  @include media-breakpoint-down(md) {
     flex: 1 49%;
   }
 }

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -466,7 +466,7 @@ $genders: (
 
 .list-group.conversation-nav .list-group-item {
   margin: 1px 0px 1px 0px;
-  border-radius: inherit;
+  border-radius: 4px;
   //@each $color, $value in $theme-colors {
   //&.list-group-item-#{$color} {
   //color: color-yiq($value);

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -363,7 +363,7 @@
 }
 
 .message-highlight {
-  background-color: theme-color-level('success', -8);
+  background-color: color.scale($color: $success, $alpha: -50%);
 }
 
 .message-action .bbcode {

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -446,8 +446,7 @@ $genders: (
   .hasNew {
     background-color: theme-color-level('warning', -2);
     border-color: theme-color-level('warning', -4);
-    //color: color-yiq(theme-color('warning'));
-    color: theme-color-level('warning', 8);
+    color: color-contrast($warning);
     &:hover {
       background-color: theme-color-level('warning', -4);
     }

--- a/scss/_core.scss
+++ b/scss/_core.scss
@@ -3,6 +3,26 @@
 @forward 'abstracts/functions';
 @forward 'abstracts/mixins';
 
+// Define bg-light using theme's light color variable
+.bg-light {
+  background-color: $light !important;
+}
+
+// Form spacing adjustments to match Bootstrap 4 spacing
+.mb-3 {
+  margin-bottom: 1rem !important;
+}
+
+// Remove margin from last form group in card bodies
+.card-body > .mb-3:last-child {
+  margin-bottom: 0 !important;
+}
+
+label {
+  display: inline-block;
+  margin-bottom: 0.5rem;
+}
+
 .flash-messages-fixed {
   top: 0px;
   left: auto;
@@ -34,10 +54,12 @@
 
 .character-menu-item {
   width: 250px;
+
   .character-link {
     display: inline-block;
     padding-right: 0;
   }
+
   .character-edit-link {
     margin-left: auto;
     padding: 3px 20px 2px 0;

--- a/scss/_flist_derived.scss
+++ b/scss/_flist_derived.scss
@@ -14,7 +14,7 @@ $pink-color: #f9c !default;
 $gray-color: $gray-700 !default;
 $orange-color: #f60 !default;
 $collapse-header-bg: $card-bg !default;
-$collapse-border: color.scale($card-border-color, $lightness: -25%) !default;
+$collapse-border: color.scale($border-color, $lightness: -25%) !default;
 $text-dark: $text-muted !default;
 
 // Character page quick kink comparison
@@ -25,11 +25,8 @@ $quick-compare-maybe-bg: theme-color-level('warning', -6) !default;
 $quick-compare-no-bg: theme-color-level('danger', -6) !default;
 
 // character page badges
-$character-badge-bg: color.scale($card-bg, $lightness: -10%) !default;
-$character-badge-border: color.scale(
-  $card-border-color,
-  $lightness: -10%
-) !default;
+$character-badge-bg: color.scale($body-bg, $lightness: -10%) !default;
+$character-badge-border: color.scale($border-color, $lightness: -10%) !default;
 $character-badge-subscriber-bg: theme-color-bg('info') !default;
 $character-badge-subscriber-border: theme-color-border('info') !default;
 

--- a/scss/_flist_overrides.scss
+++ b/scss/_flist_overrides.scss
@@ -3,6 +3,10 @@ hr {
   margin-bottom: 5px;
 }
 
+a {
+  text-decoration: none;
+}
+
 .modal-dialog.modal-wide {
   max-width: 95%;
 }

--- a/scss/_flist_overrides.scss
+++ b/scss/_flist_overrides.scss
@@ -129,6 +129,11 @@ input:checked {
   border-bottom: none;
 }
 
+.card-header {
+  padding: 0.75rem 1.25rem;
+  margin-bottom: 0;
+}
+
 @font-face {
   font-family: 'OpenMoji';
   //The url is checked from the theme file, so we have to use this absolutely bonkers relative path.

--- a/scss/_flist_overrides.scss
+++ b/scss/_flist_overrides.scss
@@ -120,7 +120,7 @@ input:checked {
 
 .nav-tabs .nav-link.active {
   background: none;
-  border-bottom: none;
+  border-bottom: 1px solid transparent;
 }
 
 .nav-tabs li {

--- a/scss/_flist_overrides.scss
+++ b/scss/_flist_overrides.scss
@@ -54,6 +54,12 @@ a {
   padding: 0.5rem 0.75rem 0.5rem 0.75rem;
 }
 
+.modal-header .btn-close {
+  --bs-btn-close-bg: none;
+  font-size: 1em;
+  margin-bottom: 0px;
+}
+
 .card-title {
   font-weight: bold;
 }

--- a/scss/_flist_overrides.scss
+++ b/scss/_flist_overrides.scss
@@ -204,12 +204,3 @@ $font-family-base:
 body {
   font-family: $font-family-base;
 }
-// HACK: Bootstrap offers no way to override these by default, and they are SUPER bright.
-// The level numbers have been changed to make them work for dark themes.
-@if $theme-is-dark {
-  @each $color, $value in $theme-colors {
-    @include table-row-variant($color, theme-color-level($color, 5));
-  }
-}
-
-@include table-row-variant(active, $table-active-bg);

--- a/scss/abstracts/_functions.scss
+++ b/scss/abstracts/_functions.scss
@@ -20,20 +20,6 @@
   @return #{$em-size}em;
 }
 
-// Color contrast function
-@function color-contrast($color, $dark: $dark-color, $light: $light-color) {
-  $color-brightness: (
-      red($color) * 299 + green($color) * 587 + blue($color) * 114
-    ) /
-    1000;
-
-  @if $color-brightness > 128 {
-    @return $dark;
-  } @else {
-    @return $light;
-  }
-}
-
 // Get color from map
 @function color($key) {
   @if map-has-key($colors, $key) {

--- a/scss/package.json
+++ b/scss/package.json
@@ -12,6 +12,6 @@
     "build": "sass --load-path=. --style=compressed --source-map --importer=./importer.js --update ."
   },
   "devDependencies": {
-    "bootstrap": "^4.6.2"
+    "bootstrap": "^5.3.7"
   }
 }

--- a/scss/pnpm-lock.yaml
+++ b/scss/pnpm-lock.yaml
@@ -16,8 +16,8 @@ importers:
         version: 1.85.1
     devDependencies:
       bootstrap:
-        specifier: ^4.6.2
-        version: 4.6.2(jquery@3.7.1)(popper.js@1.16.1)
+        specifier: ^5.3.7
+        version: 5.3.7(@popperjs/core@2.11.8)
 
 packages:
 
@@ -28,11 +28,13 @@ packages:
     resolution: {integrity: sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==}
     engines: {node: '>=6'}
 
-  bootstrap@4.6.2:
-    resolution: {integrity: sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==}
+  '@popperjs/core@2.11.8':
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  bootstrap@5.3.7:
+    resolution: {integrity: sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==}
     peerDependencies:
-      jquery: 1.9.1 - 3
-      popper.js: ^1.16.1
+      '@popperjs/core': ^2.11.8
 
   buffer-builder@0.2.0:
     resolution: {integrity: sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==}
@@ -46,13 +48,6 @@ packages:
 
   immutable@5.0.3:
     resolution: {integrity: sha512-P8IdPQHq3lA1xVeBRi5VPqUm5HDgKnx0Ru51wZz5mjxHr5n3RWhjIpOFU7ybkUxfB+5IToy+OLaHYDBIWsv+uw==}
-
-  jquery@3.7.1:
-    resolution: {integrity: sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==}
-
-  popper.js@1.16.1:
-    resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
-    deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -206,10 +201,11 @@ snapshots:
 
   '@fortawesome/fontawesome-free@6.7.2': {}
 
-  bootstrap@4.6.2(jquery@3.7.1)(popper.js@1.16.1):
+  '@popperjs/core@2.11.8': {}
+
+  bootstrap@5.3.7(@popperjs/core@2.11.8):
     dependencies:
-      jquery: 3.7.1
-      popper.js: 1.16.1
+      '@popperjs/core': 2.11.8
 
   buffer-builder@0.2.0: {}
 
@@ -218,10 +214,6 @@ snapshots:
   has-flag@4.0.0: {}
 
   immutable@5.0.3: {}
-
-  jquery@3.7.1: {}
-
-  popper.js@1.16.1: {}
 
   rxjs@7.8.2:
     dependencies:

--- a/scss/themes/_chat.scss
+++ b/scss/themes/_chat.scss
@@ -64,6 +64,14 @@
   }
 }
 
+.list-group-item-danger:not(.active) {
+  &:hover,
+  &:focus {
+    color: color-contrast($danger);
+  }
+  color: color-contrast($danger);
+}
+
 .list-group-action.list-group-item {
   &:hover,
   &:focus {

--- a/scss/themes/_chat.scss
+++ b/scss/themes/_chat.scss
@@ -24,6 +24,8 @@
 @import '~bootstrap/scss/popover';
 @import '~bootstrap/scss/badge';
 @import '~bootstrap/scss/utilities';
+@import '~bootstrap/scss/utilities/api';
+@import '~bootstrap/scss/helpers/color-bg';
 
 @import '../core';
 @import '../chat';
@@ -34,20 +36,28 @@
 @import '../flist_overrides';
 @import '../rising';
 
-// Global YIQ contrast overrides for Bootstrap components
+// Color contrast overrides for Bootstrap components
 .list-group-item.active {
-  color: color-yiq(theme-color('primary'));
+  color: color-contrast($primary);
 }
 
 .nav-pills .nav-link.active,
 .nav-pills .show > .nav-link {
-  color: color-yiq(theme-color('primary'));
+  color: color-contrast($primary);
 }
 
 .btn {
   @each $color, $value in $theme-colors {
     &.btn-#{$color} {
-      color: color-yiq($value);
+      color: color-contrast($value);
+    }
+  }
+}
+
+.badge {
+  @each $color, $value in $theme-colors {
+    &.text-bg-#{$color} {
+      color: color-contrast($value);
     }
   }
 }

--- a/scss/themes/_chat.scss
+++ b/scss/themes/_chat.scss
@@ -67,9 +67,9 @@
 .list-group-item-danger:not(.active) {
   &:hover,
   &:focus {
-    color: color-contrast($danger);
+    color: color-contrast($danger-bg-subtle);
   }
-  color: color-contrast($danger);
+  color: color-contrast($danger-bg-subtle);
 }
 
 .list-group-action.list-group-item {

--- a/scss/themes/_chat.scss
+++ b/scss/themes/_chat.scss
@@ -1,3 +1,7 @@
+@import '~bootstrap/scss/functions';
+@import '~bootstrap/scss/variables';
+@import '~bootstrap/scss/variables-dark';
+@import '~bootstrap/scss/maps';
 @import '~bootstrap/scss/mixins';
 @import '~bootstrap/scss/root';
 @import '~bootstrap/scss/reboot';
@@ -9,8 +13,6 @@
 @import '~bootstrap/scss/transitions';
 @import '~bootstrap/scss/dropdown';
 @import '~bootstrap/scss/button-group';
-@import '~bootstrap/scss/input-group';
-@import '~bootstrap/scss/custom-forms';
 @import '~bootstrap/scss/nav';
 @import '~bootstrap/scss/card';
 @import '~bootstrap/scss/pagination';
@@ -21,13 +23,7 @@
 @import '~bootstrap/scss/modal';
 @import '~bootstrap/scss/popover';
 @import '~bootstrap/scss/badge';
-@import '~bootstrap/scss/utilities/background';
-@import '~bootstrap/scss/utilities/borders';
-@import '~bootstrap/scss/utilities/display';
-@import '~bootstrap/scss/utilities/flex';
-@import '~bootstrap/scss/utilities/sizing';
-@import '~bootstrap/scss/utilities/shadows';
-@import '~bootstrap/scss/utilities/text';
+@import '~bootstrap/scss/utilities';
 
 @import '../core';
 @import '../chat';
@@ -64,7 +60,7 @@
 
 * {
   &::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 8px $card-border-color;
+    box-shadow: inset 0 0 8px var(--bs-border-color);
     border-radius: 10px;
   }
 

--- a/scss/themes/_chat.scss
+++ b/scss/themes/_chat.scss
@@ -41,8 +41,41 @@
   color: color-contrast($primary);
 }
 
+.list-group-item-action:not(.active):hover,
+.list-group-item-action:not(.active):focus {
+  color: var(--bs-secondary-text-emphasis);
+}
+
+// Map list-group-action colors to their list-group-item equivalents
+@each $color, $value in $theme-colors {
+  .list-group-item-action.list-group-item-#{$color} {
+    color: var(--bs-#{$color}-text-emphasis);
+    background-color: var(--bs-#{$color}-bg-subtle);
+
+    &:hover,
+    &:focus {
+      color: var(--bs-#{$color}-text-emphasis);
+      background-color: color-mix(
+        in srgb,
+        var(--bs-#{$color}-bg-subtle) 95%,
+        $black
+      );
+    }
+  }
+}
+
+.list-group-action.list-group-item {
+  &:hover,
+  &:focus {
+    color: initial;
+  }
+}
+
 .nav-pills .nav-link.active,
-.nav-pills .show > .nav-link {
+.nav-pills .show > .nav-link,
+.list-group.conversation-nav
+  .list-group-item-action.item-private.active
+  .online-status {
   color: color-contrast($primary);
 }
 
@@ -63,6 +96,7 @@
 }
 
 :root {
+  --bs-warning-bg-subtle: #{mix($warning, $white, 25%)};
   @each $varName, $value in $risingVariables {
     --#{$varName}: #{$value};
   }

--- a/scss/themes/chat/dracula.scss
+++ b/scss/themes/chat/dracula.scss
@@ -84,15 +84,6 @@ $genders: (
   }
 }
 
-.list-group-item-warning {
-  background-color: shift-color($warning, -5);
-  border-color: shift-color($warning, -5);
-  color: shift-color($warning, 6);
-  &:hover {
-    background-color: shift-color($warning, -6);
-  }
-}
-
 .user-bookmark,
 .message-event .user-bookmark {
   color: $dracula-green;

--- a/scss/themes/chat/dracula.scss
+++ b/scss/themes/chat/dracula.scss
@@ -85,12 +85,11 @@ $genders: (
 }
 
 .list-group-item-warning {
-  background-color: theme-color-level('warning', -5);
-  border-color: theme-color-level('warning', -5);
-  //color: color-yiq(theme-color('warning'));
-  color: theme-color-level('warning', 6);
+  background-color: shift-color($warning, -5);
+  border-color: shift-color($warning, -5);
+  color: shift-color($warning, 6);
   &:hover {
-    background-color: theme-color-level('warning', -6);
+    background-color: shift-color($warning, -6);
   }
 }
 
@@ -100,7 +99,7 @@ $genders: (
 }
 
 .message-highlight {
-  background-color: color.scale(theme-color-level('success', -8), $alpha: -60%);
+  background-color: color.scale($success, $alpha: -60%);
 }
 
 :root {

--- a/scss/themes/chat/dracula.scss
+++ b/scss/themes/chat/dracula.scss
@@ -1,8 +1,8 @@
 @use 'sass:color';
-@import '../variables/dracula_variables';
 @import '~bootstrap/scss/functions';
-@import '~bootstrap/scss/variables';
 @import '../../functions';
+@import '../variables/dracula_variables';
+@import '~bootstrap/scss/variables';
 @import '../../flist_derived';
 @import '../variables/dracula_derived';
 

--- a/scss/themes/chat/light.scss
+++ b/scss/themes/chat/light.scss
@@ -44,23 +44,37 @@
     --#{$varName}: #{$value};
   }
 }
-.list-group-item-warning {
-  background-color: theme-color-level('warning', -3);
-  border-color: theme-color-level('warning', -3);
-  //color: color-yiq(theme-color('warning'));
-  color: theme-color-level('warning', 6);
+
+// Custom muted warning/danger colors
+$warning-bg-subtle-custom: mix($warning, $white, 55%);
+$danger-bg-subtle-custom: mix($danger, $white, 55%);
+
+:root {
+  --bs-warning-bg-subtle: #{$warning-bg-subtle-custom};
+  --bs-danger-bg-subtle: #{$danger-bg-subtle-custom};
+}
+
+.list-group-item-action.list-group-item-warning {
+  --bs-list-group-bg: var(--bs-warning-bg-subtle);
+  --bs-list-group-border-color: var(--bs-warning-border-subtle);
+  --bs-list-group-color: var(--bs-warning-text-emphasis);
+
   &:hover {
-    background-color: theme-color-level('warning', -4);
+    background-color: color-mix(
+      in srgb,
+      var(--bs-warning-bg-subtle) 90%,
+      black
+    );
   }
 }
 
-.list-group-item-danger {
-  background-color: theme-color-level('danger', -3);
-  border-color: theme-color-level('danger', -3);
-  //color: color-yiq(theme-color('warning'));
-  color: theme-color-level('danger', 6);
+.list-group-item-action.list-group-item-danger {
+  --bs-list-group-bg: var(--bs-danger-bg-subtle);
+  --bs-list-group-border-color: var(--bs-danger-border-subtle);
+  --bs-list-group-color: var(--bs-danger-text-emphasis);
+
   &:hover {
-    background-color: theme-color-level('danger', -4);
+    background-color: color-mix(in srgb, var(--bs-danger-bg-subtle) 90%, black);
   }
 }
 

--- a/scss/themes/chat/peached.scss
+++ b/scss/themes/chat/peached.scss
@@ -58,22 +58,37 @@ body,
 .character-card-header {
   background: $body-bg !important;
 }
-.list-group-item-warning {
-  background-color: theme-color-level('warning', -3);
-  border-color: theme-color-level('warning', -3);
-  //color: color-yiq(theme-color('warning'));
-  color: theme-color-level('warning', 6);
+
+// Custom muted warning/danger colors
+$warning-bg-subtle-custom: mix($warning, $white, 55%);
+$danger-bg-subtle-custom: mix($danger, $white, 55%);
+
+:root {
+  --bs-warning-bg-subtle: #{$warning-bg-subtle-custom};
+  --bs-danger-bg-subtle: #{$danger-bg-subtle-custom};
+}
+
+.list-group-item-action.list-group-item-warning {
+  --bs-list-group-bg: var(--bs-warning-bg-subtle);
+  --bs-list-group-border-color: var(--bs-warning-border-subtle);
+  --bs-list-group-color: var(--bs-warning-text-emphasis);
+
   &:hover {
-    background-color: theme-color-level('warning', -4);
+    background-color: color-mix(
+      in srgb,
+      var(--bs-warning-bg-subtle) 90%,
+      black
+    );
   }
 }
 
-.list-group-item-danger {
-  background-color: theme-color-level('danger', -3);
-  border-color: theme-color-level('danger', -3);
-  color: theme-color-level('danger', 6);
+.list-group-item-action.list-group-item-danger {
+  --bs-list-group-bg: var(--bs-danger-bg-subtle);
+  --bs-list-group-border-color: var(--bs-danger-border-subtle);
+  --bs-list-group-color: var(--bs-danger-text-emphasis);
+
   &:hover {
-    background-color: theme-color-level('danger', -4);
+    background-color: color-mix(in srgb, var(--bs-danger-bg-subtle) 90%, black);
   }
 }
 

--- a/scss/themes/chat/wilted-rose.scss
+++ b/scss/themes/chat/wilted-rose.scss
@@ -45,7 +45,7 @@ body,
 
 * {
   &::-webkit-scrollbar-track {
-    box-shadow: inset 0 0 2px $card-border-color;
+    box-shadow: inset 0 0 2px var(--bs-border-color);
     border-radius: 10px;
   }
 

--- a/scss/themes/variables/_classic_variables.scss
+++ b/scss/themes/variables/_classic_variables.scss
@@ -41,8 +41,9 @@ $modal-backdrop-bg: $white;
 $modal-content-bg: $gray-200;
 $modal-header-border-color: $gray-300;
 
-// Fix YIQ(automatic text contrast) preferring black over white on dark themes.
-$yiq-text-light: $black;
+// Bootstrap 5 contrast colors
+$light-color: $black;
+$dark-color: $gray-base;
 
 // Reduce default padding slightly between columns in grids.
 $grid-gutter-width: 20px;

--- a/scss/themes/variables/_dark_dimmed_variables.scss
+++ b/scss/themes/variables/_dark_dimmed_variables.scss
@@ -15,11 +15,10 @@ $gray-800: color.scale($gray-base, $lightness: 80%);
 $gray-900: color.scale($gray-base, $lightness: 90%);
 $black: #fff;
 
-// YIQ contrast settings
-$yiq-contrasted-threshold: 150;
-$yiq-text-light: $black;
-$yiq-text-dark: $gray-base;
-$component-active-color: $yiq-text-light;
+// Bootstrap 5 contrast colors
+$light-color: $black;
+$dark-color: $gray-base;
+$component-active-color: $light-color;
 
 // Theme and brand colors
 $primary: rgb(89, 89, 89);

--- a/scss/themes/variables/_dark_variables.scss
+++ b/scss/themes/variables/_dark_variables.scss
@@ -15,11 +15,10 @@ $gray-800: color.scale($gray-base, $lightness: 80%);
 $gray-900: color.scale($gray-base, $lightness: 90%);
 $black: #fff;
 
-// YIQ contrast settings
-$yiq-contrasted-threshold: 150;
-$yiq-text-light: $black;
-$yiq-text-dark: $gray-base;
-$component-active-color: $yiq-text-light;
+// Bootstrap 5 contrast colors
+$light-color: $black;
+$dark-color: $gray-base;
+$component-active-color: $light-color;
 
 // Theme and brand colors
 $primary: #003399;

--- a/scss/themes/variables/_default_variables.scss
+++ b/scss/themes/variables/_default_variables.scss
@@ -15,11 +15,10 @@ $gray-800: color.scale($gray-base, $lightness: 80%);
 $gray-900: color.scale($gray-base, $lightness: 90%);
 $black: #fff;
 
-// YIQ contrast settings
-$yiq-contrasted-threshold: 150;
-$yiq-text-light: $black;
-$yiq-text-dark: $gray-base;
-$component-active-color: $yiq-text-light;
+// Bootstrap 5 contrast colors
+$light-color: $black;
+$dark-color: $gray-base;
+$component-active-color: $light-color;
 
 // Theme and brand colors
 $primary: #0447af;

--- a/scss/themes/variables/_dracula_variables.scss
+++ b/scss/themes/variables/_dracula_variables.scss
@@ -29,11 +29,10 @@ $gray-800: color.scale($gray-base, $lightness: 80%);
 $gray-900: color.scale($gray-base, $lightness: 90%);
 $black: $dracula-foreground;
 
-$yiq-contrasted-threshold: 150;
-
-$yiq-text-light: $dracula-foreground; // Light text for dark buttons
-$yiq-text-dark: $dracula-bg; // Dark text for light buttons
-$component-active-color: $yiq-text-light;
+// Bootstrap 5 contrast colors
+$light-color: $dracula-foreground;
+$dark-color: $dracula-bg;
+$component-active-color: $light-color;
 
 $primary: $dracula-purple;
 $secondary: $gray-400;

--- a/scss/themes/variables/_dracula_variables.scss
+++ b/scss/themes/variables/_dracula_variables.scss
@@ -66,6 +66,7 @@ $input-color: $black;
 $custom-select-bg: $gray-100;
 $form-check-input-checked-bg-color: $primary;
 
+$form-check-input-checked-bg-image: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'><path fill='none' stroke='#{$white}' stroke-linecap='round' stroke-linejoin='round' stroke-width='3' d='m6 10 3 3 6-6'/></svg>");
 // List groups
 $list-group-bg: $gray-100;
 $list-group-hover-bg: $gray-200;

--- a/scss/themes/variables/_invert.scss
+++ b/scss/themes/variables/_invert.scss
@@ -3,7 +3,7 @@
 @use 'sass:math';
 
 // Theme color interval
-$theme-color-interval: 8%;
+$theme-color-interval: -15%;
 
 // Bootstrap 5 shade and tint mixins for dark themes
 // In Bootstrap 4, dark themes were not officially supported, so the original version of this function was

--- a/scss/themes/variables/_invert.scss
+++ b/scss/themes/variables/_invert.scss
@@ -5,10 +5,45 @@
 // Theme color interval
 $theme-color-interval: 8%;
 
+// Bootstrap 5 shade and tint mixins for dark themes
+// In Bootstrap 4, dark themes were not officially supported, so the original version of this function was
+// used to make sure that the auto-tinted components would work in dark themes.
+// While Bootstrap 5 does actually support dark themes, we ported this function instead of using the native support
+// because porting over the dark themes to use Bootstrap 5's new color system would lead to too many visual inconsistencies.
+@function tint-color($color, $weight) {
+  @if type-of($color) == 'string' {
+    @return $color;
+  }
+
+  @return color.mix(black, $color, $weight * 1%);
+}
+
+@function shade-color($color, $weight) {
+  @if type-of($color) == 'string' {
+    @return $color;
+  }
+
+  @return color.mix(white, $color, $weight * 1%);
+}
+
+@function shift-color($color, $weight) {
+  @if type-of($color) == 'string' {
+    @return $color;
+  }
+
+  @return if(
+    $weight > 0,
+    shade-color($color, $weight),
+    tint-color($color, -$weight)
+  );
+}
+
+// Legacy support
 @function lighten($color, $amount) {
   @if type-of($color) == 'string' {
     @return $color;
   }
+
   @return color.adjust($color, $lightness: -$amount);
 }
 
@@ -16,20 +51,25 @@ $theme-color-interval: 8%;
   @if type-of($color) == 'string' {
     @return $color;
   }
+
   @return color.adjust($color, $lightness: $amount);
 }
 
+// Bootstrap 5 level function
 @function theme-color-level($color-name: 'primary', $level: 0) {
-  $color: theme-color($color-name);
-  $color-base: if($level < 0, #000, #fff);
+  $color: var(--#{$prefix}#{$color-name});
+  $color-base: if($level < 0, black, white);
   $level: abs($level);
 
   @if type-of($color) == 'string' {
     @return $color;
   }
-  @return mix($color-base, $color, $level * $theme-color-interval);
+
+  @return color.mix($color-base, $color, $level * $theme-color-interval);
 }
 
-// Alert color levels
-$alert-border-level: 4;
+// Alert and theme settings
+$alert-border-scale: -8%;
+$alert-color-scale: -80%;
 $theme-is-dark: true;
+$prefix: bs-;

--- a/scss/themes/variables/_invert.scss
+++ b/scss/themes/variables/_invert.scss
@@ -3,7 +3,7 @@
 @use 'sass:math';
 
 // Theme color interval
-$theme-color-interval: -15%;
+$theme-color-interval: 10%;
 
 // Bootstrap 5 shade and tint mixins for dark themes
 // In Bootstrap 4, dark themes were not officially supported, so the original version of this function was

--- a/scss/themes/variables/_light_variables.scss
+++ b/scss/themes/variables/_light_variables.scss
@@ -89,3 +89,5 @@ $headerBackgroundMaskColor: #e5e5e5;
 
 $linkForcedColor: #007bff;
 $tabSecondaryFgColor: rgba(0, 0, 0, 0.4);
+
+@import 'theme_level';

--- a/scss/themes/variables/_light_variables.scss
+++ b/scss/themes/variables/_light_variables.scss
@@ -28,11 +28,10 @@ $pink-color: #da1677;
 $green-color: #036603;
 $primary: #e26f2e;
 
-// YIQ contrast settings
-$yiq-contrasted-threshold: 150;
-$yiq-text-light: $white;
-$yiq-text-dark: $black;
-$component-active-color: $yiq-text-dark;
+// Bootstrap 5 contrast colors
+$light-color: $black;
+$dark-color: $gray-base;
+$component-active-color: $light-color;
 
 $link-color: $gray-800;
 $link-hover-color: $black;

--- a/scss/themes/variables/_mars_variables.scss
+++ b/scss/themes/variables/_mars_variables.scss
@@ -15,11 +15,10 @@ $gray-800: color.scale($gray-base, $lightness: 80%);
 $gray-900: color.scale($gray-base, $lightness: 90%);
 $black: #fff;
 
-// YIQ contrast settings
-$yiq-contrasted-threshold: 150;
-$yiq-text-light: $black;
-$yiq-text-dark: $gray-base;
-$component-active-color: $yiq-text-light;
+// Bootstrap 5 contrast colors
+$light-color: $black;
+$dark-color: $gray-base;
+$component-active-color: $light-color;
 
 $mars-red: #c1666b;
 $mars-green: #00a676;

--- a/scss/themes/variables/_peached_variables.scss
+++ b/scss/themes/variables/_peached_variables.scss
@@ -95,3 +95,5 @@ $headerBackgroundMaskColor: #e5e5e5;
 
 $linkForcedColor: #007bff;
 $tabSecondaryFgColor: rgba(0, 0, 0, 0.4);
+
+@import 'theme_level';

--- a/scss/themes/variables/_peached_variables.scss
+++ b/scss/themes/variables/_peached_variables.scss
@@ -14,11 +14,10 @@ $gray-800: #333333 !default;
 $gray-900: #191919 !default;
 $black: #000000 !default;
 
-// YIQ contrast settings
-$yiq-contrasted-threshold: 150;
-$yiq-text-light: $white;
-$yiq-text-dark: $black;
-$component-active-color: $yiq-text-dark;
+// Bootstrap 5 contrast colors
+$light-color: $white;
+$dark-color: $black;
+$component-active-color: $dark-color;
 
 // Theme colors
 $gray-color: $gray-400;

--- a/scss/themes/variables/_rose_variables.scss
+++ b/scss/themes/variables/_rose_variables.scss
@@ -13,10 +13,10 @@ $gray-800: #f7f3f7;
 $gray-900: color.scale($gray-base, $lightness: 90%);
 $black: #f7f3f7;
 
-$yiq-contrasted-threshold: 150;
-$yiq-text-light: $black;
-$yiq-text-dark: $gray-base;
-$component-active-color: $yiq-text-light;
+// Bootstrap 5 contrast colors
+$light-color: $black;
+$dark-color: $gray-base;
+$component-active-color: $light-color;
 
 $rose-red: #ff3b30;
 $rose-green: #91ebaf;

--- a/scss/themes/variables/_theme_level.scss
+++ b/scss/themes/variables/_theme_level.scss
@@ -1,0 +1,11 @@
+@function theme-color-level($color-name: 'primary', $level: 0) {
+  $color: var(--#{$prefix}#{$color-name});
+  $color-base: white;
+  $level: abs($level);
+
+  @if type-of($color) == 'string' {
+    @return $color;
+  }
+
+  @return color.mix($color-base, $color, $level * $theme-color-interval);
+}

--- a/site/NoteStatus.vue
+++ b/site/NoteStatus.vue
@@ -14,7 +14,9 @@
         :class="`status-report ${report.type} ${report.count > 0 && report.count !== report.dismissedCount ? 'active' : ''}`"
       >
         <i :class="getIconClass(report)"></i>
-        <span class="badge badge-primary badge-pill">{{ report.count }}</span>
+        <span class="badge text-bg-primary rounded-pill">{{
+          report.count
+        }}</span>
       </a>
 
       <!--This was part of the original design, where the NoteStatus component floated on the bottom left

--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -3,6 +3,7 @@
     <div class="col-md-4 col-lg-3 col-xl-2" v-if="loading || !character">
       <div
         class="card characterpage-placeholder"
+        style="height: 100%"
         :class="loading ? 'throbber' : 'bg-light'"
       ></div>
     </div>
@@ -631,8 +632,13 @@
   .compare-highlight-block {
     margin-bottom: 3px;
 
-    .quick-compare-block button {
-      margin-left: 2px;
+    .quick-compare-block {
+      & button {
+        margin-left: 2px;
+      }
+      &.input-group {
+        width: initial;
+      }
     }
   }
   .characterpage-placeholder {

--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -662,7 +662,7 @@
         min-width: 200px;
         margin-bottom: 0;
         padding-bottom: 0;
-
+        position: absolute;
         opacity: 1;
       }
 

--- a/site/character_page/copy_custom_dialog.vue
+++ b/site/character_page/copy_custom_dialog.vue
@@ -47,7 +47,7 @@
     >
       <select
         v-model="choice"
-        class="form-control"
+        class="form-select"
         slot-scope="props"
         :class="props.cls"
         id="copyCustomChoice"

--- a/site/character_page/duplicate_dialog.vue
+++ b/site/character_page/duplicate_dialog.vue
@@ -26,7 +26,7 @@
           slot-scope="props"
           :class="props.cls"
         />
-        <div slot="button" class="input-group-append">
+        <div slot="button">
           <button
             type="button"
             class="btn btn-secondary"

--- a/site/character_page/duplicate_dialog.vue
+++ b/site/character_page/duplicate_dialog.vue
@@ -11,7 +11,7 @@
       images. Guestbook entries, friends, groups, and bookmarks are not
       duplicated.
     </p>
-    <div class="form-row mb-2">
+    <div class="row mb-2">
       <form-group-inputgroup
         class="col-12"
         :errors="errors"

--- a/site/character_page/friend_dialog.vue
+++ b/site/character_page/friend_dialog.vue
@@ -100,7 +100,7 @@
           <h4>Request Friendship</h4>
         </div>
         <div class="card-body">
-          <div class="form-inline">
+          <div class="d-flex align-items-center">
             <label class="control-label" for="friendRequestCharacter"
               >Character:
             </label>

--- a/site/character_page/kinks.vue
+++ b/site/character_page/kinks.vue
@@ -25,15 +25,13 @@
         class="input-group quick-compare-block col-12 col-lg-4 col-xl-3"
       >
         <character-select v-model="characterToCompare"></character-select>
-        <div class="input-group-append">
-          <button
-            class="btn btn-outline-secondary"
-            @click="compareKinks()"
-            :disabled="loading || !characterToCompare"
-          >
-            {{ compareButtonText }}
-          </button>
-        </div>
+        <button
+          class="btn btn-outline-secondary"
+          @click="compareKinks()"
+          :disabled="loading || !characterToCompare"
+        >
+          {{ compareButtonText }}
+        </button>
       </div>
 
       <div class="col-12 col-lg-4 col-xl-2">

--- a/site/character_page/kinks.vue
+++ b/site/character_page/kinks.vue
@@ -37,7 +37,7 @@
       </div>
 
       <div class="col-12 col-lg-4 col-xl-2">
-        <select v-model="highlightGroup" class="form-control">
+        <select v-model="highlightGroup" class="form-select">
           <option :value="undefined">None</option>
           <option
             v-for="group in kinkGroups"
@@ -50,7 +50,7 @@
         </select>
       </div>
     </div>
-    <div class="form-row mt-3" :class="{ highlighting: !!highlightGroup }">
+    <div class="row mt-3" :class="{ highlighting: !!highlightGroup }">
       <div class="col-sm-6 col-lg-3 kink-block-favorite kink-block">
         <div class="card bg-light">
           <div class="card-header border-bottom border-info">

--- a/site/character_page/memo_dialog.vue
+++ b/site/character_page/memo_dialog.vue
@@ -7,7 +7,7 @@
     dialog-class="w-100 modal-dialog-centered"
     iconClass="fas fa-note-sticky"
   >
-    <div class="form-group">
+    <div class="mb-3">
       <textarea
         v-model="message"
         maxlength="1000"

--- a/site/character_page/report_dialog.vue
+++ b/site/character_page/report_dialog.vue
@@ -5,9 +5,9 @@
     :disabled="!dataValid || submitting"
     @submit.prevent="submitReport()"
   >
-    <div class="form-group">
+    <div class="mb-3">
       <label>Type</label>
-      <select v-model="type" class="form-control">
+      <select v-model="type" class="form-select">
         <option>None</option>
         <option value="profile">Profile Violation</option>
         <option value="name_request">Name Request</option>
@@ -16,9 +16,9 @@
       </select>
     </div>
     <div v-if="type !== 'takedown'">
-      <div class="form-group" v-if="type === 'profile'">
+      <div class="mb-3" v-if="type === 'profile'">
         <label>Violation Type</label>
-        <select v-model="violation" class="form-control">
+        <select v-model="violation" class="form-select">
           <option>Real life images on underage character</option>
           <option>Real life animal images on sexual character</option>
           <option>Amateur/farmed real life images</option>
@@ -29,11 +29,11 @@
           <option>Other</option>
         </select>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label>Your Character</label>
         <character-select v-model="ourCharacter"></character-select>
       </div>
-      <div class="form-group">
+      <div class="mb-3">
         <label>Reason/Message</label>
         <bbcode-editor
           v-model="message"


### PR DESCRIPTION
Making this a PR for now because I don't want to completely fuck up stuff in the dev branch.


  - [x] Theme color scaling for dark/ light themes
    - [x] Check if current method in [branch ](https://github.com/Fchat-Horizon/Horizon/tree/experimental/bootstrap5-dark-mode-fix)is fine.
    - [x] Fix list-group-item warning color for consistency
    - [x] Fix list-group-item text colors
    - [x] Fix list-group-item overrides in light, dracula and peached themes
  - [x] Flex box issues with buttons on bottom of profile viewer
  - [x] Message boxes w/ colored borders in settings
  - [x] Profile viewer forward/ backwards button
  - [x] Fix up FilterableSelect component
  - [x] Color contrast functions
  - [x] Window control icons
  - [x] Main sidebar user name and status spacing
  - [x] Tab bottom border fade
  - [x] List group checkbox items in settings
  - [x] Form input ''attachments'' (like the search icon in the channel members list)
  - [x] Close buttons