### PR TITLE
Implement proper embedding for Bluesky links

### DIFF
--- a/chat/preview/image-url-mutator.ts
+++ b/chat/preview/image-url-mutator.ts
@@ -109,7 +109,8 @@ export class ImageUrlMutator {
       async (url: string, match: RegExpMatchArray): Promise<string> => {
         const path = match[1];
 
-        return `https://d.fxbsky.app/${path}`;
+        // https://github.com/Lexedia/VixBluesky/wiki/Features#custom-pds-video-support
+        return `https://r.v.bskx.app/${path}`;
       }
     );
 

--- a/chat/preview/image-url-mutator.ts
+++ b/chat/preview/image-url-mutator.ts
@@ -105,6 +105,15 @@ export class ImageUrlMutator {
     );
 
     this.add(
+      /^https?:\/\/bsky\.app\/(profile\/[\w\.:]+\/post\/[\w]+)/,
+      async (url: string, match: RegExpMatchArray): Promise<string> => {
+        const path = match[1];
+
+        return `https://d.fxbsky.app/${path}`;
+      }
+    );
+
+    this.add(
       /^https?:\/\/rule34video.com\/videos\/([0-9a-zA-Z-_]+)/,
       async (_url: string, match: RegExpMatchArray): Promise<string> => {
         const videoId = match[1];

--- a/chat/preview/image-url-mutator.ts
+++ b/chat/preview/image-url-mutator.ts
@@ -105,9 +105,9 @@ export class ImageUrlMutator {
     );
 
     this.add(
-      /^https?:\/\/bsky\.app\/(profile\/[\w\.:]+\/post\/[\w]+)/,
+      /^https?:\/\/([\w-]*bsky|bskye|bskyx|bsyy)\.app\/(profile\/[\w.:]+\/post\/\w+)/,
       async (url: string, match: RegExpMatchArray): Promise<string> => {
-        const path = match[1];
+        const path = match[2];
 
         // https://github.com/Lexedia/VixBluesky/wiki/Features#custom-pds-video-support
         return `https://r.v.bskx.app/${path}`;


### PR DESCRIPTION
FxEmbed (and every other embedder that I tried) doesn't play nicely with Bluesky videos in Horizon, so instead we're using [VixBluesky](https://github.com/Lexedia/VixBluesky) which is the only solution I've found that renders videos properly. 

Unfortunately, we either have to choose between videos working OR having a working gallery view for posts with multiple images, but I figured that working videos mattered more. We don't even show gallery views for Twitter posts, anyways. 

Closes #579 