### PR TITLE
Catch og:image and twitter:image before grabbing preview image.

### DIFF
--- a/chat/preview/assets/browser.processor.raw.js
+++ b/chat/preview/assets/browser.processor.raw.js
@@ -69,6 +69,22 @@ class FListImagePreviewDomMutator {
   }
 
   detectImage(selectors, body) {
+    // Check for og:image or twitter:image meta tags
+    const imageMeta =
+      document.querySelector('meta[property="og:image"]') ||
+      document.querySelector('meta[name="twitter:image"]');
+
+    if (imageMeta) {
+      const imageUrl = imageMeta.getAttribute('content');
+      if (imageUrl) {
+        const img = document.createElement('img');
+        img.src = imageUrl;
+        this.debug('detectImage.ogFound', imageUrl);
+        return img;
+      }
+    }
+
+    // Fallback to original behavior (First image found)
     let selected = [];
 
     for (const selector of selectors) {


### PR DESCRIPTION
Adds just a few lines, checking for og:image and twitter:image (and more if wanted!) before loading the first image. Fixes previews broken on sites that don't prepend some image to show first!