### PR TITLE
Adjustments to modern chat UI - Probably needs optomising and definitely needs toggles.

### DIFF
--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -300,12 +300,13 @@
       @scroll="onMessagesScroll"
       style="flex: 1; overflow: auto; margin-top: 2px"
     >
-      <template v-for="message in messages">
+      <template v-for="(message, i) in messages">
         <message-view
           :message="message"
           :channel="isChannel(conversation) ? conversation.channel : undefined"
           :key="message.id"
           :classes="message == conversation.lastRead ? 'last-read' : ''"
+          :previous="messages[i - 1]"
         >
         </message-view>
         <span

--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -117,10 +117,11 @@
       @scroll="onMessagesScroll"
     >
       <message-view
-        v-for="message in displayedMessages"
+        v-for="(message, i) in displayedMessages"
         :message="message"
         :key="message.id"
         :logs="true"
+        :previous="messages[i - 1]"
       ></message-view>
     </div>
     <div class="input-group" style="flex-shrink: 0">

--- a/chat/message_view.ts
+++ b/chat/message_view.ts
@@ -65,11 +65,6 @@ const userPostfix: { [key: number]: string | undefined } = {
       if (layoutMode === 'modern') {
         // Modern layout: separate avatar column so time can sit directly after name
         const headerChildren: VNodeChildrenArrayContents = [];
-        if (message.type === Conversation.Message.Type.Action) {
-          headerChildren.push(
-            createElement('i', { class: 'message-pre fas fa-star-of-life' })
-          );
-        }
         headerChildren.push(
           createElement(UserView, {
             props: {
@@ -145,10 +140,16 @@ const userPostfix: { [key: number]: string | undefined } = {
       if ('isHighlight' in message && message.isHighlight)
         classes += ' message-highlight';
     }
+
+    const isModernAction =
+      layoutMode === 'modern' &&
+      message.type === Conversation.Message.Type.Action;
     const isAd = message.type === Conversation.Message.Type.Ad && !this.logs;
     const bbcodeNode = createElement(BBCodeView(core.bbCodeParser), {
       props: {
-        unsafeText: message.text,
+        unsafeText: isModernAction
+          ? ' ' + message.sender.name + message.text
+          : message.text,
         afterInsert: isAd
           ? (elm: HTMLElement) => {
               setImmediate(() => {
@@ -169,9 +170,20 @@ const userPostfix: { [key: number]: string | undefined } = {
 
     if (layoutMode === 'modern') {
       if (modernInner && modernInner.children) {
-        (modernInner.children as VNodeChildrenArrayContents).push(
-          createElement('div', { staticClass: 'message-content' }, [bbcodeNode])
-        );
+        if (message.type === Conversation.Message.Type.Action) {
+          (modernInner.children as VNodeChildrenArrayContents).push(
+            createElement('div', { staticClass: 'message-content' }, [
+              createElement('i', { class: 'message-pre fas fa-star-of-life' }),
+              bbcodeNode
+            ])
+          );
+        } else {
+          (modernInner.children as VNodeChildrenArrayContents).push(
+            createElement('div', { staticClass: 'message-content' }, [
+              bbcodeNode
+            ])
+          );
+        }
       } else {
         // fallback just append bbcode
         children.push(bbcodeNode);

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -293,9 +293,7 @@
 
 .message-block {
   padding: 1px 0;
-  &:not(:last-child) {
-    border-bottom: solid 1px $card-border-color;
-  }
+  border-top: solid 1px $card-border-color;
 }
 
 .message-own {
@@ -396,7 +394,7 @@
       border-radius: 2px;
     }
     .message-avatar-spacer {
-      height: 1px;
+      height: 0px;
     }
     .message-modern-inner {
       flex: 1;
@@ -426,7 +424,7 @@
       }
     }
     .message-content {
-      margin-top: 2px;
+      margin-top: 0px;
       min-width: 0;
       .bbcode {
         background: transparent;


### PR DESCRIPTION
So, putting this here while I work on it a little more but this fixes /me interactions being a little janky. I've put a few screenies in the discord earlier for that.

The primary thing this includes is grouping (needs toggle implemented as of time of writing) like discord does, it's set to group every message someone makes 2 minutes after their last AS LONG AS nothing else interrupts between it. Needs some more testing and all. 
The primary issue with this is that it stores the entirety of the previous message in the current messageView every time. I don't imagine the RAM hit will be significant but it may be worth figuring out something better. Either me or someone who is signficantly smarter than me.

I'd work on it more before sending but it is 1 AM and this is for something that's likely going in 1.34 anyway so there should be time to fix it up. Can gather some more screens and put them in here later too.