### PR TITLE
Fix for .focus() on alt+tab

### DIFF
--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -430,18 +430,20 @@
           this.show(this.tabMap[id]);
         }
       );
+
+      // Handle explicit focus requests
+      electron.ipcRenderer.on('do-focus', () => {
+        if (!browserWindow.isMinimized()) {
+          this.activeTab!.view.webContents.focus();
+          this.activeTab!.view.webContents.send('active-tab');
+        }
+      });
+
       document.addEventListener('click', () =>
         this.activeTab!.view.webContents.focus()
       );
       window.addEventListener('focus', () => {
         if (!browserWindow.isMinimized()) {
-          // This fixes the bug but isn't a good solution
-          if (
-            this._altTabFlag.altDown ||
-            Date.now() - this._altTabFlag.lastAltTime < 300
-          ) {
-            this.activeTab!.view.webContents.focus();
-          }
           this.activeTab!.view.webContents.send('active-tab');
         }
       });

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -47,7 +47,7 @@ import { defaultHost, GeneralSettings } from './common';
 import MenuItemConstructorOptions = electron.MenuItemConstructorOptions;
 import * as _ from 'lodash';
 import { AdCoordinatorHost } from '../chat/ads/ad-coordinator-host';
-import { IpcMainEvent, session } from 'electron';
+import { IpcMainEvent, IpcMainInvokeEvent, session } from 'electron';
 import Axios from 'axios';
 import * as browserWindows from './browser_windows';
 import * as remoteMain from '@electron/remote/main';
@@ -961,6 +961,19 @@ async function onReady(): Promise<void> {
   electron.ipcMain.handle('get-connected-characters', () => {
     return characters.slice();
   });
+
+  electron.ipcMain.handle(
+    'request-focus',
+    async (event: IpcMainInvokeEvent) => {
+      const window = electron.BrowserWindow.fromWebContents(event.sender);
+      if (window && !window.isMinimized()) {
+        // Send a do-focus event to the window
+        window.webContents.send('do-focus');
+        return { success: true };
+      }
+      return { success: false };
+    }
+  );
 
   const adCoordinator = new AdCoordinatorHost();
   electron.ipcMain.on('request-send-ad', (event: IpcMainEvent, adId: string) =>

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -1,4 +1,5 @@
 import * as remote from '@electron/remote';
+import * as electron from 'electron';
 import core from '../chat/core';
 import { Conversation } from '../chat/interfaces';
 //tslint:disable-next-line:match-default-export-name
@@ -27,13 +28,15 @@ export default class Notifications extends BaseNotifications {
         title,
         this.getOptions(conversation, body, icon)
       );
-      notification.onclick = () => {
+      notification.onclick = async () => {
         browserWindow.webContents.send(
           'show-tab',
           remote.getCurrentWebContents().id
         );
         conversation.show();
         if (browserWindow.isMinimized()) browserWindow.restore();
+        // Request focus via IPC handler
+        await electron.ipcRenderer.invoke('request-focus');
         browserWindow.focus();
         notification.close();
       };


### PR DESCRIPTION
This isn't an ideal solution, it just brute-force checks if you were using alt before switching.

A better solution would swap out when we run the .focus and do it only for clicking on a notification box or optionally receiving a message.

Currently
```js
// notifications.ts
browserWindow.webContents.send('request-focus');

// Window.vue  
electron.ipcRenderer.on('request-focus', () => {
  // handle focus
});
```

Maybe instead of calling that request focus in there we could listen for the ipc from clicking, or whatever.
Then trigger a slightly smarter `do-focus` somewhere else?