### PR TITLE
Fix cleanup not being called when exporting HTML logs

### DIFF
--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -175,7 +175,12 @@
                 }
               : undefined,
             html
-              ? t => `${core.bbCodeParser.parseEverything(t).innerHTML}`
+              ? t => {
+                  const parsedElement = core.bbCodeParser.parseEverything(t);
+                  const result = parsedElement.innerHTML;
+                  parsedElement.cleanup?.();
+                  return `${result}`;
+                }
               : undefined
           ),
         start


### PR DESCRIPTION
fix: Ensure that the log export cleans up elements after fetching the HTML generated from logs

This reduces RAM usage when exporting logs. It should also _technically_ fix the log export freezing/crashing issue #266
But I still think that needs a more involved approach to be considered properly fixed.