### PR TITLE
Fixes Redgifs previews embedding

### DIFF
--- a/chat/preview/image-url-mutator.ts
+++ b/chat/preview/image-url-mutator.ts
@@ -137,16 +137,6 @@ export class ImageUrlMutator {
     );
 
     this.add(
-      /^https?:\/\/(www.|v3.)?gifdeliverynetwork.com\/([a-z0-9A-Z]+)/,
-      async (_url: string, match: RegExpMatchArray): Promise<string> => {
-        const redgifId = match[2];
-
-        // Redgifs is correct
-        return `https://www.redgifs.com/ifr/${redgifId}?controls=0&hd=1`;
-      }
-    );
-
-    this.add(
       /^https?:\/\/(www.|v3.)?redgifs.com\/watch\/([a-z0-9A-Z]+)/,
       async (_url: string, match: RegExpMatchArray): Promise<string> => {
         const redgifId = match[2];


### PR DESCRIPTION
Fixed Redgifs preview embedding by pulling the direct HD URL from the API. If the API token is ever invalid (session disconnected, token expires, etc.), it'll request a new one before defaulting to the previous iframe. Images on Redgifs are natively shared by the direct image link, so those should just work regardless.

Also removed the gifdeliverynetwork.com handler, I'm 99% sure that's a very outdated URL that redgifs no longer uses, but we can still keep it if needed.

Closes #302