### PR TITLE
Fixes theme-color-level instances no longer scaling after Bootstrap 5

### DIFF
--- a/scss/_character_page.scss
+++ b/scss/_character_page.scss
@@ -48,9 +48,9 @@
     }
 
     &.character-badge-maintainer {
-      background-color: theme-color-bg('success');
-      border: 1px solid theme-color-border('success');
-      color: theme-color-level('success', 8);
+      background-color: mix($white, $success, 10 * 8%);
+      border: 1px solid mix($white, $success, 9 * 8%);
+      color: mix($black, $success, 8 * 8%);
       font-weight: bold;
     }
   }

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -319,8 +319,7 @@
 
 .messages-both {
   .message-ad:not(.message-score) {
-    --bs-bg-opacity: 0.3;
-    background-color: rgba(var(--bs-info-rgb), var(--bs-bg-opacity)) !important;
+    background-color: mix($white, $info, 4 * 8%);
     padding: 0 2px 2px 2px;
     box-shadow: $gray-500 -2px -2px 2px inset;
   }
@@ -364,7 +363,7 @@
 }
 
 .message-highlight {
-  background-color: color.scale($color: $success, $alpha: -70%);
+  background-color: mix($white, $success, 4 * 8%);
 }
 
 .message-action .bbcode {

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -7,7 +7,7 @@
 .btn-primary,
 .btn-primary:hover,
 .btn-primary:active {
-  color: color-yiq(theme-color('primary'));
+  color: color-yiq($primary);
 }
 
 .bg-solid-text {
@@ -37,7 +37,7 @@
 }
 
 .has-new {
-  background-color: theme-color-level('danger', 4) !important;
+  background-color: mix($black, $danger, 4 * 8%) !important;
 }
 @keyframes throb {
   0% {
@@ -265,7 +265,7 @@
 }
 .ads-text-box,
 .ads-text-box:focus {
-  background-color: theme-color-level('info', -4);
+  background-color: mix($white, $info, 4 * 8%);
 }
 
 .border-top {
@@ -376,7 +376,7 @@
 }
 
 .last-read {
-  border-bottom: solid 2px theme-color-level('success', -2) !important;
+  border-bottom: solid 2px mix($white, $success, 2 * 8%) !important;
 }
 
 .fas.active {
@@ -463,11 +463,11 @@ $genders: (
 
 #window-tabs {
   .hasNew {
-    background-color: theme-color-level('warning', -2);
-    border-color: theme-color-level('warning', -4);
+    background-color: mix($white, $warning, 2 * 8%);
+    border-color: mix($white, $warning, 4 * 8%);
     color: color-contrast($warning);
     &:hover {
-      background-color: theme-color-level('warning', -4);
+      background-color: mix($white, $warning, 4 * 8%);
     }
   }
   .tab:not(.active):not(:hover) {

--- a/scss/_flist_derived.scss
+++ b/scss/_flist_derived.scss
@@ -19,25 +19,25 @@ $text-dark: $text-muted !default;
 
 // Character page quick kink comparison
 $quick-compare-active-border: $black-color !default;
-$quick-compare-favorite-bg: theme-color-level('info', -6) !default;
-$quick-compare-yes-bg: theme-color-level('success', -6) !default;
-$quick-compare-maybe-bg: theme-color-level('warning', -6) !default;
-$quick-compare-no-bg: theme-color-level('danger', -6) !default;
+$quick-compare-favorite-bg: mix($white, $info, 6 * 8%) !default;
+$quick-compare-yes-bg: mix($white, $success, 6 * 8%) !default;
+$quick-compare-maybe-bg: mix($white, $warning, 6 * 8%) !default;
+$quick-compare-no-bg: mix($white, $danger, 6 * 8%) !default;
 
 // character page badges
 $character-badge-bg: color.scale($body-bg, $lightness: -10%) !default;
 $character-badge-border: color.scale($border-color, $lightness: -10%) !default;
-$character-badge-subscriber-bg: theme-color-bg('info') !default;
-$character-badge-subscriber-border: theme-color-border('info') !default;
+$character-badge-subscriber-bg: mix($white, $info, 10 * 8%) !default;
+$character-badge-subscriber-border: mix($white, $info, 9 * 8%) !default;
 
 // Character editor
 $character-list-selected-border: $success !default;
 $character-image-selected-border: $success !default;
 
 // Notes conversation view
-$note-conversation-you-bg: theme-color-bg('info') !default;
-$note-conversation-you-text: theme-color-level('info', 6) !default;
-$note-conversation-you-border: theme-color-border('info') !default;
+$note-conversation-you-bg: mix($white, $info, 10 * 8%) !default;
+$note-conversation-you-text: mix($black, $info, 6 * 8%) !default;
+$note-conversation-you-border: mix($white, $info, 9 * 8%) !default;
 $note-conversation-them-bg: $card-bg !default;
 $note-conversation-them-text: $body-color !default;
 $note-conversation-them-border: $card-border-color !default;

--- a/scss/_tag_input.scss
+++ b/scss/_tag_input.scss
@@ -33,11 +33,11 @@
 }
 
 .tag-error {
-  border: 1px solid theme-color-level(danger, $alert-border-level);
-  background-color: theme-color-level(danger, $alert-bg-level);
+  border: 1px solid mix($black, $danger, $alert-border-level * 8%);
+  background-color: mix($white, $danger, abs($alert-bg-level) * 8%);
   .tag-input {
-    text-color: theme-color-level(danger, $alert-color-level);
-    background-color: theme-color-level(danger, $alert-bg-level);
+    text-color: mix($black, $danger, $alert-color-level * 8%);
+    background-color: mix($white, $danger, abs($alert-bg-level) * 8%);
   }
 }
 

--- a/scss/themes/chat/wilted-rose.scss
+++ b/scss/themes/chat/wilted-rose.scss
@@ -39,8 +39,8 @@ body,
 }
 
 .list-group-item-danger {
-  color: theme-color-level('danger', -9);
-  background-color: theme-color-level('danger', -7);
+  color: mix($white, $danger, 9 * 8%);
+  background-color: mix($white, $danger, 7 * 8%);
 }
 
 .colorblindMode {

--- a/scss/themes/variables/_invert.scss
+++ b/scss/themes/variables/_invert.scss
@@ -3,7 +3,7 @@
 @use 'sass:math';
 
 // Theme color interval
-$theme-color-interval: 10%;
+$theme-color-interval: 8%;
 
 // Bootstrap 5 shade and tint mixins for dark themes
 // In Bootstrap 4, dark themes were not officially supported, so the original version of this function was


### PR DESCRIPTION
Bootstrap 4 scaled a bunch of these things with a function called ``theme-color-level``, which was deprecated in BS5 and they instead want us to use their new colour system.

 These colours then stopped scaling for us, but since the function just scaled stuff with a specific percentage (8%) and then mixed it with black or white depending on whether we pass it a positive or negative integer... we can just do it manually and get the exact same colours back :^)


Todo:

- [x] Fix existing instances of theme-color-level functions
- [ ] Remove my shitty attempts at porting the function to BS5 (which did nothing)
- [ ] Find instances where theme-color-level was removed for something else and bring them back with this new calculation.