### PR TITLE
WIP: Custom channel icons

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -299,11 +299,7 @@
         >
           <span
             class="conversation-icon"
-            :class="
-              conversation.channel.id.substr(0, 4) !== 'adh-'
-                ? 'fa fa-star'
-                : 'fas fa-hashtag'
-            "
+            :class="conversation.channel.horizonIcon"
           ></span>
           <div class="name">{{ conversation.name }}</div>
         </a>

--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -77,11 +77,7 @@
         <div style="flex: 1">
           <span
             class="fa-fw"
-            :class="
-              conversation.channel.id.substr(0, 4) !== 'adh-'
-                ? 'fa fa-star'
-                : 'fas fa-hashtag'
-            "
+            :class="conversation.channel.horizonIcon"
             :title="l('channel.official')"
             style="vertical-align: sub"
           ></span>

--- a/fchat/channels.ts
+++ b/fchat/channels.ts
@@ -46,6 +46,14 @@ class Channel implements Interfaces.Channel {
   members: { [key: string]: SortableMember | undefined } = {};
   sortedMembers: SortableMember[] = [];
 
+  get horizonIcon(): string {
+    if (this.id.substr(0, 4) !== 'adh-') return 'fa fa-star';
+    const customIconMatch = this.description.match(
+      /(?<=Horizon icon: ")fa[s]? fa-[a-z|-]+(?=")/gm
+    );
+    return customIconMatch ? customIconMatch[0] : 'fas fa-hashtag';
+  }
+
   constructor(
     readonly id: string,
     readonly name: string

--- a/fchat/interfaces.ts
+++ b/fchat/interfaces.ts
@@ -390,6 +390,7 @@ export namespace Channel {
     readonly sortedMembers: ReadonlyArray<Member>;
     readonly opList: ReadonlyArray<string>;
     readonly owner: string;
+    readonly horizonIcon: string;
   }
 }
 


### PR DESCRIPTION
This is a _**VERY**_ quick and dirty implementation to let channel owners set a custom icon for their channels in the conversation header, and the mobile view's quick jump on top. 

I mostly want to see if people would be interested in such a feature, and we all know that actually showing something tangible is a far better way of getting opinions than to theorycraft with hastily edited screenshots.

Speaking of... here are the screenshots (the star rooms are official channels):

<img width="315" height="66" alt="image" src="https://github.com/user-attachments/assets/98dda6b7-5330-45e6-90df-5444551863ee" />

<img width="645" height="36" alt="image" src="https://github.com/user-attachments/assets/315e886b-a736-46b0-ad5d-9115b0224a63" />

Even _**if**_ we do implement this, I'll add a whitelist for FontAwesome icons that people can choose from (though it can obviously be expanded per user requests), just so that we can make sure that official F-List channels will be marked properly. In this quick and dirty implementation people can just pick literally any of the available icons.



