### PR TITLE
Implements infinite loading + scrolling for e-icon search results

### DIFF
--- a/bbcode/EIconSelector.vue
+++ b/bbcode/EIconSelector.vue
@@ -736,6 +736,14 @@
       this.runSearch();
 
       this.refreshing = false;
+
+      this.$nextTick(() => {
+        // reattach scroll listener after refresh
+        const resultsContainer = this.$refs['resultsContainer'] as HTMLElement;
+        if (resultsContainer) {
+          resultsContainer.addEventListener('scroll', this.handleScroll);
+        }
+      });
     }
 
     setFocus(): void {


### PR DESCRIPTION
Allows you to scroll through **all** e-icon search results instead of just a flat 301 maximum. For performance purposes it only loads 77 results at a time (1.5 pages) until you scroll to the bottom, which should help speed up loading while we're at it.

Technically the random and blank search results only scroll up to 2000 results, but I _really_ don't think anyone's scrolling further than that