### PR TITLE
Adds generic components for toggling settings

### DIFF
--- a/chat/ConversationSettings.vue
+++ b/chat/ConversationSettings.vue
@@ -9,59 +9,55 @@
     iconClass="fas fa-gear"
   >
     <div class="mb-3">
-      <label class="control-label" :for="'notify' + conversation.key">{{
-        l('conversationSettings.notify')
-      }}</label>
-      <select
-        class="form-select"
-        :id="'notify' + conversation.key"
-        v-model="notify"
-      >
-        <option :value="setting.Default">
-          {{ l('conversationSettings.default') }}
-        </option>
-        <option :value="setting.True">
-          {{ l('conversationSettings.true') }}
-        </option>
-        <option :value="setting.False">
-          {{ l('conversationSettings.false') }}
-        </option>
-      </select>
-    </div>
-    <div class="mb-3">
-      <label class="control-label" :for="'highlight' + conversation.key">{{
-        l('settings.highlight')
-      }}</label>
-      <select
-        class="form-select"
-        :id="'highlight' + conversation.key"
-        v-model="highlight"
-      >
-        <option :value="setting.Default">
-          {{ l('conversationSettings.default') }}
-        </option>
-        <option :value="setting.True">
-          {{ l('conversationSettings.true') }}
-        </option>
-        <option :value="setting.False">
-          {{ l('conversationSettings.false') }}
-        </option>
-      </select>
-    </div>
-    <div class="mb-3">
-      <div class="form-check">
-        <input
-          class="form-check-input"
-          type="checkbox"
-          id="defaultHighlights"
-          v-model="defaultHighlights"
-        />
-        <label class="form-check-label" for="defaultHighlights">
-          {{ l('settings.defaultHighlights') }}
-        </label>
+      <div class="d-flex p-2 justify-content-between align-items-start">
+        <div class="w-50">
+          <label class="control-label" :for="'notify' + conversation.key">{{
+            l('conversationSettings.notify')
+          }}</label>
+          <div class="text-muted">
+            {{ l('conversationSettings.notify.description') }}
+          </div>
+        </div>
+        <settings-radio
+          v-model="notify"
+          :name="'notify' + conversation.key"
+          :id="'notify' + conversation.key"
+        ></settings-radio>
+      </div>
+      <div class="d-flex p-2 justify-content-between align-items-start">
+        <div class="w-50">
+          <label class="control-label" :for="'highlight' + conversation.key">{{
+            l('settings.highlight')
+          }}</label>
+        </div>
+        <settings-radio
+          v-model="highlight"
+          :name="'highlight' + conversation.key"
+        ></settings-radio>
       </div>
     </div>
     <div class="mb-3">
+      <div class="d-flex p-2 justify-content-between align-items-start">
+        <div class="w-50">
+          <label
+            class="control-label"
+            :for="'defaultHighlights' + conversation.key"
+          >
+            {{ l('settings.defaultHighlights') }}
+          </label>
+          <!--
+          <div class="text-muted">
+            {{ l('conversationSettings.defaultHighlights.description') }}
+          </div>
+          -->
+        </div>
+        <settings-checkbox
+          v-model="defaultHighlights"
+          :name="'defaultHighlights' + conversation.key"
+        ></settings-checkbox>
+      </div>
+    </div>
+    <div class="mb-3 p-2">
       <label class="control-label" :for="'highlightWords' + conversation.key">{{
         l('settings.highlightWords')
       }}</label>
@@ -71,7 +67,7 @@
         v-model="highlightWords"
       />
     </div>
-    <div class="mb-3">
+    <div class="mb-3 p-2">
       <label class="control-label" :for="'highlightUsers' + conversation.key">{{
         l('settings.highlightUsers.conversation')
       }}</label>
@@ -82,44 +78,34 @@
       />
     </div>
     <div class="mb-3">
-      <label class="control-label" :for="'joinMessages' + conversation.key">{{
-        l('settings.joinMessages')
-      }}</label>
-      <select
-        class="form-select"
-        :id="'joinMessages' + conversation.key"
-        v-model="joinMessages"
-      >
-        <option :value="setting.Default">
-          {{ l('conversationSettings.default') }}
-        </option>
-        <option :value="setting.True">
-          {{ l('conversationSettings.true') }}
-        </option>
-        <option :value="setting.False">
-          {{ l('conversationSettings.false') }}
-        </option>
-      </select>
+      <div class="d-flex p-2 justify-content-between align-items-start">
+        <div class="w-50">
+          <label
+            class="control-label"
+            :for="'joinMessages' + conversation.key"
+            >{{ l('settings.joinMessages') }}</label
+          >
+        </div>
+        <settings-radio
+          v-model="joinMessages"
+          :name="'joinMessages' + conversation.key"
+        ></settings-radio>
+      </div>
     </div>
     <div class="mb-3">
-      <label class="control-label" :for="'logMessages' + conversation.key">{{
-        l('conversationSettings.logMessages')
-      }}</label>
-      <select
-        class="form-select"
-        :id="'logMessages' + conversation.key"
-        v-model="logMessages"
-      >
-        <option :value="setting.Default">
-          {{ l('conversationSettings.default') }}
-        </option>
-        <option :value="setting.True">
-          {{ l('conversationSettings.true') }}
-        </option>
-        <option :value="setting.False">
-          {{ l('conversationSettings.false') }}
-        </option>
-      </select>
+      <div class="d-flex p-2 justify-content-between align-items-start">
+        <div class="w-50">
+          <label
+            class="control-label"
+            :for="'logMessages' + conversation.key"
+            >{{ l('conversationSettings.logMessages') }}</label
+          >
+        </div>
+        <settings-radio
+          v-model="logMessages"
+          :name="'logMessages' + conversation.key"
+        ></settings-radio>
+      </div>
     </div>
   </modal>
 </template>
@@ -127,12 +113,18 @@
 <script lang="ts">
   import { Component, Prop } from '@f-list/vue-ts';
   import CustomDialog from '../components/custom_dialog';
+  import SettingsRadio from '../components/SettingsRadio.vue';
+  import SettingsCheckbox from '../components/SettingsCheckbox.vue';
   import Modal from '../components/Modal.vue';
   import { Conversation } from './interfaces';
   import l from './localize';
 
   @Component({
-    components: { modal: Modal }
+    components: {
+      modal: Modal,
+      'settings-radio': SettingsRadio,
+      'settings-checkbox': SettingsCheckbox
+    }
   })
   export default class ConversationSettings extends CustomDialog {
     @Prop({ required: true })

--- a/chat/locales/en_us.json
+++ b/chat/locales/en_us.json
@@ -324,6 +324,7 @@
   "conversationSettings.false": "No",
   "conversationSettings.logMessages": "Log messages",
   "conversationSettings.notify": "Notify for messages",
+  "conversationSettings.notify.description": "Sends a notification every time a message is sent.",
   "conversationSettings.save": "Save settings",
   "conversationSettings.title": "Tab Settings",
   "conversationSettings.true": "Yes",

--- a/components/SettingsCheckbox.vue
+++ b/components/SettingsCheckbox.vue
@@ -1,0 +1,49 @@
+<template>
+  <div
+    class="btn-group"
+    role="group input-group"
+    aria-label="Basic radio toggle button group"
+  >
+    <input
+      type="radio"
+      class="btn-check form-control"
+      :name="name"
+      :id="`${name}-true`"
+      autocomplete="off"
+      :title="l('conversationSettings.true')"
+      :checked="value === true"
+      @change="$emit('input', true)"
+    />
+    <label class="btn btn-outline-success" :for="`${name}-true`">
+      <i class="fa-solid fa-check"></i>
+    </label>
+
+    <input
+      type="radio"
+      class="btn-check"
+      :name="name"
+      :id="`${name}-false`"
+      autocomplete="off"
+      :title="l('conversationSettings.false')"
+      :checked="value === false"
+      @change="$emit('input', false)"
+    />
+    <label class="btn btn-outline-danger" :for="`${name}-false`">
+      <i class="fa-solid fa-xmark"></i>
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import l from '../chat/localize';
+
+  interface Props {
+    value: boolean;
+    name: string;
+  }
+
+  defineProps<Props>();
+  defineEmits<{
+    input: [value: boolean];
+  }>();
+</script>

--- a/components/SettingsRadio.vue
+++ b/components/SettingsRadio.vue
@@ -1,0 +1,66 @@
+<template>
+  <div
+    class="btn-group"
+    role="group input-group"
+    aria-label="Basic radio toggle button group"
+  >
+    <input
+      type="radio"
+      class="btn-check form-control"
+      :name="name"
+      :id="`${name}-true`"
+      autocomplete="off"
+      :title="l('conversationSettings.true')"
+      :checked="value === setting.True"
+      @change="$emit('input', setting.True)"
+    />
+    <label class="btn btn-outline-success" :for="`${name}-true`">
+      <i class="fa-solid fa-check"></i>
+    </label>
+
+    <input
+      type="radio"
+      class="btn-check"
+      :name="name"
+      :id="`${name}-default`"
+      autocomplete="off"
+      :title="l('conversationSettings.default')"
+      :checked="value === setting.Default"
+      @change="$emit('input', setting.Default)"
+    />
+    <label class="btn btn-outline-secondary" :for="`${name}-default`">
+      <i class="fa-solid fa-minus"></i>
+    </label>
+
+    <input
+      type="radio"
+      class="btn-check"
+      :name="name"
+      :id="`${name}-false`"
+      autocomplete="off"
+      :title="l('conversationSettings.false')"
+      :checked="value === setting.False"
+      @change="$emit('input', setting.False)"
+    />
+    <label class="btn btn-outline-danger" :for="`${name}-false`">
+      <i class="fa-solid fa-xmark"></i>
+    </label>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { Conversation as Interfaces } from '../chat/interfaces';
+  import l from '../chat/localize';
+
+  interface Props {
+    value: Interfaces.Setting;
+    name: string;
+  }
+
+  defineProps<Props>();
+  defineEmits<{
+    input: [value: Interfaces.Setting];
+  }>();
+
+  const setting = Interfaces.Setting;
+</script>


### PR DESCRIPTION
This PR is more for laying a tiny bit of groundwork for the global settings system where users will be able to override the character-specific settings against their global values. Instead of only letting them be defined on a character-level (and thus won't allow you to set a default).

This also redesigns the channel/ conversation settings menu to use these new components, so that they don't go to waste for now :)

Before and after:

<img width="1094" height="1516" alt="old" src="https://github.com/user-attachments/assets/c46dccf3-adf6-4e9c-a7c9-7a86c321141a" />
<img width="1094" height="1640" alt="new" src="https://github.com/user-attachments/assets/6249187a-3df8-48f2-8ffd-57b914aa9ace" />
