### PR TITLE
Recreates log index if missing during log fix process

### DIFF
--- a/electron/filesystem.ts
+++ b/electron/filesystem.ts
@@ -173,8 +173,10 @@ export function fixLogs(character: string): void {
     const fd = fs.openSync(full, 'r+');
     const indexPath = path.join(dir, `${file}.idx`);
     if (!fs.existsSync(indexPath)) {
-      fs.unlinkSync(full);
-      continue;
+      const nameBuffer = Buffer.allocUnsafe(file.length + 1);
+      nameBuffer.writeUInt8(file.length, 0);
+      nameBuffer.write(file, 1);
+      fs.writeFileSync(indexPath, nameBuffer);
     }
     const indexFd = fs.openSync(indexPath, 'r+');
     fs.readSync(indexFd, buffer, 0, 1, 0);


### PR DESCRIPTION
Fixes #383

The only problem here is that recreating the log index means you have to take the conversation's name from the log's filename. If the conversation was a user ran room, that means its name will be lost forever.