### PR TITLE
Reminders on which awful piece of the cache system does what.

### DIFF
--- a/chat/profile_api.ts
+++ b/chat/profile_api.ts
@@ -68,6 +68,17 @@ import throat from 'throat';
 // Throttle queries so that only two profile requests can run at any given time
 const characterDataThroat = throat(2);
 
+/**
+ * This is the, "I need the data returned right now" version of {@link core.cache.addProfile | `CacheManager.addProfile`}. Where that function adds the profile fetching to a queue (which adds the character profile to the profile cache), this function directly returns the character profile.
+ *
+ * All values are passed to {@link executeCharacterData | `executeCharacterData`}. `id` is unused.
+ * @param name Character name
+ * @param definitions Custom kink definitions to use? Otherwise, {@link Store.shared} is used.
+ * @param skipEvent (Default: false) Do not emit the `character-data` {@link EventBus | `EventBus`} event.
+ * @returns Requested character
+ *
+ * Comment imported from Frolic; may be inaccurate if significant changes occured.
+ */
 // tslint:disable-next-line: ban-ts-ignore
 // @ts-ignore
 async function characterData(
@@ -187,6 +198,14 @@ function contactMethodIconUrl(name: string): string {
   return `${Utils.staticDomain}images/social/${name}.png`;
 }
 
+/**
+ * Fields do not change regularly so a basic cache is a perfectly fine way to do it.
+ *
+ * It would probably be better if this was some sort of class (random raw data management is bad design.)
+ * @returns The cached definitions, or new ones if they weren't cached yet.
+ *
+ * Comment imported from Frolic; may be inaccurate if significant changes occured.
+ */
 async function fieldsGet(): Promise<void> {
   if (Store.shared !== undefined) return; //tslint:disable-line:strict-type-predicates
   try {

--- a/fchat/interfaces.ts
+++ b/fchat/interfaces.ts
@@ -326,6 +326,9 @@ export namespace Character {
     setOverride(name: string, type: keyof CharacterOverrides, value: any): void;
   }
 
+  /**
+   * Chat character: Name, gender, status, typing indicator, relationships, and overrides.
+   */
   export interface Character {
     readonly name: string;
     readonly gender: Gender | undefined;
@@ -339,6 +342,9 @@ export namespace Character {
   }
 }
 
+/**
+ * Chat character: Name, gender, status, typing indicator, relationships, and overrides.
+ */
 export type Character = Character.Character;
 
 export namespace Channel {

--- a/interfaces.ts
+++ b/interfaces.ts
@@ -1,3 +1,10 @@
+/**
+ * The most simple character structure, used primarily for listing your characters on the log-in selector.
+ *
+ * Character name, unique ID, and whether or not the character exists.
+ *
+ * Comment imported from Frolic; may be inaccurate if significant changes occured.
+ */
 export interface SimpleCharacter {
   id: number;
   name: string;
@@ -51,6 +58,13 @@ export interface Infotag {
   infotag_group: number;
 }
 
+/**
+ * Public character page. Why does this extend SimpleCharacter? Investigate usage.
+ *
+ * @see [file://site/character_page/interfaces.ts](site/character_page/interfaces.ts)
+ *
+ * Comment imported from Frolic; may be inaccurate if significant changes occured.
+ */
 export interface Character extends SimpleCharacter {
   id: number;
   name: string;

--- a/learn/cache-manager.ts
+++ b/learn/cache-manager.ts
@@ -95,6 +95,16 @@ export class CacheManager {
     return this.lastPost;
   }
 
+  /**
+   * Add a user to the queue for fetching profiles from the server.
+   *
+   * Use addProfile instead. This should be private.
+   * @param name Character name
+   * @param skipCacheCheck The cache can be skipped to hard-reload character data
+   * @param channelId Provide a channel id to allow dropping this character from the queue if we un-focus the channel. (Useful to mitigate background noise from characters your no longer care about)
+   *
+   * Comment imported from Frolic; may be inaccurate if significant changes occured.
+   */
   async queueForFetching(
     name: string,
     skipCacheCheck: boolean = false,
@@ -144,6 +154,14 @@ export class CacheManager {
     // console.log('AddProfileForFetching', name, this.queue.length);
   }
 
+  /**
+   * The solution if `getSync` and `get` fail. An async function that just wraps the character API call and invokes the cacher + matcher on the profile. Theoretically, this should be a total replacement for directly using the character_page API.
+   * @param name Character name
+   * @param skipCacheCheck The cache can be skipped to hard-reload character data
+   * @param channelId Provide a channel id to allow dropping this character from the queue if we un-focus the channel. (Useful to mitigate background noise from characters your no longer care about)
+   *
+   * Comment imported from Frolic; may be inaccurate if significant changes occured.
+   */
   async fetchProfile(name: string): Promise<ComplexCharacter | null> {
     try {
       await methods.fieldsGet();
@@ -161,6 +179,14 @@ export class CacheManager {
     }
   }
 
+  /**
+   * A wasteful function that will probably die when the cache is more orderly.
+   * @param c
+   * @param score
+   * @param isFiltered
+   *
+   * Comment imported from Frolic; may be inaccurate if significant changes occured.
+   */
   updateAdScoringForProfile(
     c: ComplexCharacter,
     score: number,
@@ -205,6 +231,16 @@ export class CacheManager {
     }
   }
 
+  /**
+   * Fetch a character profile from the server and add it to the cache.
+   * If provided a character object, then it runs the secondary processes of
+   * turning that character into a fully fleshed-out character.
+   *
+   * But under what scenarios do we actually need to process without fetching?
+   * @param character Character name to fetch, or a character object to finish
+   *
+   * Comment imported from Frolic; may be inaccurate if significant changes occured.
+   */
   async addProfile(character: string | ComplexCharacter): Promise<void> {
     if (typeof character === 'string') {
       // console.log('Learn discover', character);
@@ -529,6 +565,17 @@ export class CacheManager {
     return draft?.message || '';
   }
 
+  /**
+   * Match a character, score their message (if provided), and return their scored Character.
+   * @param skipStore Don't store profile in cache; just retrieve scoring info
+   * @param char Character who posted the message
+   * @param conv Conversation message is posted in
+   * @param msg Message to be scored
+   * @param populateAll (Default: true) Spread score to all conversations?
+   * @returns CharacterCache if relevant
+   *
+   * Comment imported from Frolic; may be inaccurate if significant changes occured.
+   */
   async resolveProfileScore(
     skipStore: boolean,
     char: Character.Character,

--- a/learn/profile-cache.ts
+++ b/learn/profile-cache.ts
@@ -40,6 +40,9 @@ export interface CharacterMatchSummary {
   autoResponded?: boolean;
 }
 
+/**
+ * The "cache record" holds information about when the character was added to the cache. This information can be useful for deciding when to refresh a character profile or to remove them entirely.
+ */
 export interface CharacterCacheRecord {
   character: ComplexCharacter;
   lastFetched: Date;
@@ -62,6 +65,15 @@ export class ProfileCache extends AsyncCache<CharacterCacheRecord> {
     _.each(this.cache, cb);
   }
 
+  /**
+   * Query the cache for a player record, returning immediately. Fails with `null` if the character hasn't been cached. Use {@link get | `get` (async)} if you want to reach deeper and get the profile from the disk-backed store and cache it in readily-accessible memory.
+   *
+   * This method does **NOT** query the server for the character.
+   * @param name Character to query the cache for
+   * @returns Character profile if it's cached; null otherwise
+   *
+   * Comment imported from Frolic; may be inaccurate if significant changes occured.
+   */
   getSync(name: string): CharacterCacheRecord | null {
     const key = AsyncCache.nameKey(name);
 
@@ -72,6 +84,19 @@ export class ProfileCache extends AsyncCache<CharacterCacheRecord> {
     return null;
   }
 
+  /**
+   * Asynchronously gets a character from the in-memory cache, or from the PermanentIndexedStore if it's not in memory. Then register it with the matcher (was matcher data not saved before...?).
+   *
+   * This method does **NOT** query the server for the character.
+   *
+   * This function could use some adjustment to ensure it always runs async, as "potentially async" is bad control flow design. Please remove this comment line when you do so. :)
+   * @param name Character to retrieve
+   * @param skipStore Return negative if the character isn't in the cache
+   * @param _fromChannel Unused
+   * @returns Preferably a character; null if not in cache and `skipStore`; null if profile is not in the store
+   *
+   * Comment imported from Frolic; may be inaccurate if significant changes occured.
+   */
   async get(
     name: string,
     skipStore: boolean = false,
@@ -295,6 +320,14 @@ export class ProfileCache extends AsyncCache<CharacterCacheRecord> {
     }
   }
 
+  /**
+   * Register the profile with the in-memory cache and (by default) the disk-backed store; putting it through the matcher and smart filters in the process.
+   * @param c Response from "character profile" API request
+   * @param skipStore (Default: false) Don't add the updated character to the store
+   * @returns Character with match details
+   *
+   * Comment imported from Frolic; may be inaccurate if significant changes occured.
+   */
   async register(
     c: ComplexCharacter,
     skipStore: boolean = false

--- a/site/character_page/interfaces.ts
+++ b/site/character_page/interfaces.ts
@@ -22,6 +22,17 @@ export interface StoreMethods {
     description: string,
     choice: KinkChoice
   ): Promise<void>;
+  /**
+   * This is the, "I need the data returned right now" version of `CacheManager.addProfile`. Where that function adds the profile fetching to a queue (which calls characterData then adds the character profile to the profile cache), this function directly returns the character profile.
+   *
+   * All values are passed to `executeCharacterData`.
+   * @param name Character name
+   * @param definitions Custom kink definitions to use? Otherwise, {@link Store.shared} is used.
+   * @param skipEvent (Default: false) Do not emit the `character-data` {@link EventBus | `EventBus`} event.
+   * @returns Character with name `name`
+   *
+   * Comment imported from Frolic; may be inaccurate if significant changes occured.
+   */
   characterData(
     name: string | undefined,
     id: number | undefined,
@@ -137,6 +148,9 @@ export interface CharacterMemo {
   memo: string;
 }
 
+/**
+ * Character page API response (including the public character page as `character`).
+ */
 export interface Character {
   readonly is_self: boolean;
   character: CharacterInfo;


### PR DESCRIPTION
Better late than never.

One of the comments is in there twice because it needed to be in order to show up properly in vscodium.

There's an addendum on tsdoc comments that these notes were imported, that way when you stumble across them in the future or as part of an exported doc you won't be wondering why they have mild inaccuracies or bad opinions. Remove those import notices as you rewrite/invalidate the markup.