### PR TITLE
Convert character_select.vue to Composition API

### DIFF
--- a/components/character_select.vue
+++ b/components/character_select.vue
@@ -1,5 +1,5 @@
 <template>
-  <select v-model="value" @change="onSelectChange" class="form-select">
+  <select :value="selected" @change="onSelectChange" class="form-select">
     <option
       v-for="character in characters"
       :key="character.id"
@@ -17,19 +17,34 @@
   import * as Utils from '../site/utils';
 
   const props = defineProps<{
+    // Maintaining Vue 2 backwards-compat, remove after full Vue 3 migration
     value: number;
+
+    // Forward-compat for Vue 3
+    modelValue: number;
   }>();
 
   const emit = defineEmits<{
-    (e: 'update:value', value: number): void;
+    // Maintaining Vue 2 backwards-compat, remove after full Vue 3 migration
+    (e: 'input', value: number): void;
+
+    // Forward-compat for Vue 3
+    (e: 'update:modelValue', value: number): void;
   }>();
 
   const characters = computed<SimpleCharacter[]>(() => Utils.characters);
+  const selected = computed<number>(() => {
+    return props.modelValue !== undefined ? props.modelValue : props.value;
+  });
 
   const onSelectChange = (evt: Event): void => {
     const target = evt.target as HTMLSelectElement;
     const newValue = parseInt(target.value, 10);
 
-    emit('update:value', newValue);
+    // Maintaining Vue 2 backwards-compat, remove after full Vue 3 migration
+    emit('input', newValue);
+
+    // Forward-compat for Vue 3
+    emit('update:modelValue', newValue);
   };
 </script>


### PR DESCRIPTION
(Disclaimer: I am a Vue noobie and am relying on migration documents and other examples I've found. Please validate this work carefully since this isn't my immediate domain of expertise 😉 ).

Converts a simple Vue component (character-select) to the new Composition API - using this as a quick trial to make sure I'm on the right path here, before converting other simple components and moving on to much more involved migrations. Testing seemed to work normally for this element sans the default not being set (looking into now) but would love more eyes to test and find flaws.

Resolves #479 