### PR TITLE
Original avatars in classic chat view

### DIFF
--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -247,6 +247,9 @@
     @Prop({ default: false })
     readonly isMarkerShown: boolean = false;
 
+    @Prop({ default: false })
+    readonly useOriginalAvatar: boolean = false;
+
     userClass = '';
 
     rankIcon: string | null = null;
@@ -348,9 +351,10 @@
       this.matchClass = res.matchClass;
       this.matchScore = res.matchScore;
       this.userClass = res.userClass;
-      this.avatarUrl =
-        this.character.overrides.avatarUrl ||
-        characterImage(this.character.name);
+      this.avatarUrl = characterImage(
+        this.character.name,
+        this.useOriginalAvatar
+      );
     }
 
     getMatchScoreTitle(score: number | string | null): string {

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -7,10 +7,14 @@ export function profileLink(this: any | never, character: string): string {
   return `https://www.f-list.net/c/${character}`;
 }
 
-export function characterImage(this: any | never, character: string): string {
+export function characterImage(
+  this: any | never,
+  character: string,
+  useOriginalAvatar: boolean = false
+): string {
   const c = core.characters.get(character);
 
-  if (c.overrides.avatarUrl) {
+  if (c.overrides.avatarUrl && !useOriginalAvatar) {
     return c.overrides.avatarUrl;
   }
 

--- a/chat/message_view.ts
+++ b/chat/message_view.ts
@@ -149,6 +149,7 @@ const userPostfix: { [key: number]: string | undefined } = {
               avatar: core.connection.character
                 ? core.state.settings.risingShowPortraitInMessage
                 : false,
+              useOriginalAvatar: 'true',
               character: message.sender,
               channel: this.channel,
               isMarkerShown: core.connection.character


### PR DESCRIPTION
Moved from https://github.com/Fchat-Horizon/Horizon/pull/405/
This just makes the avatar at the side of UserView use the original avatar instead of the Horizon portrait when you are in classic view. 