### PR TITLE
Feature/bug 531 tip typo

### DIFF
--- a/chat/locales/en_us.json
+++ b/chat/locales/en_us.json
@@ -908,7 +908,7 @@
   "tips.25": "Regularly backup your logs and settings using the export feature found in the app menu.",
   "tips.26": "You can easily search and compare kinks in the profile viewer by using the new buttons there.",
   "tips.27": "Don't want to accidentally send an ad as a chat message? Check if the text box is blue, and the little buttons on the right side are set to 'Ad'.",
-  "tips.28": "Your manual kink preferences for genders will always take presedence over your orientation.",
+  "tips.28": "Your manual kink preferences for genders will always take precedence over your orientation.",
   "tips.29": "Press [kbd]Shift[/kbd] + [kbd]Enter[/kbd] while typing a message to insert a newline without sending (or to send the message when \"Enter sends messages\" is turned off).",
   "title": "Horizon",
   "title.beta": "Horizon (Beta)",


### PR DESCRIPTION
Solution to issue 531: https://github.com/Fchat-Horizon/Horizon/issues/531

Small typo in tip 28, written as "presedence" instead of "precedence."