### PR TITLE
1.33.5 Pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
-_Nothing yet._
+## [1.33.5] - 2025-09-03
+
+### Added
+
+- The dismiss buttons for the note/ site messages checker have been brought back. Dismissed notifications will keep the icon, but will not have the number count visible. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/6cd75849f678b6f587093fa6a41017723ef4f304)
+- Added reduced motion accessibility support for our custom animations. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/10c7e46f1dc67e69af8a4aa51fbb67bbbd5b02fe)
+
+### Fixed
+
+- Fixes some cases where using the color picker keybind would make people accidentally overwrite their selected text. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/8a7423028520698ad0a111c7bc5e33926c4691c8)
+- Fixes some cases where BBCode would parse correctly where it wouldn't in vanilla 3.0, for consistency with other users. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/08a15531572219dc37be2b4b2601fe0e29e08436)
+- Fixes the user right click menu becoming unnecessarily wide for longer names if those names need multiple lines (and thus won't need the horizontal space anymore). [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/96021e74d9568730c4c90205d60c8001fca5999c)
+- Fixes select dropdowns (like those found in the settings menu, or the log viewer) not using the same width as the main element. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/b56657f83dd3cb328dc12bda06027ca5f55bf098)
+  - This also fixes those selection dropdowns not having a mouse over colour in light themes.
+- Fixes search results for characters not set to 'Looking' having a broken layout if their status message was considerably tall. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/c0407949ea979ee1797cd99a35918faaf3deb1f0)
+
+### Changed
+
+- Profiles without a species no longer default to "human" for the matcher. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/7ebaad62e3d7803f7c1ddd9d21812fb4df84e50f)
+- The ping highlight colour has been corrected back to a less bright shade of green. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/29d280df3cf7a3c56b9f43ec6ef5511edc05ecce)
+- Broken inline tags no longer display their bbcode on profiles (which they don't on the website either). [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/2adb0e6c3dbe6aa08c191bd1281c57da9dddbf50)
+- Sending a message now sets the conversation as read, instead of keeping the 'last read' green line in limbo. [[Commit]](https://github.com/Fchat-Horizon/Horizon/commit/4fc11027f743325cbec641aeb4084c4995f7ee08)
+
+### Merged Pull Requests
+
+- https://github.com/Fchat-Horizon/Horizon/pull/281 by @BootsieWootsie
+- https://github.com/Fchat-Horizon/Horizon/pull/336 by @BootsieWootsie
 
 # [Releases]
 

--- a/bbcode/core.ts
+++ b/bbcode/core.ts
@@ -81,22 +81,6 @@ export class CoreBBCodeParser extends BBCodeParser {
     this.addTag(new BBCodeSimpleTag('s', 'del'));
     this.addTag(new BBCodeSimpleTag('noparse', 'span', [], []));
     this.addTag(
-      new BBCodeSimpleTag(
-        'sub',
-        'sub',
-        [],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
-      )
-    );
-    this.addTag(
-      new BBCodeSimpleTag(
-        'sup',
-        'sup',
-        [],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
-      )
-    );
-    this.addTag(
       new BBCodeTextTag('icon', (parser, parent, param, content) => {
         if (param.length > 0)
           parser.warning('Unexpected parameter on icon tag.');

--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -31,21 +31,30 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
       'hr',
       [],
       [
-        'collapse',
-        'justify',
-        'center',
-        'left',
-        'right',
         'url',
         'i',
-        'u',
         'b',
-        'color',
+        'u',
         's',
-        'big',
+        'color',
         'sub',
+        'sup',
+        'big',
+        'small',
+        'heading',
         'hr',
-        'img'
+        'icon',
+        'user',
+        'img',
+        'eicon',
+        'quote',
+        'collapse',
+        'left',
+        'center',
+        'right',
+        'justify',
+        'indent',
+        'noparse'
       ]
     );
     hrTag.noClosingTag = true;
@@ -66,6 +75,8 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
     this.addTag(new BBCodeSimpleTag('right', 'span', ['rightText']));
     this.addTag(new BBCodeSimpleTag('center', 'span', ['centerText']));
     this.addTag(new BBCodeSimpleTag('justify', 'span', ['justifyText']));
+    this.addTag(new BBCodeSimpleTag('sub', 'sub', [], ['i', 'u', 'b', 'hr']));
+    this.addTag(new BBCodeSimpleTag('sup', 'sup', [], ['i', 'u', 'b', 'hr']));
     this.addTag(
       new BBCodeCustomTag('color', (parser, parent, param) => {
         const cregex =
@@ -88,7 +99,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'big',
         'span',
         ['bigText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr']
       )
     );
     this.addTag(
@@ -96,7 +107,7 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'small',
         'span',
         ['smallText'],
-        ['url', 'i', 'u', 'b', 'color', 's', 'hr', 'img', 'eicon']
+        ['url', 'i', 'u', 'b', 'color', 's', 'hr']
       )
     );
     this.addTag(new BBCodeSimpleTag('indent', 'div', ['indentText']));
@@ -106,24 +117,30 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         'h2',
         [],
         [
-          'collapse',
-          'justify',
-          'center',
-          'left',
-          'right',
           'url',
           'i',
-          'u',
           'b',
-          'color',
+          'u',
           's',
-          'big',
-          'small',
+          'color',
           'sub',
           'sup',
+          'big',
+          'small',
+          'heading',
           'hr',
+          'icon',
+          'user',
           'img',
-          'eicon'
+          'eicon',
+          'quote',
+          'collapse',
+          'left',
+          'center',
+          'right',
+          'justify',
+          'indent',
+          'noparse'
         ]
       )
     );

--- a/bbcode/standard.ts
+++ b/bbcode/standard.ts
@@ -237,19 +237,31 @@ export class StandardBBCodeParser extends CoreBBCodeParser {
         const parser = <StandardBBCodeParser>p;
         if (typeof parser.inlines === 'undefined') {
           parser.warning('This page does not support inline images.');
-          return undefined;
+          const el = parser.createElement('span');
+          el.className = `Text`;
+          el.innerText = ``;
+          parent.appendChild(el);
+          return el;
         }
         const displayMode = Utils.settings.inlineDisplayMode;
         if (!/^\d+$/.test(param)) {
           parser.warning('img tag parameters must be numbers.');
-          return undefined;
+          const el = parser.createElement('span');
+          el.className = `Text`;
+          el.innerText = ``;
+          parent.appendChild(el);
+          return el;
         }
         const inline = parser.inlines[param];
         if (typeof inline !== 'object') {
           parser.warning(
             `Could not find an inline image with id ${param} It will not be visible.`
           );
-          return undefined;
+          const el = parser.createElement('span');
+          el.className = `Text`;
+          el.innerText = ``;
+          parent.appendChild(el);
+          return el;
         }
         inline.name = content;
         let element: HTMLElement;

--- a/chat/CharacterSearch.vue
+++ b/chat/CharacterSearch.vue
@@ -94,6 +94,7 @@
         <template v-if="record.character.status === 'looking'" v-once>
           <img
             :src="characterImage(record.character.name)"
+            class="character-avatar user"
             v-if="showAvatars"
           />
           <user
@@ -775,8 +776,10 @@
       & > .status-crown {
         overflow: hidden;
         width: 100%;
-        height: 2em;
+        min-height: 2em;
+        max-height: 7em;
         padding-top: 5px;
+        display: flex;
 
         .user-avatar {
           max-width: 2em;
@@ -786,17 +789,26 @@
           margin-top: -5px;
         }
 
+        .user-view {
+          flex-shrink: 0;
+        }
+
         .status-text {
           opacity: 0.75;
           padding-left: 4px;
+          max-height: 5.5em;
+          height: 100%;
           display: inline-flex;
+          overflow-y: auto;
+          flex-grow: 1;
         }
       }
 
-      img {
+      .character-avatar.user {
         float: left;
         margin-right: 5px;
         width: 50px;
+        height: auto;
       }
 
       .search-result:nth-child(2n) {

--- a/chat/Chat.vue
+++ b/chat/Chat.vue
@@ -561,6 +561,9 @@
       transition:
         box-shadow 0.08s,
         transform 0.08s;
+      @media (prefers-reduced-motion: reduce) {
+        transition: none;
+      }
       text-align: center;
       position: relative;
 
@@ -628,6 +631,9 @@
             -webkit-text-stroke 0.12s,
             opacity 0.12s,
             transform 0.12s;
+          @media (prefers-reduced-motion: reduce) {
+            transition: none;
+          }
           font-size: 14px;
           transform: scale(1);
 

--- a/chat/QuickJump.vue
+++ b/chat/QuickJump.vue
@@ -427,6 +427,11 @@
 
       .quick-jump-results {
         overflow-y: auto;
+        @media (prefers-reduced-motion: reduce) {
+          .quick-jump-result {
+            transition: none !important;
+          }
+        }
 
         .quick-jump-result {
           padding: 12px 16px;
@@ -481,6 +486,11 @@
         text-align: center;
 
         opacity: 0.8;
+        @media (prefers-reduced-motion: reduce) {
+          .quick-jump-new-conversation {
+            transition: none !important;
+          }
+        }
 
         .quick-jump-new-conversation {
           margin-top: 12px;

--- a/chat/UserMenu.vue
+++ b/chat/UserMenu.vue
@@ -526,8 +526,11 @@
 
   #userMenuMatch,
   #userMenuStatus {
-    max-width: 220px;
     background: none;
+  }
+
+  #userMenuMatch {
+    max-width: 220px;
   }
 
   .userMenuInner {

--- a/chat/UserMenu.vue
+++ b/chat/UserMenu.vue
@@ -486,6 +486,10 @@
   #userMenu-userInfo {
     max-width: 70%;
     overflow-x: hidden;
+    & > .userInfo-name {
+      width: min-content;
+      min-width: 100%;
+    }
   }
 
   #userMenu-userInfo,
@@ -527,6 +531,8 @@
   #userMenuMatch,
   #userMenuStatus {
     background: none;
+    width: min-content;
+    min-width: 100%;
   }
 
   #userMenuMatch {

--- a/chat/bbcode.ts
+++ b/chat/bbcode.ts
@@ -2,7 +2,11 @@ import Vue from 'vue';
 import { BBCodeElement, CoreBBCodeParser } from '../bbcode/core';
 //tslint:disable-next-line:match-default-export-name
 import BaseEditor from '../bbcode/Editor.vue';
-import { BBCodeTextTag, BBCodeCustomTag } from '../bbcode/parser';
+import {
+  BBCodeTextTag,
+  BBCodeCustomTag,
+  BBCodeSimpleTag
+} from '../bbcode/parser';
 import ChannelView from './ChannelTagView.vue';
 // import {characterImage} from './common';
 import core from './core';
@@ -18,6 +22,12 @@ export default class BBCodeParser extends CoreBBCodeParser {
 
   constructor() {
     super();
+    this.addTag(
+      new BBCodeSimpleTag('sub', 'sub', [], ['b', 'i', 'u', 's', 'color'])
+    );
+    this.addTag(
+      new BBCodeSimpleTag('sup', 'sup', [], ['b', 'i', 'u', 's', 'color'])
+    );
     this.addTag(
       new BBCodeCustomTag('color', (parser, parent, param) => {
         const cregex =

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -395,6 +395,7 @@ class PrivateConversation
 
       if (core.state.settings.logMessages)
         await core.logs.logMessage(this, message);
+      this.markRead();
     });
   }
 
@@ -595,7 +596,6 @@ class ChannelConversation
           new Date()
         )
       );
-
       if (isAd) {
         this.nextAd = Date.now() + core.connection.vars.lfrp_flood * 1000;
 
@@ -608,6 +608,7 @@ class ChannelConversation
           }
         };
       }
+      this.markRead();
     });
   }
 

--- a/chat/localize.ts
+++ b/chat/localize.ts
@@ -22,6 +22,7 @@ const strings: { [key: string]: string | undefined } = {
   'action.preferences': 'Preferences',
   'action.markAsRead': 'Mark all as read',
   'action.cancel': 'Cancel',
+  'action.dismiss': 'Dismiss',
   'admgr.open': 'Ad Center',
   'admgr.postingBegins': 'Posting begins in {0}m {1}s',
   'admgr.nextPostDue': 'Next ad in {0}m {1}s',

--- a/components/Dropdown.vue
+++ b/components/Dropdown.vue
@@ -49,6 +49,7 @@
     @Watch('isOpen')
     onToggle(): void {
       const menu = this.$refs['menu'] as HTMLElement;
+      const button = this.$refs['button'] as HTMLElement;
       if (!this.isOpen) {
         menu.style.cssText = '';
         return;
@@ -56,6 +57,7 @@
       menu.style.display = 'block';
       const offset = menu.getBoundingClientRect();
       menu.style.position = 'fixed';
+      menu.style.minWidth = `${button.clientWidth}px`;
       menu.style.left =
         offset.right < window.innerWidth
           ? `${offset.left}px`

--- a/electron/Settings.vue
+++ b/electron/Settings.vue
@@ -147,7 +147,7 @@
                   </div>
                 </div>
                 <div class="mb-3" v-if="!settings.themeSync">
-                  <label class="control-label" for="theme" style="width: 20ch">
+                  <label class="control-label" for="theme" style="width: 24ch">
                     {{ l('settings.theme.app') }}
                     <filterable-select
                       v-model="settings.theme"
@@ -165,7 +165,7 @@
                   <label
                     class="control-label"
                     for="themeSyncLight"
-                    style="width: 20ch"
+                    style="width: 24ch"
                   >
                     {{ l('settings.theme.app.light') }}
                     <filterable-select
@@ -183,7 +183,7 @@
                   <label
                     class="control-label"
                     for="themeSyncDark"
-                    style="width: 20ch"
+                    style="width: 24ch"
                   >
                     {{ l('settings.theme.app.dark') }}
                     <filterable-select
@@ -274,7 +274,7 @@
                   <label
                     class="control-label"
                     for="spellCheckLang"
-                    style="width: 20ch"
+                    style="width: 24ch"
                   >
                     {{ l('settings.spellcheck') }}
                     <filterable-select
@@ -321,7 +321,7 @@
                   <label
                     class="control-label"
                     for="soundTheme"
-                    style="width: 20ch"
+                    style="width: 24ch"
                   >
                     {{ l('settings.soundTheme') }}
                     <filterable-select
@@ -1153,7 +1153,7 @@
   }
 
   .custom-select {
-    width: 20ch;
+    width: 24ch;
   }
 
   .close {

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horizon-electron",
-  "version": "1.33.4",
+  "version": "1.33.5-beta.1",
   "author": "The F-List Team and Horizon Contributors",
   "description": "Horizon",
   "homepage": "https://horizn.moe",

--- a/learn/matcher.ts
+++ b/learn/matcher.ts
@@ -1376,7 +1376,12 @@ export class Matcher {
     const mySpecies = Matcher.getTagValue(TagId.Species, c);
 
     if (!mySpecies || !mySpecies.string) {
-      return Species.Human; // best guess
+      log.debug('matcher.species.empty', {
+        character: c.name
+      });
+
+      return null; // In this case, we won't guess. Just get marked as being specieless.
+      //Fill in your profiles, people!
     }
 
     const s = Matcher.getMappedSpecies(mySpecies.string);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fchat-horizon",
-  "version": "1.33.4",
+  "version": "1.33.5-beta.1",
   "author": "The F-List Team and Horizon Contributors",
   "description": "A heavily modded FChat 3.0 client for F-List, continued from Rising",
   "license": "GPL-3.0-or-later",

--- a/scss/_bbcode.scss
+++ b/scss/_bbcode.scss
@@ -214,6 +214,9 @@ div.indentText {
     width: 50px;
   }
   transition: opacity 0.25s;
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
   &.loading {
     opacity: 0;
     visibility: hidden;
@@ -239,6 +242,9 @@ div.indentText {
 .bbcode-collapse-body {
   margin-left: 0.5rem;
   transition: height 0.2s;
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
   overflow-y: hidden;
 
   &.closed {

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -220,7 +220,10 @@
     font-size: 1.15rem;
     display: inline-block;
     border-radius: 6px;
-    transition: 0.2s;
+    transition: $transition-base;
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
     position: relative;
     .userInfo-pager-text {
       font-size: 1rem;
@@ -234,7 +237,10 @@
   overflow-x: hidden;
   padding: 0px 5px 6px 5px;
   border-radius: 8px;
-  transition: 0.2s;
+  transition: $transition-base;
+  @media (prefers-reduced-motion: reduce) {
+    transition: none;
+  }
   &:hover,
   &:active {
     text-decoration: none;
@@ -260,7 +266,10 @@
     text-decoration: none;
     color: var(--black);
     opacity: 1;
-    transition: 0.2s;
+    transition: $transition-base;
+    @media (prefers-reduced-motion: reduce) {
+      transition: none;
+    }
   }
 }
 .ads-text-box,

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -378,6 +378,10 @@
   border-bottom: solid 2px mix($white, $success, 2 * 8%) !important;
 }
 
+.messages .message:last-of-type.last-read {
+  border-bottom: none !important;
+}
+
 .fas.active {
   color: theme-color('success');
 }

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -363,7 +363,7 @@
 }
 
 .message-highlight {
-  background-color: mix($white, $success, 4 * 8%);
+  background-color: mix($white, $success, 10 * 8%);
 }
 
 .message-action .bbcode {
@@ -375,7 +375,7 @@
 }
 
 .last-read {
-  border-bottom: solid 2px mix($white, $success, 2 * 8%) !important;
+  border-bottom: solid 2px mix($white, $success, 4 * 8%) !important;
 }
 
 .messages .message:last-of-type.last-read {

--- a/scss/themes/variables/_light_variables.scss
+++ b/scss/themes/variables/_light_variables.scss
@@ -39,6 +39,8 @@ $link-hover-color: $black;
 $input-bg: $gray-base;
 $list-group-bg: $gray-base;
 
+$dropdown-link-hover-bg: $gray-200;
+
 // F-List Rising
 $scorePerfectMatchBg: rgb(0, 173, 173);
 $scorePerfectMatchFg: rgb(29, 154, 154);

--- a/site/NoteStatus.vue
+++ b/site/NoteStatus.vue
@@ -16,21 +16,22 @@
         <i :class="getIconClass(report)"></i>
         <span class="badge text-bg-primary rounded-pill">{{
           report.count
-        }}</span>
+        }}</span
+        ><a
+          :class="`status-report ${report.type} ${report.count > 0 && report.count !== report.dismissedCount ? 'active' : ''}`"
+          class="dismiss"
+          role="button"
+          :title="l('action.dismiss')"
+          ><i
+            @click.prevent="dismissReport(report)"
+            class="fas fa-times-circle"
+          ></i
+        ></a>
       </a>
 
       <!--This was part of the original design, where the NoteStatus component floated on the bottom left
           But in this new design, where it's part of the lefthand sidebar it's just too visually busy to have dismissal buttons too."
 -->
-      <!--
-      <a
-        :key="`report-${index}`"
-        :class="`status-report ${report.type} ${report.count > 0 && report.count !== report.dismissedCount ? 'active' : ''}`"
-        @click="dismissReport(report)"
-        class="dismiss"
-        ><i class="fas fa-times-circle"></i
-      ></a>
-      -->
     </template>
   </div>
 </template>
@@ -40,6 +41,7 @@
   import Vue from 'vue';
   import core from '../chat/core';
   import { EventBus } from '../chat/preview/event-bus';
+  import l from '../chat/localize';
 
   interface ReportState {
     type: string;
@@ -54,19 +56,20 @@
     reports: ReportState[] = [
       {
         type: 'message',
-        title: 'Messages',
+        title: l('pager.messages'),
         count: 0,
         dismissedCount: 0,
         url: 'https://www.f-list.net/messages.php'
       },
       {
         type: 'note',
-        title: 'Notes',
+        title: l('pager.notes'),
         count: 0,
         dismissedCount: 0,
         url: 'https://www.f-list.net/read_notes.php'
       }
     ];
+    l = l;
 
     callback?: () => void;
 
@@ -155,24 +158,34 @@
   }
   .userInfo-buttons-container {
     .userInfo-button-item.userInfo-pager-button {
-      display: none;
+      display: inline-block;
       .badge {
+        display: none;
         margin-left: 4px;
         vertical-align: text-top;
       }
-      & + .dismiss {
-        display: none;
+      &:hover .dismiss {
         opacity: 0.6;
+      }
+      & .dismiss {
+        display: none;
+        position: absolute;
+        opacity: 0;
+        //color: var(--bs-danger);
+        z-index: 12;
+        top: 0px;
+        right: 0px;
+
         &:hover {
           opacity: 1;
         }
         &.active {
-          display: initial;
+          display: block;
         }
       }
 
-      &.active {
-        display: inline-block;
+      &.active .badge {
+        display: initial;
       }
     }
   }


### PR DESCRIPTION
To-do list:

- [x] Merge all related milestone PRs
- [ ] Update changelog.md
- [ ] Version bump


# Preliminary Changelog

## [1.33.5] - 2025-09-03

### Added

- The dismiss buttons for the note/ site messages checker have been brought back. Dismissed notifications will keep the icon, but will not have the number count visible. [Commit]
- Added reduced motion accessibility support for our custom animations. [Commit]

### Fixed

- Fixes some cases where using the color picker keybind would make people accidentally overwrite their selected text. [Commit]
- Fixes some cases where BBCode would parse correctly where it wouldn't in vanilla 3.0, for consistency with other users. [Commit]
- Fixes the user right click menu becoming unnecessarily wide for longer names if those names need multiple lines (and thus won't need the horizontal space anymore).
- Fixes select dropdowns (like those found in the settings menu, or the log viewer) not using the same width as the main element. [Commit]
  - This also fixes those selection dropdowns not having a mouse over colour in light themes.
- Fixes search results for characters not set to 'Looking' having a broken layout if their status message was considerably tall. [Commit]

### Changed

- Profiles without a species no longer default to "human" for the matcher. [Commit]
- The ping highlight colour has been corrected back to a less bright shade of green. [Commit]
- Broken inline tags no longer display their bbcode on profiles (which they don't on the website either). [Commit]

### Merged Pull Requests

- https://github.com/Fchat-Horizon/Horizon/pull/281 by @BootsieWootsie 
- https://github.com/Fchat-Horizon/Horizon/pull/336 by @BootsieWootsie 

Other, non-PR'd changes by @CodingWithAnxiety and @FatCatClient.