### PR TITLE
Fixes window focus event firing incorrectly on KDE Plasma Wayland

### DIFF
--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -434,7 +434,7 @@
         this.activeTab!.view.webContents.focus()
       );
       window.addEventListener('focus', () => {
-        if (!browserWindow.isMinimized()) {
+        if (!browserWindow.isMinimized() && browserWindow.isFocused()) {
           this.activeTab!.view.webContents.focus();
           this.activeTab!.view.webContents.send('active-tab');
         }


### PR DESCRIPTION
On KDE Plasma 6 (Wayland) the window focus event seems to fire when alt-tabbing out of the app window, which then causes the taskbar icon to glow when it shouldn't.

While this patch fixes that issue, we need to actually test it across different platforms to see if it won't break anything there either. Alternatively, we can see if we can reproduce the issue in Electron Fiddle and potentially get it fixed upstream instead.