### PR TITLE
Window tab animations (but good)

### DIFF
--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -724,11 +724,11 @@
 
       // Use requestAnimationFrame for smooth animation
       requestAnimationFrame(() => {
-        el.style.transition = 'all 0.3s ease-out';
+        el.style.transition = 'all 0.15s ease-out';
         el.style.opacity = '1';
         el.style.transform = 'translateX(0)';
 
-        setTimeout(done, 300);
+        setTimeout(done, 150);
       });
     }
 
@@ -738,10 +738,10 @@
         return;
       }
 
-      el.style.transition = 'opacity 0.2s ease-in';
+      el.style.transition = 'opacity 0.1s ease-in';
       el.style.opacity = '0';
 
-      setTimeout(done, 200);
+      setTimeout(done, 100);
     }
 
     getThemeClass() {


### PR DESCRIPTION
Before reverting the previous attempt with 1ce5d66fb436a09da884da4bd98bbafb1ad2f2b3 and 828f980107d6dec6af9583640133f6a0e90063b0, window tab animations were handled through a ``<transition-group>`` Vue root-level component.

While this works well in isolation, there was too much behaviour that directly relied on the state of tab objects-- represented with the actual DOM nodes. As a result, there were far too many issues to easily resolve and at some point going back to the drawing board is a better idea than to restructure large amounts of codes for some eyecandy.

This new approach is a lot simpler, since it just relies on some JS hooks in the Window.vue component to handle playing the animations upon tab creation/ removal. Issues that'd otherwise result from dangling DOM references when closing a window directly are handled by adding a safety check that gets enabled during the ``destroyAllTabs()`` function.