### PR TITLE
feat(theme): add Moon Prism theme

### DIFF
--- a/.github/workflows/release_ping.yml
+++ b/.github/workflows/release_ping.yml
@@ -1,0 +1,20 @@
+on:
+  release:
+    types: [released]
+jobs:
+  release-to-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Release to Discord
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
+          nodetail: true
+          title: "New Release (${{ github.event.release.tag_name }})"
+          description: |
+            ${{ github.event.release.body }}
+
+            [Download Here](${{ github.event.release.html_url }})
+          color: 0x00FF00
+          content: "||<@&1409675106900246540>||"
+          username: "Release Bot"

--- a/.github/workflows/release_ping.yml
+++ b/.github/workflows/release_ping.yml
@@ -10,11 +10,11 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_RELEASES }}
           nodetail: true
-          title: "New Release (${{ github.event.release.tag_name }})"
+          title: 'New Release (${{ github.event.release.tag_name }})'
           description: |
             ${{ github.event.release.body }}
 
             [Download Here](${{ github.event.release.html_url }})
           color: 0x00FF00
-          content: "||<@&1409675106900246540>||"
-          username: "Release Bot"
+          content: '||<@&1409675106900246540>||'
+          username: 'Release Bot'

--- a/.github/workflows/testers.yml
+++ b/.github/workflows/testers.yml
@@ -10,7 +10,7 @@ jobs:
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK_TESTERS }}
           nodetail: true
-          title: "New Prerelease (${{ github.event.release.tag_name }})"
+          title: 'New Prerelease (${{ github.event.release.tag_name }})'
           description: |
             ${{ github.event.release.body }}
 
@@ -18,5 +18,5 @@ jobs:
 
             Discuss in <#1409676927995740272>
           color: 0x00FF00
-          content: "||<@&1409673714890440828>||"
-          username: "Pre-Release Bot"
+          content: '||<@&1409673714890440828>||'
+          username: 'Pre-Release Bot'

--- a/.github/workflows/testers.yml
+++ b/.github/workflows/testers.yml
@@ -1,0 +1,22 @@
+on:
+  release:
+    types: [prereleased]
+jobs:
+  release-to-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Release to Discord
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_TESTERS }}
+          nodetail: true
+          title: "New Prerelease (${{ github.event.release.tag_name }})"
+          description: |
+            ${{ github.event.release.body }}
+
+            [Download Here](${{ github.event.release.html_url }})
+
+            Discuss in <#1409676927995740272>
+          color: 0x00FF00
+          content: "||<@&1409673714890440828>||"
+          username: "Pre-Release Bot"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,33 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
-## [1.33.4-beta.1] - 2025-08-26
+## [1.33.4] - 2025-08-26
 
 ### Added
 
-- Button to join Discord in several places. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/bf4430d)
-- Character selector pinning. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/046c56c)
+- Button to join Discord in several places. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/bf4430d)
+- Character selector pinning. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/046c56c)
 
 ### Fixed
 
-- Make character selector respect theme colours (removes placeholder colours). [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/f1f7f2a)
+- Ensure default profile star and pin icons render above character images in the character selector.
+- Make character selector respect theme colours (removes placeholder colours). [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/f1f7f2a)
 - Character selection screen fixes:
   - Fixes vertical scroll clipping for the whole grid
   - Fixes grid item backgrounds being invisible in light themes
-  - Fixes avatars clipping into the avatar background [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/d5625c9)
-- Profile analysis now marks unparsable species fields as empty instead of crashing. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/c06642c)
-- Fixes Default and Mars themes being detected as light themes by unstyled components. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/4a57466)
-- Fixes Dracula message-own background colour. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/8a5cc9e)
-- Fixes vanilla gender colours overriding the "Highlight friends/ bookmarks" name colours; that setting now uses the vanilla colour correctly. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/01603af)
+  - Fixes avatars clipping into the avatar background [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/d5625c9)
+- Profile analysis now marks unparsable species fields as empty instead of crashing. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/c06642c)
+- Fixes Default and Mars themes being detected as light themes by unstyled components. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/4a57466)
+- Fixes Dracula message-own background colour. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/8a5cc9e)
+- Fixes vanilla gender colours overriding the "Highlight friends/ bookmarks" name colours; that setting now uses the vanilla colour correctly. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/01603af)
+-
 
 ### Changed
 
-- Notification volume control styled with Bootstrap classes. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/700ea2a)
-- Moved the version button to under "About Horizon". [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/c6ae55a)
+- Notification volume control styled with Bootstrap classes. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/700ea2a)
+- Moved the version button to under "About Horizon". [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/c6ae55a)
 
 ### Development
 
-- Added GitHub Actions workflows for release notifications to Discord. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/f5b4dc6)
+- Added GitHub Actions workflows for release notifications to Discord. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/f5b4dc6)
 
 # [Releases]
 
@@ -41,19 +43,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed background color for ads when both ads and chat are visible being very hard to read. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/94438bddd0959bdd43a059018e99750ada393a22)
-- The quick switcher on the top for narrow windows now shows up at the proper screen widths again. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/fa372a179c5872c6aa0a96e538208a28cd8ef6c8)
-- Fixed a MacOS issue where the 'About Horizon' window could not be closed. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/5a44f12f67a870177c1c6cbaa4e7155e0cd75c73)
-- Readjusted some overly bright text colours after the Bootstrap 5 upgrade: [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/017f4ced877626f69210f7d9faad7c330b2e89a9)
+- Fixed background color for ads when both ads and chat are visible being very hard to read. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/94438bddd0959bdd43a059018e99750ada393a22)
+- The quick switcher on the top for narrow windows now shows up at the proper screen widths again. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/fa372a179c5872c6aa0a96e538208a28cd8ef6c8)
+- Fixed a MacOS issue where the 'About Horizon' window could not be closed. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/5a44f12f67a870177c1c6cbaa4e7155e0cd75c73)
+- Readjusted some overly bright text colours after the Bootstrap 5 upgrade: [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/017f4ced877626f69210f7d9faad7c330b2e89a9)
   - Active tab text color
   - Unread conversation text color
   - Own message background color
-- Fixed the "Show friends/ bookmarks in a different color" setting not working for the new 1.33.0 themes. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/14b9b0ecbf02bad376e6cdb7632503c8bb72d129)
+- Fixed the "Show friends/ bookmarks in a different color" setting not working for the new 1.33.0 themes. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/14b9b0ecbf02bad376e6cdb7632503c8bb72d129)
 
 ### Changed
 
-- The light theme's primary color has been reverted back to blue for legibility reasons. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/33ca6e96c6410d3ad2bdedebcea381478eba9474)
-- Regrouped the text color settings into their own header. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/80aa51dc63857c050f839a60dfb431d94182187b)
+- The light theme's primary color has been reverted back to blue for legibility reasons. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/33ca6e96c6410d3ad2bdedebcea381478eba9474)
+- Regrouped the text color settings into their own header. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/80aa51dc63857c050f839a60dfb431d94182187b)
 
 ## [1.33.2] - 2025-08-24
 
@@ -410,9 +412,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A new setting to notify you when a friend or bookmark logs in. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/c5b401f59db98450ceede0818c9f85d74a95e737)
 - The 'Smart Filter' automated reply message can now be customized. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/3edab4956b0121cd711c1e67abb4d279bdfcd69d)
   - This also shuffles the related settings around, and hopefully explains the system a bit better.
-- A new setting to display gender symbols next to character names. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/1ae7b9cd2c634b481e83aaee5823627a06decb8c)
+- A new setting to display gender symbols next to character names. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/1ae7b9cd2c634b481e83aaee5823627a06decb8c)
   - These symbols can (optionally) retain the original gendered name colour for characters using a custom colour.
-- Automated update checks. The settings button on top-- or on Mac, a new one only visible when there's an update, will glow when a new version of Horizon is available for download. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/b9189fe9f123dcd2d7a6d6c939e48d744401504b)
+- Automated update checks. The settings button on top-- or on Mac, a new one only visible when there's an update, will glow when a new version of Horizon is available for download. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/b9189fe9f123dcd2d7a6d6c939e48d744401504b)
   - This also brings back and repurposes the old 3.0 beta channel setting, for checking if pre-release versions are available.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). You can also read it on our [website](https://fchat-horizon.github.io/docs/changelog.html).
 
+
+# [Unreleased]
+
+## [1.33.4-beta.1] - 2025-08-26
+
+### Added
+
+- Button to join Discord in several places. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/bf4430d)
+- Character selector pinning. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/046c56c)
+
+### Fixed
+
+- Make character selector respect theme colours (removes placeholder colours). [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/f1f7f2a)
+- Character selection screen fixes:
+  - Fixes vertical scroll clipping for the whole grid
+  - Fixes grid item backgrounds being invisible in light themes
+  - Fixes avatars clipping into the avatar background [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/d5625c9)
+- Profile analysis now marks unparsable species fields as empty instead of crashing. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/c06642c)
+- Fixes Default and Mars themes being detected as light themes by unstyled components. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/4a57466)
+- Fixes Dracula message-own background colour. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/8a5cc9e)
+- Fixes vanilla gender colours overriding the "Highlight friends/ bookmarks" name colours; that setting now uses the vanilla colour correctly. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/01603af)
+
+### Changed
+
+- Notification volume control styled with Bootstrap classes. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/700ea2a)
+- Moved the version button to under "About Horizon". [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/c6ae55a)
+
+### Development
+
+- Added GitHub Actions workflows for release notifications to Discord. [\[Commit\]](https://github.com/Fchat-Horizon/Horizon/commit/f5b4dc6)
+
 # [Releases]
 
 ## [1.33.3] - 2025-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). You can also read it on our [website](https://fchat-horizon.github.io/docs/changelog.html).
 
-
 # [Unreleased]
 
 ## [1.33.4-beta.1] - 2025-08-26

--- a/bbcode/core.ts
+++ b/bbcode/core.ts
@@ -129,6 +129,23 @@ export class CoreBBCodeParser extends BBCodeParser {
         img.src = `${Utils.staticDomain}images/eicon/${content.toLowerCase()}${extension}`;
         img.title = img.alt = content;
         img.className = 'character-avatar icon';
+        if (Utils.settings.animateEicons && Utils.settings.smoothMosaics){
+          img.classList.add('loading');
+          img.addEventListener('load', evt => { //whenever an image is loaded, check if every other image in the span has been loaded. Only then should you show them all
+            let imgs = [];
+            for (let i of (evt.target as Node).parentElement?.children || []) {
+              if (i.tagName == 'IMG') {
+                imgs.push(i);
+                if (!(i as HTMLImageElement).complete) {
+                  return;
+                }
+              }
+            }
+            for (let i of imgs) {
+              i.classList.remove('loading'); //perhaps we could use a spinner here instead of that. Tried it but it looks terrible on mosaics and the transition is smooth
+            }
+          });
+        } 
         parent.appendChild(img);
         return img;
       })

--- a/bbcode/core.ts
+++ b/bbcode/core.ts
@@ -129,9 +129,10 @@ export class CoreBBCodeParser extends BBCodeParser {
         img.src = `${Utils.staticDomain}images/eicon/${content.toLowerCase()}${extension}`;
         img.title = img.alt = content;
         img.className = 'character-avatar icon';
-        if (Utils.settings.animateEicons && Utils.settings.smoothMosaics){
+        if (Utils.settings.animateEicons && Utils.settings.smoothMosaics) {
           img.classList.add('loading');
-          img.addEventListener('load', evt => { //whenever an image is loaded, check if every other image in the span has been loaded. Only then should you show them all
+          img.addEventListener('load', evt => {
+            //whenever an image is loaded, check if every other image in the span has been loaded. Only then should you show them all
             let imgs = [];
             for (let i of (evt.target as Node).parentElement?.children || []) {
               if (i.tagName == 'IMG') {
@@ -145,7 +146,7 @@ export class CoreBBCodeParser extends BBCodeParser {
               i.classList.remove('loading'); //perhaps we could use a spinner here instead of that. Tried it but it looks terrible on mosaics and the transition is smooth
             }
           });
-        } 
+        }
         parent.appendChild(img);
         return img;
       })

--- a/chat/Chat.vue
+++ b/chat/Chat.vue
@@ -89,7 +89,6 @@
               <i class="fas fa-thumbtack"></i>
             </span>
 
-            <!-- Default star (moved to the right) -->
             <span
               v-if="character.id === defaultCharacter"
               class="char-icon default-star"
@@ -535,6 +534,7 @@
       .char-icon {
         position: absolute;
         top: 6px;
+  z-index: 10;
         display: inline-flex;
         align-items: center;
         justify-content: center;

--- a/chat/Chat.vue
+++ b/chat/Chat.vue
@@ -341,6 +341,7 @@
           {
             defaultCharacter: this.defaultCharacter,
             animateEicons: core.state.settings.animatedEicons,
+            smoothMosaics: core.state.settings.smoothMosaics,
             fuzzyDates: true,
             inlineDisplayMode: InlineDisplayMode.DISPLAY_ALL
           },

--- a/chat/Chat.vue
+++ b/chat/Chat.vue
@@ -390,7 +390,8 @@
     flex-wrap: wrap;
     gap: 12px;
     max-height: 320px;
-    overflow: auto;
+    /* Allow shadows to render outside the scroll area so glows aren't clipped */
+    overflow: visible;
     padding: 6px 2px;
   }
 
@@ -418,8 +419,10 @@
   }
 
   .character-tile.selected {
-    outline: 2px solid rgba(100, 150, 255, 0.9);
-    box-shadow: 0 8px 22px rgba(50, 80, 200, 0.25);
+    outline: 2px solid var(--bs-primary);
+    box-shadow:
+      0 8px 22px rgba(var(--bs-primary-rgb), 0.25),
+      0 0 8px rgba(var(--bs-primary-rgb), 0.18);
   }
 
   .avatar-wrap {
@@ -443,9 +446,12 @@
   .char-name {
     margin-top: 6px;
     font-size: 12px;
+    width: 100%;
+    line-height: 1.2;
+    min-height: 2.4em; /* two lines at 1.2 line-height */
     overflow: hidden;
     text-overflow: ellipsis;
-    white-space: nowrap;
-    width: 100%;
+    white-space: normal;
+    word-break: break-word;
   }
 </style>

--- a/chat/Chat.vue
+++ b/chat/Chat.vue
@@ -534,7 +534,7 @@
       .char-icon {
         position: absolute;
         top: 6px;
-  z-index: 10;
+        z-index: 10;
         display: inline-flex;
         align-items: center;
         justify-content: center;

--- a/chat/Chat.vue
+++ b/chat/Chat.vue
@@ -13,17 +13,39 @@
       v-if="!connected"
     >
       <div class="alert alert-danger" v-show="error">{{ error }}</div>
-      <h3 class="card-header" style="margin-top: 0; display: flex">
+      <h3
+        class="card-header"
+        style="margin-top: 0; display: flex; align-items: center"
+      >
         {{ l('title') }}
-        <a
-          href="#"
-          @click.prevent="showLogs()"
-          class="btn"
-          style="flex: 1; text-align: right"
+        <div
+          style="
+            margin-left: auto;
+            display: flex;
+            gap:4px;
+            align-items: center;
+          "
         >
-          <span class="fa fa-file-alt"></span>
-          <span class="btn-text">{{ l('logs.title') }}</span>
-        </a>
+          <a
+            href="https://discord.gg/JYuxqNVNtP"
+            target="_blank"
+            rel="noopener"
+            class="btn"
+            title="Join our Discord"
+          >
+            <span class="fab fa-discord"></span>
+          </a>
+
+          <a
+            href="#"
+            @click.prevent="showLogs()"
+            class="btn"
+            style="text-align: right"
+          >
+            <span class="fa fa-file-alt"></span>
+            <span class="btn-text">{{ l('logs.title') }}</span>
+          </a>
+        </div>
       </h3>
       <div class="card-body">
         <h4 class="card-title">{{ l('login.selectCharacter') }}</h4>

--- a/chat/Chat.vue
+++ b/chat/Chat.vue
@@ -22,7 +22,7 @@
           style="
             margin-left: auto;
             display: flex;
-            gap:4px;
+            gap: 4px;
             align-items: center;
           "
         >
@@ -82,6 +82,7 @@
                 alt="avatar"
                 class="avatar"
               />
+              <div class="avatar-bg"></div>
             </div>
             <div class="char-name">{{ character.name }}</div>
           </div>
@@ -412,9 +413,8 @@
     flex-wrap: wrap;
     gap: 12px;
     max-height: 320px;
-    /* Allow shadows to render outside the scroll area so glows aren't clipped */
-    overflow: visible;
-    padding: 6px 2px;
+    overflow-y: auto;
+    padding: 6px 2px 26px 2px;
   }
 
   .character-tile {
@@ -425,7 +425,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
-    background: rgba(255, 255, 255, 0.02);
+    background: rgba(var(--bs-black-rgb), 0.02);
     border-radius: 8px;
     padding: 8px;
     cursor: pointer;
@@ -450,19 +450,25 @@
   .avatar-wrap {
     width: 64px;
     height: 64px;
-    border-radius: 8px;
     overflow: hidden;
     display: flex;
     align-items: center;
     justify-content: center;
-    background: rgba(0, 0, 0, 0.08);
-  }
-
-  .avatar {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
+    position: relative;
+    .avatar-bg {
+      position: absolute;
+      bottom: 0px;
+      height: 100%;
+      width: 100%;
+      border-radius: 8px;
+      background: rgba(0, 0, 0, 0.08);
+    }
+    .avatar {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      display: block;
+    }
   }
 
   .char-name {

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -50,10 +50,10 @@
               href="#"
               role="button"
               class="userInfo-button-item"
-              :title="l('settings.character')"
-              @click.prevent="showSettings()"
+              :title="l('characterSearch.open')"
+              @click.prevent="showSearch()"
             >
-              <i class="fa-solid fa-user-gear fa-fw"></i>
+              <i class="fa-solid fa-search fa-fw"></i>
             </a>
             <a
               href="#"
@@ -72,6 +72,15 @@
                 @click.prevent="stopAllAds()"
               ></span>
             </span>
+            <a
+              href="#"
+              role="button"
+              class="userInfo-button-item"
+              :title="l('settings.character')"
+              @click.prevent="showSettings()"
+            >
+              <i class="fa-solid fa-user-gear fa-fw"></i>
+            </a>
 
             <a
               href="#"
@@ -116,13 +125,6 @@
             >
           </span>
 
-          <a
-            href="#"
-            @click.prevent="showSearch()"
-            :title="l('characterSearch.open')"
-            class="btn"
-            ><span class="fas fa-fw fa-search"></span>
-          </a>
           <a
             href="#"
             @click.prevent="showRecent()"
@@ -974,7 +976,7 @@
 
   #sidebar {
     .body a.btn {
-      padding: 2px 0;
+      padding: 0px 4px;
       text-align: left;
     }
     .conversationList-header {

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -109,6 +109,19 @@
         </div>
       </div>
       <div class="mb-3">
+        <div class="form-check">
+          <input
+            class="form-check-input"
+            type="checkbox"
+            id="smoothMosaics"
+            v-model="smoothMosaics"
+          />
+          <label class="form-check-label" for="smoothMosaics">
+            {{ l('settings.smoothMosaics') }}
+          </label>
+        </div>
+      </div>
+      <div class="mb-3">
         <label class="control-label" for="idleTimer">{{
           l('settings.idleTimer')
         }}</label>
@@ -948,6 +961,7 @@
     highlightWords!: string;
     showAvatars!: boolean;
     animatedEicons!: boolean;
+    smoothMosaics!: boolean;
     idleTimer!: string;
     messageSeparators!: boolean;
     eventMessages!: boolean;
@@ -1004,6 +1018,7 @@
       this.highlightWords = settings.highlightWords.join(',');
       this.showAvatars = settings.showAvatars;
       this.animatedEicons = settings.animatedEicons;
+      this.smoothMosaics = settings.smoothMosaics;
       this.idleTimer = settings.idleTimer.toString();
       this.messageSeparators = settings.messageSeparators;
       this.eventMessages = settings.eventMessages;
@@ -1118,6 +1133,7 @@
           .filter(x => x.length),
         showAvatars: this.showAvatars,
         animatedEicons: this.animatedEicons,
+        smoothMosaics: this.smoothMosaics,
         idleTimer: isNaN(idleTimer)
           ? 0
           : idleTimer < 0

--- a/chat/ads/AdCenter.vue
+++ b/chat/ads/AdCenter.vue
@@ -70,6 +70,7 @@
   import { Component } from '@f-list/vue-ts';
   import CustomDialog from '../../components/custom_dialog';
   import Modal from '../../components/Modal.vue';
+  import AdLauncherDialog from './AdLauncher.vue';
   import { Conversation } from '../interfaces';
   import l from '../localize';
   import { Editor } from '../bbcode';
@@ -98,6 +99,7 @@
 
     async submit(): Promise<void> {
       await core.adCenter.set(this.ads);
+      (<AdLauncherDialog>this.$parent.$refs['adLauncher'])!.show();
     }
 
     addAd(): void {
@@ -141,8 +143,16 @@
   }
 
   .ad-list .form-control.form-tag {
+    .input-tag {
+      padding: 4px 3px;
+      span,
+      a.remove {
+        line-height: 100%;
+        vertical-align: middle;
+      }
+    }
+    padding-bottom: 0px;
     display: flex;
-    padding: 0px;
   }
 
   .form-group.ad-list {

--- a/chat/ads/AdLauncher.vue
+++ b/chat/ads/AdLauncher.vue
@@ -10,8 +10,15 @@
     :buttonText="'Start Posting Ads'"
     iconClass="fas fa-rectangle-ad"
   >
-    <div v-if="hasAds()">
+    <div v-if="hasAds()" style="position: relative">
+      <button
+        class="btn btn-primary position-absolute top-0 end-0"
+        @click="openAdEditor()"
+      >
+        <i class="fa-solid fa-pencil"></i> Edit Ads
+      </button>
       <h5>Ad Tags</h5>
+
       <div style="padding-bottom: 1em">
         <div class="mb-3">
           <p>Serve ads that match any one of these tags:</p>
@@ -28,9 +35,6 @@
             </label>
           </div>
         </div>
-        <button class="btn btn-outline-secondary" @click="openAdEditor()">
-          <i class="fa-solid fa-pencil"></i> Edit Ads
-        </button>
       </div>
 
       <h5>Target Channels</h5>

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -49,6 +49,7 @@ export class Settings implements ISettings {
   highlightWords: string[] = [];
   showAvatars = true;
   animatedEicons = true;
+  smoothMosaics = true;
   idleTimer = 0;
   messageSeparators = false;
   eventMessages = true;

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -261,6 +261,7 @@ export namespace Settings {
     readonly highlightWords: ReadonlyArray<string>;
     readonly showAvatars: boolean;
     readonly animatedEicons: boolean;
+    readonly smoothMosaics: boolean;
     readonly idleTimer: number;
     readonly messageSeparators: boolean;
     readonly eventMessages: boolean;

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -215,6 +215,7 @@ Are you sure?`,
     'Notify when the following characters send a message (comma-separated)',
   'settings.showAvatars': 'Show character avatars',
   'settings.animatedEicons': 'Animate [eicon]s',
+  'settings.smoothMosaics': 'Attempt to synchronise [eicon] mosaics',
   'settings.idleTimer': 'Idle timer (minutes, clear to disable)',
   'settings.messageSeparators': 'Display separators between messages',
   'settings.eventMessages':

--- a/chat/profile_api.ts
+++ b/chat/profile_api.ts
@@ -138,6 +138,7 @@ async function executeCharacterData(
 
   Utils.settings.inlineDisplayMode = data.current_user.inline_mode;
   Utils.settings.animateEicons = core.state.settings.animatedEicons;
+  Utils.settings.smoothMosaics = core.state.settings.smoothMosaics;
 
   // Add maintainer badge for Horizon developers
   const badges = [...data.badges];

--- a/electron/Changelog.vue
+++ b/electron/Changelog.vue
@@ -39,6 +39,16 @@
               ref="mdContainer"
             ></div>
             <div class="modal-footer">
+              <a
+                class="btn btn-outline-primary"
+                href="https://discord.gg/JYuxqNVNtP"
+                target="_blank"
+                rel="noopener"
+                style="margin-left: 8px"
+              >
+                <span class="fab fa-discord"></span>
+                <span style="margin-left: 6px">Join Our Discord</span>
+              </a>
               <button
                 type="button"
                 class="btn btn-secondary"

--- a/electron/Changelog.vue
+++ b/electron/Changelog.vue
@@ -143,8 +143,8 @@
           : 'v' + process.env.APP_VERSION);
       let releaseInfo: ReleaseInfo = (await Axios.get<ReleaseInfo>(apiUrl))
         .data;
-      let md = markdownit();
-      md.use(alert);
+  let md = markdownit({ html: true, linkify: true, typographer: true });
+  md.use(alert);
 
       const defaultRender =
         md.renderer.rules.link_open ||
@@ -323,5 +323,22 @@
   .disableWindowsHighContrast,
   .disableWindowsHighContrast * {
     forced-color-adjust: none;
+  }
+
+  /* Make images and embedded media inside the changelog scale to the window while keeping aspect ratio */
+  .logs-container img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0.5em auto;
+    max-height: calc(100vh - 160px);
+    object-fit: contain;
+    
+  }
+
+  .logs-container iframe,
+  .logs-container video {
+    max-width: 100%;
+    max-height: calc(100vh - 160px);
   }
 </style>

--- a/electron/Changelog.vue
+++ b/electron/Changelog.vue
@@ -143,8 +143,8 @@
           : 'v' + process.env.APP_VERSION);
       let releaseInfo: ReleaseInfo = (await Axios.get<ReleaseInfo>(apiUrl))
         .data;
-  let md = markdownit({ html: true, linkify: true, typographer: true });
-  md.use(alert);
+      let md = markdownit({ html: true, linkify: true, typographer: true });
+      md.use(alert);
 
       const defaultRender =
         md.renderer.rules.link_open ||
@@ -333,7 +333,6 @@
     margin: 0.5em auto;
     max-height: calc(100vh - 160px);
     object-fit: contain;
-    
   }
 
   .logs-container iframe,

--- a/electron/Settings.vue
+++ b/electron/Settings.vue
@@ -328,47 +328,45 @@
                       <div
                         v-for="(path, sound) in currentSoundThemeDetails.sounds"
                         :key="sound"
-                        class="sound-row"
-                        style="
-                          display: flex;
-                          align-items: center;
-                          gap: 8px;
-                          margin-bottom: 8px;
-                        "
+                        class="sound-row d-flex flex-row mb-3 align-items-center"
                       >
-                        <div style="width: 14ch; text-transform: capitalize">
+                        <div
+                          style="width: 14ch; text-transform: capitalize"
+                          class="p-2"
+                        >
                           {{ sound }}
                         </div>
                         <input
                           type="range"
+                          class="form-range p-2 flex-grow-1"
                           min="0"
                           max="1"
                           step="0.01"
                           v-model.number="liveVolumeMap[sound]"
                           @input="onVolumeChange(sound)"
-                          style="flex: 1"
+                          style="width: unset"
                         />
-                        <input
-                          type="number"
-                          min="0"
-                          max="100"
-                          step="1"
-                          style="
-                            width: 7ch;
-                            text-align: right;
-                            margin-left: 8px;
-                          "
-                          :value="Math.round((liveVolumeMap[sound] ?? 1) * 100)"
-                          @input="handlePercentInput($event, sound)"
-                        />
-                        <button
-                          class="btn btn-sm btn-outline-primary"
-                          @click.prevent.stop="previewSound(sound)"
-                          title="Preview"
-                          style="margin-left: 8px"
-                        >
-                          Preview
-                        </button>
+                        <div class="input-group p-2" style="width: unset">
+                          <input
+                            type="number"
+                            class="form-control"
+                            min="0"
+                            max="100"
+                            step="1"
+                            style="text-align: right"
+                            :value="
+                              Math.round((liveVolumeMap[sound] ?? 1) * 100)
+                            "
+                            @input="handlePercentInput($event, sound)"
+                          />
+                          <button
+                            class="btn btn-sm btn-outline-primary p-2"
+                            @click.prevent.stop="previewSound(sound)"
+                            title="Preview"
+                          >
+                            Preview
+                          </button>
+                        </div>
                       </div>
                     </div>
                   </div>

--- a/electron/changelog.html
+++ b/electron/changelog.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self' 'unsafe-inline'; img-src file: data: https://static.f-list.net; connect-src https://api.github.com https://horizn.moe"
+      content="default-src 'self' 'unsafe-inline'; img-src * data:; connect-src https://api.github.com https://horizn.moe"
     />
     <title>Horizon</title>
     <link href="fa.css" rel="stylesheet" />

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -334,6 +334,19 @@ function onReady(): void {
               browserWindows.createAboutWindow(w);
             }
           },
+          {
+            label: l(
+              process.env.NODE_ENV !== 'development'
+                ? 'version'
+                : 'developmentVersion',
+              process.env.APP_VERSION || app.getVersion()
+            ),
+            click: (_m: electron.MenuItem, w: electron.BrowserWindow) => {
+              let win = w || electron.BrowserWindow.getFocusedWindow();
+              if (!win) return;
+              browserWindows.createChangelogWindow(settings, false, win);
+            }
+          },
           { type: 'separator' },
           {
             label: l('action.newWindow'),
@@ -424,21 +437,6 @@ function onReady(): void {
           {
             label: l('help.fchat'),
             click: () => openURLExternally('https://horizn.moe/docs')
-          },
-          {
-            label: l(
-              process.env.NODE_ENV !== 'development'
-                ? 'version'
-                : 'developmentVersion',
-              process.env.APP_VERSION || app.getVersion()
-            ),
-            click: (
-              _m: electron.MenuItem,
-              w: electron.BrowserWindow,
-              _e: KeyboardEvent
-            ) => {
-              browserWindows.createChangelogWindow(settings, false, w);
-            }
           },
           // {
           //     label: l('help.feedback'),

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horizon-electron",
-  "version": "1.33.3",
+  "version": "1.33.4-beta.1",
   "author": "The F-List Team and Horizon Contributors",
   "description": "Horizon",
   "homepage": "https://horizn.moe",

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horizon-electron",
-  "version": "1.33.4-beta.1",
+  "version": "1.33.4-beta.2",
   "author": "The F-List Team and Horizon Contributors",
   "description": "Horizon",
   "homepage": "https://horizn.moe",

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -126,6 +126,7 @@ export const enum InlineDisplayMode {
 
 export interface Settings {
   animateEicons: boolean;
+  smoothMosaics: boolean;
   inlineDisplayMode: InlineDisplayMode;
   defaultCharacter: number;
   fuzzyDates: boolean;

--- a/learn/recommend/profile-recommendation.ts
+++ b/learn/recommend/profile-recommendation.ts
@@ -294,13 +294,25 @@ export class ProfileRecommendationAnalyzer {
     }
 
     if (p.species === null) {
-      this.add(
-        'SPECIES',
-        ProfileRecommendationLevel.CRITICAL,
-        'Enter species',
-        "Specifying the species of your character – even if it's 'human' – will improve your matches with other players.",
-        'https://wiki.f-list.net/Guide:_Character_Profiles#General_Details'
-      );
+      let isUnparsable =
+        this.profile.character.infotags[TagId.Species]?.string !== undefined;
+      if (isUnparsable) {
+        this.add(
+          'SPECIES',
+          ProfileRecommendationLevel.NOTE,
+          'Hard to parse species',
+          "The matcher couldn't parse your species. Only species that have default kinks can be matched.",
+          'https://wiki.f-list.net/Guide:_Character_Profiles#General_Details'
+        );
+      } else {
+        this.add(
+          'SPECIES',
+          ProfileRecommendationLevel.CRITICAL,
+          'Enter species',
+          "Specifying the species of your character – even if it's 'human' – will improve your matches with other players.",
+          'https://wiki.f-list.net/Guide:_Character_Profiles#General_Details'
+        );
+      }
     } else {
       this.add(
         'SPECIES',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fchat-horizon",
-  "version": "1.33.4-beta.1",
+  "version": "1.33.4-beta.2",
   "author": "The F-List Team and Horizon Contributors",
   "description": "A heavily modded FChat 3.0 client for F-List, continued from Rising",
   "license": "GPL-3.0-or-later",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fchat-horizon",
-  "version": "1.33.3",
+  "version": "1.33.4-beta.1",
   "author": "The F-List Team and Horizon Contributors",
   "description": "A heavily modded FChat 3.0 client for F-List, continued from Rising",
   "license": "GPL-3.0-or-later",

--- a/scss/_bbcode.scss
+++ b/scss/_bbcode.scss
@@ -213,6 +213,11 @@ div.indentText {
     height: 50px;
     width: 50px;
   }
+  transition: opacity 1s;
+  &.loading{
+    opacity: 0;
+    visibility:hidden;
+  }
 }
 
 .bbcode {

--- a/scss/_bbcode.scss
+++ b/scss/_bbcode.scss
@@ -214,9 +214,9 @@ div.indentText {
     width: 50px;
   }
   transition: opacity 1s;
-  &.loading{
+  &.loading {
     opacity: 0;
-    visibility:hidden;
+    visibility: hidden;
   }
 }
 

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -216,7 +216,7 @@
     }
     flex: auto;
     padding: 5px 3px 5px 3px;
-    min-width: 55px;
+    min-width: 50px;
     text-align: center;
     font-size: 1.15rem;
     display: inline-block;

--- a/scss/themes/chat/default.scss
+++ b/scss/themes/chat/default.scss
@@ -42,7 +42,7 @@
 }
 
 :root {
-  color-scheme: light;
+  color-scheme: dark;
 }
 
 //@import "../../util/accecss";

--- a/scss/themes/chat/dracula.scss
+++ b/scss/themes/chat/dracula.scss
@@ -83,7 +83,7 @@ $genders: (
 }
 
 .message-own:not(.message-warn) {
-  background-color: rgba($gray-300, 0.7);
+  background-color: rgba($gray-200, 0.7);
 }
 
 .colorblindMode {

--- a/scss/themes/chat/mars.scss
+++ b/scss/themes/chat/mars.scss
@@ -74,7 +74,7 @@ body,
 }
 
 :root {
-  color-scheme: light;
+  color-scheme: dark;
 }
 
 $genders: (

--- a/scss/themes/chat/moon-prism.scss
+++ b/scss/themes/chat/moon-prism.scss
@@ -1,0 +1,211 @@
+@use 'sass:color';
+@import '../../functions';
+@import '~bootstrap/scss/functions';
+@import '../variables/moon_prism_variables';
+@import '~bootstrap/scss/variables';
+@import '../../flist_derived';
+@import '../variables/default_derived';
+
+$red-color: $moon-prism-red;
+$green-color: $moon-prism-green;
+$blue-color: $moon-prism-blue;
+$yellow-color: $moon-prism-gold;
+$purple-color: $moon-prism-purple;
+$cyan-color: $moon-prism-cyan;
+$white-color: $black;
+$black-color: #b8c2e0;
+$brown-color: $moon-prism-orange;
+$pink-color: $moon-prism-pink;
+$gray-color: $moon-prism-silver;
+$orange-color: $moon-prism-orange;
+
+@import '../chat';
+
+body,
+.modal-body {
+  background: #1a1b2e;
+  background: linear-gradient(
+    135deg,
+    rgba(26, 27, 46, 1) 0%,
+    rgba(10, 11, 20, 1) 40%,
+    rgba(18, 22, 42, 1) 100%
+  );
+}
+
+.sidebar {
+  background-color: rgba($body-bg, 0.4);
+}
+
+.message-own:not(.message-warn) {
+  background-color: rgba($gray-200, 0.65);
+}
+
+* {
+  &::-webkit-scrollbar-track {
+    box-shadow: inset 0 0 2px $card-border-color;
+    border-radius: 10px;
+  }
+
+  &::-webkit-scrollbar {
+    width: 8px;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    border-radius: 10px;
+    box-shadow: inset 0 0 2px rgba(0, 0, 0, 0.8);
+    background-color: $gray-300;
+    &:hover {
+      background-color: $gray-500;
+    }
+
+    &:active {
+      background-color: $gray-700;
+    }
+  }
+}
+
+$genders: (
+  'shemale': $moon-prism-magenta,
+  'herm': $moon-prism-purple,
+  'none': $black-color,
+  'female': $moon-prism-pink,
+  'male': $moon-prism-blue,
+  'male-herm': $moon-prism-cyan,
+  'transgender': $moon-prism-orange,
+  'cunt-boy': $moon-prism-green
+);
+
+.list-group.conversation-nav
+  .list-group-item-action.item-private.active
+  .online-status {
+  color: color-contrast($primary);
+}
+
+@each $gender, $color in $genders {
+  .gender-#{$gender} {
+    color: $color;
+  }
+
+  .message-event .gender-#{$gender} {
+    color: color.scale($color, $lightness: 5%);
+  }
+}
+
+.message-highlight {
+  .blackText,
+  .blackNameText,
+  .gender-none {
+    color: #d4d9ff;
+  }
+  .redText,
+  .redNameText {
+    color: #ffb3b3;
+  }
+  .gender-cunt-boy,
+  .greenText,
+  .greenNameText {
+    color: #b3ffcc;
+  }
+  .gender-female,
+  .pinkText,
+  .pinkNameText {
+    color: #ffb3e0;
+  }
+  .gender-male,
+  .blueText,
+  .blueNameText {
+    color: #b3ccff;
+  }
+  .grayText,
+  .grayNametext {
+    color: #e6ecff;
+  }
+  .yellowText,
+  .yellowNameText {
+    color: #ffe6b3;
+  }
+  .gender-transgender,
+  .orangeText,
+  .orangeNameText {
+    color: #ffccb3;
+  }
+  .gender-male-herm,
+  .cyanText,
+  .cyanNameText {
+    color: #b3ffff;
+  }
+}
+
+.message-warn {
+  .pinkText,
+  .pinkNameText,
+  .gender-female {
+    color: #ff66c7;
+  }
+  .whiteText,
+  .whiteNameText {
+    color: $white;
+  }
+  .brownText,
+  .brownNameText {
+    color: #332d1a;
+  }
+  .blueText,
+  .blueNameText,
+  .gender-male {
+    color: #4d79ff;
+  }
+  .yellowText,
+  .yellowNameText {
+    color: #ffeb4d;
+  }
+  .greenText,
+  .greenNameText,
+  .gender-cunt-boy {
+    color: #66ff80;
+  }
+  .redText,
+  .redNameText,
+  .gender-herm {
+    color: #ff6666;
+  }
+  .orangeText,
+  .orangeNameText,
+  .brownNameText,
+  .brownText,
+  .gender-transgender {
+    color: #ff9966;
+  }
+  .purpleText,
+  .purpleNameText,
+  .gender-shemale {
+    color: #cc66ff;
+  }
+  .cyanText,
+  .cyanNameText,
+  .gender-male-herm {
+    color: #66ffff;
+  }
+  .grayText,
+  .grayNametext {
+    color: #cccccc;
+  }
+  .blackText,
+  .blackNameText,
+  .gender-none {
+    color: #f0f2ff;
+  }
+}
+
+.colorblindMode {
+  @import '../colorblind';
+  @import '../../rising';
+
+  @each $varName, $value in $risingVariables {
+    --#{$varName}: #{$value};
+  }
+}
+
+:root {
+  color-scheme: dark;
+}

--- a/scss/themes/variables/_moon_prism_variables.scss
+++ b/scss/themes/variables/_moon_prism_variables.scss
@@ -1,0 +1,120 @@
+@use 'sass:color';
+
+$gray-base: #0d0e1a;
+$white: $gray-base;
+$gray-100: color.scale($gray-base, $lightness: 10%);
+$gray-200: color.scale($gray-base, $lightness: 20%);
+$gray-300: color.scale($gray-base, $lightness: 30%, $saturation: 5%);
+$gray-400: color.scale($gray-base, $lightness: 40%, $saturation: 5%);
+$gray-500: color.scale($gray-base, $lightness: 50%, $saturation: 10%);
+$gray-600: color.scale($gray-base, $lightness: 60%, $saturation: 10%);
+$gray-700: color.scale($gray-base, $lightness: 70%, $saturation: 15%);
+$gray-800: color.scale($gray-base, $lightness: 80%);
+$gray-900: color.scale($gray-base, $lightness: 90%);
+$black: #f8f9ff;
+
+$light-color: $black;
+$dark-color: $gray-base;
+$component-active-color: $dark-color; // Use dark color for light primary
+
+$moon-prism-silver: #c8d5e8;
+$moon-prism-blue: #6b8cff;
+$moon-prism-purple: #a685ff;
+$moon-prism-pink: #ff85c7;
+$moon-prism-cyan: #85ffff;
+$moon-prism-gold: #ffd785;
+$moon-prism-green: #85ff9a;
+$moon-prism-red: #ff8585;
+$moon-prism-magenta: #d485ff;
+$moon-prism-orange: #ffb785;
+
+$primary: #8ba4d9;
+$secondary: $gray-400;
+$success: $moon-prism-green;
+$info: color.scale($moon-prism-blue, $lightness: -30%);
+$warning: $moon-prism-gold;
+$danger: $moon-prism-red;
+$light: $gray-200;
+$text-muted: $gray-500;
+$text-dark: $gray-600;
+
+$body-bg: $gray-100;
+$link-color: $gray-800;
+$link-hover-color: color.scale($link-color, $lightness: 15%);
+$dropdown-bg: $gray-200;
+$dropdown-divider-bg: $gray-300;
+
+$modal-backdrop-bg: $white;
+$modal-content-bg: $gray-200;
+$modal-header-border-color: $gray-300;
+
+$component-active-color: $dark-color;
+$grid-gutter-width: 20px;
+
+$input-bg: $gray-200;
+$input-color: $black;
+$custom-select-bg: $gray-200;
+$form-check-input-checked-bg-color: $primary;
+
+$list-group-bg: $gray-200;
+
+$pagination-active-color: $link-color;
+
+$text-background-color: $gray-200;
+$text-background-color-disabled: $gray-100;
+
+$scorePerfectMatchBg: rgb(0, 173, 173);
+$scorePerfectMatchFg: rgb(29, 154, 154);
+$scoreMatchBg: rgb(0, 142, 0);
+$scoreMatchFg: rgb(0, 113, 0);
+$scoreWeakMatchBg: rgb(0, 80, 0);
+$scoreWeakMatchFg: rgb(0, 64, 0);
+$scoreWeakMismatchBg: rgb(152, 134, 0);
+$scoreWeakMismatchFg: rgb(121, 107, 0);
+$scoreMismatchBg: rgb(192, 0, 0);
+$scoreMismatchFg: rgb(148, 0, 0);
+$scoreTitleColor: rgb(255, 255, 255);
+$scoreMinimizeButtonFg: rgba(255, 255, 255, 0.6);
+$scoreMinimizeButtonBg: rgba(0, 0, 0, 0.2);
+$scoreReportBg: rgba(0, 0, 0, 0.2);
+
+$scoreFadedPerfectMatchBg: color.scale($scorePerfectMatchBg, $alpha: -60%);
+$scoreFadedPerfectMatchFg: color.scale($scorePerfectMatchFg, $alpha: -60%);
+$scoreFadedMatchBg: color.scale($scoreMatchBg, $alpha: -60%);
+$scoreFadedMatchFg: color.scale($scoreMatchFg, $alpha: -60%);
+$scoreFadedWeakMatchBg: color.scale($scoreWeakMatchBg, $alpha: -60%);
+$scoreFadedWeakMatchFg: color.scale($scoreWeakMatchFg, $alpha: -60%);
+$scoreFadedWeakMismatchBg: color.scale($scoreWeakMismatchBg, $alpha: -60%);
+$scoreFadedWeakMismatchFg: color.scale($scoreWeakMismatchFg, $alpha: -60%);
+$scoreFadedMismatchBg: color.scale($scoreMismatchBg, $alpha: -60%);
+$scoreFadedMismatchFg: color.scale($scoreMismatchFg, $alpha: -60%);
+
+$scoreStandoutMatchBorderColor: #04a604;
+$scoreStandoutMatchBgColor: rgba(0, 166, 0, 0.47);
+$scoreStandoutWeakMatchBorderColor: #026502;
+$scoreStandoutWeakMatchBgColor: rgba(0, 101, 0, 0.4);
+$scoreStandoutNeutralBorderColor: #8ba4d9;
+$scoreStandoutWeakMismatchBorderColor: rgb(166, 148, 0);
+$scoreStandoutWeakMismatchBgColor: rgba(255, 215, 0, 0.2);
+$scoreStandoutMismatchBorderColor: #a41a1a;
+
+$characterImageWrapperBg: rgba(13, 14, 26, 0.3);
+$characterGuestbookPostBg: rgba(13, 14, 26, 0.25);
+$characterGuestbookPostBorderColor: rgba(139, 164, 217, 0.1);
+$characterGuestbookReplyBg: rgba(13, 14, 26, 0.15);
+$characterGuestbookTimestampFg: rgba(248, 249, 255, 0.4);
+$characterKinkCustomColor: $moon-prism-gold;
+$characterKinkCustomBorderColor: rgba(139, 164, 217, 0.1);
+$characterKinkStockColor: #d6e1f7;
+$characterKinkStockHighlightedColor: $black;
+$characterInfotagColor: rgba(248, 249, 255, 0.7);
+
+$messageTimeBgColor: $gray-300;
+$messageTimeFgColor: $gray-800;
+
+$headerBackgroundMaskColor: $gray-200;
+
+$linkForcedColor: $moon-prism-silver;
+$tabSecondaryFgColor: rgba(248, 249, 255, 0.5);
+
+@import 'invert';

--- a/site/utils.ts
+++ b/site/utils.ts
@@ -83,6 +83,7 @@ export let staticDomain = '';
 
 export let settings: Settings = {
   animateEicons: true,
+  smoothMosaics: true,
   inlineDisplayMode: InlineDisplayMode.DISPLAY_ALL,
   defaultCharacter: -1,
   fuzzyDates: true


### PR DESCRIPTION
## Summary
Adds **Moon Prism** theme to F-Chat Horizon (Sailor Moon inspired) 

## Implementation
- Added new theme alongside existing themes.
- Registered in the theme index so it appears in settings.
- No variables or files changed outside theme files this time.
- Removed comments by Copilot

## Testing
- Built and tested in Electron on Linux Mint
- Verified sidebar, channel list, message view, composer, modals, and hover/focus states. - I took a screenshot of the console, login page, and HelpDesk channel as a character

## Screenshots
<img width="1597" height="754" alt="2025-08-27_17-49" src="https://github.com/user-attachments/assets/55dc7329-912f-451a-baf6-040bb3ab9493" />
<img width="1180" height="715" alt="2025-08-27_17-50" src="https://github.com/user-attachments/assets/d37e7d43-3536-4fa4-9f8b-9b4ca89e9e38" />
<img width="1395" height="683" alt="2025-08-27_17-50_1" src="https://github.com/user-attachments/assets/5508b790-77df-43fa-a2aa-edf1beb9ce65" />

