### PR TITLE
Prevent icon cutoff

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -937,9 +937,9 @@
         }
       }
       &.item-private {
-        padding-left: 0;
-        padding-top: 0;
-        padding-bottom: 0;
+        padding-left: 1px;
+        padding-top: 1px;
+        padding-bottom: 1px;
 
         .online-status {
           padding-left: 1px;


### PR DESCRIPTION
Icons in private messages that are 100x100 have their leftmost pixel cut off.

Added a single pixel of left padding. While testing, noticed that the grey bubble could also be smaller than the chat icon at some font sizes, so added top and bottom padding too.

Examples of old behavior:
<img width="11" height="84" alt="image" src="https://github.com/user-attachments/assets/c676dbb4-48ed-486e-ad95-42b72013c076" />
<img width="68" height="14" alt="image" src="https://github.com/user-attachments/assets/381dead8-db7f-4d6b-b28d-d389ffe76441" />

After my changes:
<img width="12" height="58" alt="image" src="https://github.com/user-attachments/assets/c39378ff-886b-4106-90ae-515dde631d02" />
<img width="72" height="16" alt="image" src="https://github.com/user-attachments/assets/4193e598-40da-442f-9a8c-2e3d4f33c2ed" />

I know it probably seems trivial and pointless, but it is annoying to see an icons outline only outlining 3/4ths of the icon! I tested the behavior with multiple font sizes, and I didn't see any change to how it was at 24, but at 14 was where that first case of the icon being larger than the box it lived in was, and the left icon issue was most common at that size.