### PR TITLE
Fix Open in Incognito not keeping the full URL

### DIFF
--- a/electron/chat.ts
+++ b/electron/chat.ts
@@ -92,7 +92,7 @@ function openIncognito(url: string): void {
   for (const key in commands)
     if (browser!.indexOf(key) !== -1)
       start = commands[<keyof typeof commands>key];
-  exec(`start ${start} ${url}`);
+  exec(`start ${start} "${url}"`);
 }
 
 const wordPosSearch = new WordPosSearch();


### PR DESCRIPTION
Quick fix to cases where some links won't Open in Incognito properly due to certain characters in the URL, namely ampersand (&).

this has been plaguing me for years idk why it took me this long to look into it lol