### PR TITLE
feat: add logging settings to conversation settings

### DIFF
--- a/chat/ConversationSettings.vue
+++ b/chat/ConversationSettings.vue
@@ -101,6 +101,26 @@
         </option>
       </select>
     </div>
+    <div class="mb-3">
+      <label class="control-label" :for="'enableLogging' + conversation.key">{{
+        l('conversationSettings.enableLogging')
+      }}</label>
+      <select
+        class="form-select"
+        :id="'enableLogging' + conversation.key"
+        v-model="enableLogging"
+      >
+        <option :value="setting.Default">
+          {{ l('conversationSettings.default') }}
+        </option>
+        <option :value="setting.True">
+          {{ l('conversationSettings.true') }}
+        </option>
+        <option :value="setting.False">
+          {{ l('conversationSettings.false') }}
+        </option>
+      </select>
+    </div>
   </modal>
 </template>
 
@@ -125,6 +145,7 @@
     horizonHighlightUsers!: string;
     joinMessages!: Conversation.Setting;
     defaultHighlights!: boolean;
+    enableLogging!: Conversation.Setting;
 
     load(): void {
       const settings = this.conversation.settings;
@@ -134,6 +155,7 @@
       this.joinMessages = settings.joinMessages;
       this.defaultHighlights = settings.defaultHighlights;
       this.horizonHighlightUsers = settings.horizonHighlightUsers.join(',');
+      this.enableLogging = settings.enableLogging;
     }
 
     submit(): void {
@@ -151,7 +173,8 @@
 
         joinMessages: this.joinMessages,
         defaultHighlights: this.defaultHighlights,
-        adSettings: this.conversation.settings.adSettings
+        adSettings: this.conversation.settings.adSettings,
+        enableLogging: this.enableLogging
       };
     }
   }

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -164,6 +164,7 @@ export class ConversationSettings implements Conversation.Settings {
     lastAdTimestamp: 0
   };
   horizonHighlightUsers: string[] = [];
+  enableLogging = Conversation.Setting.Default;
 }
 
 export function formatTime(

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -141,6 +141,7 @@ export namespace Conversation {
     readonly defaultHighlights: boolean;
     readonly adSettings: AdSettings;
     readonly horizonHighlightUsers: ReadonlyArray<string>;
+    readonly enableLogging: Setting;
   }
 
   export interface AdSettings {

--- a/chat/locales/en_us.json
+++ b/chat/locales/en_us.json
@@ -321,6 +321,7 @@
   "conversation.memoLabel": "Memo:",
   "conversationSettings.action": "Edit settings for {0}",
   "conversationSettings.default": "Default",
+  "conversationSettings.enableLogging": "Enable logging",
   "conversationSettings.false": "No",
   "conversationSettings.notify": "Notify for messages",
   "conversationSettings.save": "Save settings",


### PR DESCRIPTION
Adds per-channel logging options, allowing you to disable / enable it on a per-channel basis.

Closes #385.