### PR TITLE
Fix archive export corruption

### DIFF
--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -318,6 +318,49 @@
       });
     }
 
+    sanitizeConversationName(name: string): string {
+      /*
+       * Replace characters that are forbidden in paths with an underscore.
+       * This list should cover Unix, Windows and macOS.
+       * Files and folders also may not end with spaces.
+       */
+      let sanitizedName = name.replace(/[\/<>:"\\|?*.]/g, '_').trimRight();
+
+      /*
+       * For Windows, certain names are forbidden, too.
+       */
+      if (
+        [
+          'CON',
+          'PRN',
+          'AUX',
+          'NUL',
+          'COM1',
+          'COM2',
+          'COM3',
+          'COM4',
+          'COM5',
+          'COM6',
+          'COM7',
+          'COM8',
+          'COM9',
+          'LPT1',
+          'LPT2',
+          'LPT3',
+          'LPT4',
+          'LPT5',
+          'LPT6',
+          'LPT7',
+          'LPT8',
+          'LPT9'
+        ].includes(sanitizedName)
+      ) {
+        sanitizedName += '_';
+      }
+
+      return sanitizedName;
+    }
+
     downloadDay(): void {
       if (
         this.selectedConversation === undefined ||
@@ -326,7 +369,7 @@
       )
         return;
       const html = Dialog.confirmDialog(l('logs.html'));
-      const name = `${this.selectedConversation.name}-${formatDate(new Date(this.selectedDate))}.${html ? 'html' : 'txt'}`;
+      const name = `${this.sanitizeConversationName(this.selectedConversation.name)}-${formatDate(new Date(this.selectedDate))}.${html ? 'html' : 'txt'}`;
       this.download(
         name,
         `data:${encodeURIComponent(name)},${encodeURIComponent(getLogs(this.messages, html))}`
@@ -349,7 +392,7 @@
         );
       }
       this.download(
-        `${this.selectedConversation.name}.zip`,
+        `${this.sanitizeConversationName(this.selectedConversation.name)}.zip`,
         URL.createObjectURL(new Blob([zip.toBuffer()]))
       );
     }
@@ -374,7 +417,7 @@
             date
           );
           zip.addFile(
-            `${conv.name}/${formatDate(date)}.${html ? 'html' : 'txt'}`,
+            `${this.sanitizeConversationName(conv.name)}/${formatDate(date)}.${html ? 'html' : 'txt'}`,
             Buffer.from(getLogs(messages, html), 'utf-8')
           );
         }

--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -405,11 +405,17 @@
         return;
       const zip = new AdmZip();
       const html = Dialog.confirmDialog(l('logs.html'));
+      const existingConversationNames = new Array<string>();
       for (const conv of this.conversations) {
         const dates = await core.logs.getLogDates(
           this.selectedCharacter,
           conv.key
         );
+        let sanitizedConvName = this.sanitizeConversationName(conv.name);
+        while (existingConversationNames.includes(sanitizedConvName)) {
+          sanitizedConvName += '_';
+        }
+        existingConversationNames.push(sanitizedConvName);
         for (const date of dates) {
           const messages = await core.logs.getLogs(
             this.selectedCharacter,
@@ -417,7 +423,7 @@
             date
           );
           zip.addFile(
-            `${this.sanitizeConversationName(conv.name)}/${formatDate(date)}.${html ? 'html' : 'txt'}`,
+            `${sanitizedConvName}/${formatDate(date)}.${html ? 'html' : 'txt'}`,
             Buffer.from(getLogs(messages, html), 'utf-8')
           );
         }

--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -335,7 +335,7 @@
 
     async downloadConversation(): Promise<void> {
       if (this.selectedConversation === undefined) return;
-      const zip = new Zip();
+      const zip = new AdmZip();
       const html = Dialog.confirmDialog(l('logs.html'));
       for (const date of this.dates) {
         const messages = await core.logs.getLogs(
@@ -345,12 +345,12 @@
         );
         zip.addFile(
           `${formatDate(date)}.${html ? 'html' : 'txt'}`,
-          getLogs(messages, html)
+          Buffer.from(getLogs(messages, html), 'utf-8')
         );
       }
       this.download(
         `${this.selectedConversation.name}.zip`,
-        URL.createObjectURL(zip.build())
+        URL.createObjectURL(new Blob([zip.toBuffer()]))
       );
     }
 

--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -144,7 +144,7 @@
   import { Conversation, Logs as LogInterface } from './interfaces';
   import l from './localize';
   import MessageView from './message_view';
-  import Zip from './zip';
+  import AdmZip from 'adm-zip';
   import { Dialog } from '../helpers/dialog';
 
   function formatDate(this: void, date: Date): string {
@@ -360,10 +360,9 @@
         !Dialog.confirmDialog(l('logs.confirmExport', this.selectedCharacter))
       )
         return;
-      const zip = new Zip();
+      const zip = new AdmZip();
       const html = Dialog.confirmDialog(l('logs.html'));
       for (const conv of this.conversations) {
-        zip.addFile(`${conv.name}/`, '');
         const dates = await core.logs.getLogDates(
           this.selectedCharacter,
           conv.key
@@ -376,13 +375,13 @@
           );
           zip.addFile(
             `${conv.name}/${formatDate(date)}.${html ? 'html' : 'txt'}`,
-            getLogs(messages, html)
+            Buffer.from(getLogs(messages, html), 'utf-8')
           );
         }
       }
       this.download(
         `${this.selectedCharacter}.zip`,
-        URL.createObjectURL(zip.build())
+        URL.createObjectURL(new Blob([zip.toBuffer()]))
       );
     }
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@cliqz/adblocker-electron": "1.34.0",
     "@cliqz/adblocker-electron-preload": "1.34.0",
     "@cliqz/adblocker-extended-selectors": "1.34.0",
+    "adm-zip": "^0.5.16",
     "husky": "^9.1.7",
     "jquery": "^3.7.1",
     "lint-staged": "^15.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@cliqz/adblocker-extended-selectors':
         specifier: 1.26.16
         version: 1.26.16
+      adm-zip:
+        specifier: ^0.5.16
+        version: 0.5.16
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -825,6 +828,10 @@ packages:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  adm-zip@0.5.16:
+    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
+    engines: {node: '>=12.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -5966,6 +5973,8 @@ snapshots:
       negotiator: 0.6.3
 
   acorn@8.15.0: {}
+
+  adm-zip@0.5.16: {}
 
   agent-base@6.0.2(supports-color@10.0.0):
     dependencies:


### PR DESCRIPTION
fix: Replace custom zip solution with adm-zip package to fix export corruption when logs contain certain characters

This would resolve #213 

This PR is a bit of a "suggestion."

I have added the adm-zip package, which is a small package that utilizes Node's zlib to compress archives. I've chosen this because it has no other dependencies and it supports creating archives in memory, as well as streaming the result to a buffer, which allows triggering the download like Horizon did before.

**Upsides**:
- Archives no longer get corrupted when logs and/or channel names contain certain characters
- Emoji (at least some) are correctly represented in folder names within the zip file

**Downsides**:
- adm-zip does not support selecting a compression level, and it always applies compression to some degree, which increases processing time


If you don't like this solution, feel free to reject and I'll try something else. ✌️