### PR TITLE
Downgrade back to Electron 37 release (37.6.1)

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -94,7 +94,7 @@
   },
   "devDependencies": {
     "commander": "^14.0.0",
-    "electron": "38.2.1",
+    "electron": "37.6.1",
     "electron-builder": "^26.0.12"
   },
   "pnpm": {

--- a/electron/pnpm-lock.yaml
+++ b/electron/pnpm-lock.yaml
@@ -19,8 +19,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0
       electron:
-        specifier: 38.2.1
-        version: 38.2.1
+        specifier: 37.6.1
+        version: 37.6.1
       electron-builder:
         specifier: ^26.0.12
         version: 26.0.12(electron-builder-squirrel-windows@25.1.8)
@@ -163,9 +163,6 @@ packages:
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
-
-  '@types/node@22.14.1':
-    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
 
   '@types/node@22.18.8':
     resolution: {integrity: sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==}
@@ -570,8 +567,8 @@ packages:
   electron-publish@26.0.11:
     resolution: {integrity: sha512-a8QRH0rAPIWH9WyyS5LbNvW9Ark6qe63/LqDB7vu2JXYpi0Gma5Q60Dh4tmTqhOBQt0xsrzD8qE7C+D7j+B24A==}
 
-  electron@38.2.1:
-    resolution: {integrity: sha512-P4pE2RpRg3kM8IeOK+heg6iAxR5wcXnNHrbVchn7M3GBnYAhjfJRkROusdOro5PlKzdtfKjesbbqaG4MqQXccg==}
+  electron@37.6.1:
+    resolution: {integrity: sha512-aHtJVNjqf0lk7dlPoc1X+fMBpZtLn+XGvP6IYc3gooTwsD1D/Ic2SBRC9SnIk6LkWTsDaSF9jgH1d9Q7eABy/Q==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -1540,7 +1537,7 @@ snapshots:
       make-fetch-happen: 10.2.1
       nopt: 6.0.0
       proc-log: 2.0.1
-      semver: 7.7.1
+      semver: 7.7.2
       tar: 6.2.1
       which: 2.0.2
     transitivePeerDependencies:
@@ -1657,7 +1654,7 @@ snapshots:
   '@npmcli/fs@2.1.2':
     dependencies:
       '@gar/promisify': 1.1.3
-      semver: 7.7.1
+      semver: 7.7.2
 
   '@npmcli/move-file@2.0.1':
     dependencies:
@@ -1688,7 +1685,7 @@ snapshots:
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 24.6.2
 
   '@types/http-cache-semantics@4.0.4': {}
 
@@ -1707,10 +1704,6 @@ snapshots:
 
   '@types/ms@2.1.0': {}
 
-  '@types/node@22.14.1':
-    dependencies:
-      undici-types: 6.21.0
-
   '@types/node@22.18.8':
     dependencies:
       undici-types: 6.21.0
@@ -1721,7 +1714,7 @@ snapshots:
 
   '@types/plist@3.0.5':
     dependencies:
-      '@types/node': 22.14.1
+      '@types/node': 24.6.2
       xmlbuilder: 15.1.1
     optional: true
 
@@ -1734,7 +1727,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.18.8
+      '@types/node': 24.6.2
     optional: true
 
   '@xmldom/xmldom@0.8.10': {}
@@ -1743,7 +1736,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2299,7 +2292,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@38.2.1:
+  electron@37.6.1:
     dependencies:
       '@electron/get': 2.0.3
       '@types/node': 22.18.8
@@ -2557,7 +2550,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2576,7 +2569,7 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -2838,7 +2831,7 @@ snapshots:
 
   node-abi@3.74.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   node-abi@3.77.0:
     dependencies:
@@ -2849,7 +2842,7 @@ snapshots:
 
   node-api-version@0.2.0:
     dependencies:
-      semver: 7.7.1
+      semver: 7.7.2
 
   node-api-version@0.2.1:
     dependencies:
@@ -2967,7 +2960,7 @@ snapshots:
 
   read-binary-file-arch@1.0.6:
     dependencies:
-      debug: 4.4.0
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3080,7 +3073,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.0
+      debug: 4.4.3
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^5.2.7",
     "date-fns": "2.30.0",
-    "electron": "^38.2.1",
+    "electron": "^37.6.1",
     "electron-builder": "^26.0.12",
     "electron-log": "^4.4.8",
     "electron-packager": "^15.5.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,10 +27,10 @@ importers:
         version: 2.11.6
       '@ghostery/adblocker-electron':
         specifier: ^2.0.0
-        version: 2.11.6(electron@38.2.1(supports-color@10.0.0))
+        version: 2.11.6(electron@37.6.1(supports-color@10.0.0))
       '@ghostery/adblocker-electron-preload':
         specifier: ^2.0.0
-        version: 2.11.6(electron@38.2.1(supports-color@10.0.0))
+        version: 2.11.6(electron@37.6.1(supports-color@10.0.0))
       '@ghostery/adblocker-extended-selectors':
         specifier: ^2.0.0
         version: 2.11.6
@@ -61,7 +61,7 @@ importers:
     devDependencies:
       '@electron/remote':
         specifier: ^2.1.2
-        version: 2.1.2(electron@38.2.1(supports-color@10.0.0))
+        version: 2.1.2(electron@37.6.1(supports-color@10.0.0))
       '@f-list/vue-ts':
         specifier: ^1.0.3
         version: 1.0.3
@@ -126,8 +126,8 @@ importers:
         specifier: 2.30.0
         version: 2.30.0
       electron:
-        specifier: ^38.2.1
-        version: 38.2.1(supports-color@10.0.0)
+        specifier: ^37.6.1
+        version: 37.6.1(supports-color@10.0.0)
       electron-builder:
         specifier: ^26.0.12
         version: 26.0.12(bluebird@3.7.2)(electron-builder-squirrel-windows@25.1.8)(supports-color@10.0.0)
@@ -142,7 +142,7 @@ importers:
         version: 3.2.9(bluebird@3.7.2)(supports-color@10.0.0)
       electron-settings:
         specifier: ~4.0.4
-        version: 4.0.4(electron@38.2.1(supports-color@10.0.0))
+        version: 4.0.4(electron@37.6.1(supports-color@10.0.0))
       file-loader:
         specifier: ^6.2.0
         version: 6.2.0(webpack@5.99.9)
@@ -2060,8 +2060,8 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
-  electron@38.2.1:
-    resolution: {integrity: sha512-P4pE2RpRg3kM8IeOK+heg6iAxR5wcXnNHrbVchn7M3GBnYAhjfJRkROusdOro5PlKzdtfKjesbbqaG4MqQXccg==}
+  electron@37.6.1:
+    resolution: {integrity: sha512-aHtJVNjqf0lk7dlPoc1X+fMBpZtLn+XGvP6IYc3gooTwsD1D/Ic2SBRC9SnIk6LkWTsDaSF9jgH1d9Q7eABy/Q==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -5413,9 +5413,9 @@ snapshots:
       - bluebird
       - supports-color
 
-  '@electron/remote@2.1.2(electron@38.2.1(supports-color@10.0.0))':
+  '@electron/remote@2.1.2(electron@37.6.1(supports-color@10.0.0))':
     dependencies:
-      electron: 38.2.1(supports-color@10.0.0)
+      electron: 37.6.1(supports-color@10.0.0)
 
   '@electron/universal@1.5.1(supports-color@10.0.0)':
     dependencies:
@@ -5465,16 +5465,16 @@ snapshots:
     dependencies:
       '@ghostery/adblocker-extended-selectors': 2.11.6
 
-  '@ghostery/adblocker-electron-preload@2.11.6(electron@38.2.1(supports-color@10.0.0))':
+  '@ghostery/adblocker-electron-preload@2.11.6(electron@37.6.1(supports-color@10.0.0))':
     dependencies:
       '@ghostery/adblocker-content': 2.11.6
-      electron: 38.2.1(supports-color@10.0.0)
+      electron: 37.6.1(supports-color@10.0.0)
 
-  '@ghostery/adblocker-electron@2.11.6(electron@38.2.1(supports-color@10.0.0))':
+  '@ghostery/adblocker-electron@2.11.6(electron@37.6.1(supports-color@10.0.0))':
     dependencies:
       '@ghostery/adblocker': 2.11.6
-      '@ghostery/adblocker-electron-preload': 2.11.6(electron@38.2.1(supports-color@10.0.0))
-      electron: 38.2.1(supports-color@10.0.0)
+      '@ghostery/adblocker-electron-preload': 2.11.6(electron@37.6.1(supports-color@10.0.0))
+      electron: 37.6.1(supports-color@10.0.0)
       tldts-experimental: 7.0.15
 
   '@ghostery/adblocker-extended-selectors@2.11.6': {}
@@ -7505,9 +7505,9 @@ snapshots:
       - bluebird
       - supports-color
 
-  electron-settings@4.0.4(electron@38.2.1(supports-color@10.0.0)):
+  electron-settings@4.0.4(electron@37.6.1(supports-color@10.0.0)):
     dependencies:
-      electron: 38.2.1(supports-color@10.0.0)
+      electron: 37.6.1(supports-color@10.0.0)
       lodash: 4.17.21
       mkdirp: 1.0.4
       write-file-atomic: 3.0.3
@@ -7544,7 +7544,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@38.2.1(supports-color@10.0.0):
+  electron@37.6.1(supports-color@10.0.0):
     dependencies:
       '@electron/get': 2.0.3(supports-color@10.0.0)
       '@types/node': 16.18.32
@@ -9819,7 +9819,7 @@ snapshots:
 
   read-binary-file-arch@1.0.6(supports-color@10.0.0):
     dependencies:
-      debug: 4.4.1(supports-color@10.0.0)
+      debug: 4.4.3(supports-color@10.0.0)
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Because of a variety of issues (such as #449) and currently unlisted issues with window focus in Electron 38, it might be a better idea to instead use a later release of the Electron 37 branch.

As far as I am aware, the only reason we upgraded was because of another upstream issue with Electron having poor performance on MacOS26, [but those fixes have also been backported to 37.6.X](https://releases.electronjs.org/release/v37.6.0).

Unless @CodingWithAnxiety has any other reasons to stay on 38 that is.