### PR TITLE
fix: Broken custom portrait links show standard portrait instead

### DIFF
--- a/bbcode/IconView.vue
+++ b/bbcode/IconView.vue
@@ -31,7 +31,6 @@
   export default class IconView extends Vue {
     Utils = Utils;
     characterImage = characterImage;
-    imageError = false;
 
     @Prop({ required: true })
     readonly character!: Character;
@@ -88,7 +87,6 @@
     }
 
     onImageError(): void {
-      this.imageError = true;
       this.character.overrides.avatarUrl = undefined;
     }
   }

--- a/learn/recommend/profile-recommendation.ts
+++ b/learn/recommend/profile-recommendation.ts
@@ -95,7 +95,6 @@ export class ProfileRecommendationAnalyzer {
     const portraitUrl = ProfileCache.extractHighQualityPortraitURL(
       this.profile.character.description
     );
-    console.log(`HQ Portrait URL: ${portraitUrl}`);
 
     if (!portraitUrl) {
       this.add(


### PR DESCRIPTION
Leaving this as a draft for now, because I don't know the performance implications of removing the ``v-once`` directive yet. 

It does work if you leave it in, but it will only show the placeholder original image once you have the page rerender the icon for any reason (like switching conversations). But if you remove it, it will work instantly.