### PR TITLE
More bbcode fixes, mostly fixing my mistakes!

### DIFF
--- a/bbcode/core.ts
+++ b/bbcode/core.ts
@@ -81,22 +81,6 @@ export class CoreBBCodeParser extends BBCodeParser {
     this.addTag(new BBCodeSimpleTag('s', 'del'));
     this.addTag(new BBCodeSimpleTag('noparse', 'span', [], []));
     this.addTag(
-      new BBCodeSimpleTag(
-        'sub',
-        'sub',
-        [],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
-      )
-    );
-    this.addTag(
-      new BBCodeSimpleTag(
-        'sup',
-        'sup',
-        [],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
-      )
-    );
-    this.addTag(
       new BBCodeTextTag('icon', (parser, parent, param, content) => {
         if (param.length > 0)
           parser.warning('Unexpected parameter on icon tag.');

--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -31,21 +31,30 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
       'hr',
       [],
       [
-        'collapse',
-        'justify',
-        'center',
-        'left',
-        'right',
         'url',
         'i',
-        'u',
         'b',
-        'color',
+        'u',
         's',
-        'big',
+        'color',
         'sub',
+        'sup',
+        'big',
+        'small',
+        'heading',
         'hr',
-        'img'
+        'icon',
+        'user',
+        'img',
+        'eicon',
+        'quote',
+        'collapse',
+        'left',
+        'center',
+        'right',
+        'justify',
+        'indent',
+        'noparse'
       ]
     );
     hrTag.noClosingTag = true;
@@ -66,6 +75,8 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
     this.addTag(new BBCodeSimpleTag('right', 'span', ['rightText']));
     this.addTag(new BBCodeSimpleTag('center', 'span', ['centerText']));
     this.addTag(new BBCodeSimpleTag('justify', 'span', ['justifyText']));
+    this.addTag(new BBCodeSimpleTag('sub', 'sub', [], ['i', 'u', 'b', 'hr']));
+    this.addTag(new BBCodeSimpleTag('sup', 'sup', [], ['i', 'u', 'b', 'hr']));
     this.addTag(
       new BBCodeCustomTag('color', (parser, parent, param) => {
         const cregex =
@@ -88,7 +99,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'big',
         'span',
         ['bigText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr']
       )
     );
     this.addTag(
@@ -96,7 +107,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'small',
         'span',
         ['smallText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr']
       )
     );
     this.addTag(new BBCodeSimpleTag('indent', 'div', ['indentText']));
@@ -106,24 +117,30 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'h2',
         [],
         [
-          'collapse',
-          'justify',
-          'center',
-          'left',
-          'right',
           'url',
           'i',
-          'u',
           'b',
-          'color',
+          'u',
           's',
-          'big',
-          'small',
+          'color',
           'sub',
           'sup',
+          'big',
+          'small',
+          'heading',
           'hr',
+          'icon',
+          'user',
           'img',
-          'eicon'
+          'eicon',
+          'quote',
+          'collapse',
+          'left',
+          'center',
+          'right',
+          'justify',
+          'indent',
+          'noparse'
         ]
       )
     );

--- a/chat/bbcode.ts
+++ b/chat/bbcode.ts
@@ -2,7 +2,11 @@ import Vue from 'vue';
 import { BBCodeElement, CoreBBCodeParser } from '../bbcode/core';
 //tslint:disable-next-line:match-default-export-name
 import BaseEditor from '../bbcode/Editor.vue';
-import { BBCodeTextTag, BBCodeCustomTag } from '../bbcode/parser';
+import {
+  BBCodeTextTag,
+  BBCodeCustomTag,
+  BBCodeSimpleTag
+} from '../bbcode/parser';
 import ChannelView from './ChannelTagView.vue';
 // import {characterImage} from './common';
 import core from './core';
@@ -18,6 +22,12 @@ export default class BBCodeParser extends CoreBBCodeParser {
 
   constructor() {
     super();
+    this.addTag(
+      new BBCodeSimpleTag('sub', 'sub', [], ['b', 'i', 'u', 's', 'color'])
+    );
+    this.addTag(
+      new BBCodeSimpleTag('sup', 'sup', [], ['b', 'i', 'u', 's', 'color'])
+    );
     this.addTag(
       new BBCodeCustomTag('color', (parser, parent, param) => {
         const cregex =


### PR DESCRIPTION
Also comes with some parity fixes for the profile viewer again, mostly fixing my own stuff.

- Literally everything should work in heading now.
- Passed those changes on to HR just for safety.
- sub/sup no longer supports URLs inside of them.
- sub/sup on profiles are far more restrictive than even Rising's version was to match the site only allowing a very small amount of things in them.
- sub/sup for profiles and chat are seperate again, though this time have no definition in core and still are unduplicated.