### PR TITLE
More character linking for views/console logs

### DIFF
--- a/chat/ManageChannel.vue
+++ b/chat/ManageChannel.vue
@@ -58,7 +58,10 @@
         >
           <i class="fas fa-times"></i>
         </a>
-        {{ mod }}
+        <user-view
+          :character="getCharacter(mod)"
+          :isMarkerShown="shouldShowMarker"
+        ></user-view>
       </div>
       <div style="display: flex; margin-top: 5px">
         <input
@@ -88,9 +91,10 @@
   import core from './core';
   import { Channel, channelModes } from './interfaces';
   import l from './localize';
+  import UserView from './UserView.vue';
 
   @Component({
-    components: { modal: Modal, 'bbcode-editor': Editor }
+    components: { modal: Modal, 'bbcode-editor': Editor, 'user-view': UserView }
   })
   export default class ManageChannel extends CustomDialog {
     @Prop({ required: true })
@@ -121,6 +125,14 @@
         this.channel.owner === core.connection.character ||
         core.characters.ownCharacter.isChatOp
       );
+    }
+
+    getCharacter(name: string): Character {
+      return core.characters.get(name);
+    }
+
+    get shouldShowMarker(): boolean {
+      return core.state.settings.horizonShowGenderMarker;
     }
 
     modAdd(): void {

--- a/chat/ManageChannel.vue
+++ b/chat/ManageChannel.vue
@@ -58,10 +58,7 @@
         >
           <i class="fas fa-times"></i>
         </a>
-        <user-view
-          :character="getCharacter(mod)"
-          :isMarkerShown="shouldShowMarker"
-        ></user-view>
+        <user-view :character="getCharacter(mod)"></user-view>
       </div>
       <div style="display: flex; margin-top: 5px">
         <input
@@ -129,10 +126,6 @@
 
     getCharacter(name: string): Character {
       return core.characters.get(name);
-    }
-
-    get shouldShowMarker(): boolean {
-      return core.state.settings.horizonShowGenderMarker;
     }
 
     modAdd(): void {

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -723,10 +723,7 @@
               style="cursor: pointer"
               @click.stop="hidden.splice(i, 1)"
             ></span>
-            <user-view
-              :character="getCharacter(user)"
-              :isMarkerShown="shouldShowMarker"
-            ></user-view>
+            <user-view :character="getCharacter(user)"></user-view>
           </div>
         </template>
         <template v-else>{{ l('settings.hideAds.empty') }}</template>
@@ -823,10 +820,7 @@
               :aria-label="l('user.unignore')"
               @click.stop="unignore(user)"
             ></span>
-            <user-view
-              :character="getCharacter(user)"
-              :isMarkerShown="shouldShowMarker"
-            ></user-view>
+            <user-view :character="getCharacter(user)"></user-view>
           </div>
         </template>
         <template v-else>{{
@@ -1535,9 +1529,6 @@
     }
     getCharacter(name: string): Character {
       return core.characters.get(name);
-    }
-    get shouldShowMarker(): boolean {
-      return core.state.settings.horizonShowGenderMarker;
     }
   }
 </script>

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -723,7 +723,10 @@
               style="cursor: pointer"
               @click.stop="hidden.splice(i, 1)"
             ></span>
-            {{ user }}
+            <user-view
+              :character="getCharacter(user)"
+              :isMarkerShown="shouldShowMarker"
+            ></user-view>
           </div>
         </template>
         <template v-else>{{ l('settings.hideAds.empty') }}</template>
@@ -820,7 +823,10 @@
               :aria-label="l('user.unignore')"
               @click.stop="unignore(user)"
             ></span>
-            {{ user }}
+            <user-view
+              :character="getCharacter(user)"
+              :isMarkerShown="shouldShowMarker"
+            ></user-view>
           </div>
         </template>
         <template v-else>{{
@@ -1138,6 +1144,7 @@
   import _ from 'lodash';
   import { matchesSmartFilters } from '../learn/filter/smart-filter';
   import { EventBus } from './preview/event-bus';
+  import UserView from './UserView.vue';
 
   const bbcodeParser = new UserInterfaceBBCodeParser();
 
@@ -1147,7 +1154,8 @@
       editor: Editor,
       tabs: Tabs,
       bbcode: BBCodeView(bbcodeParser),
-      'settings-checkbox': SettingsCheckbox
+      'settings-checkbox': SettingsCheckbox,
+      'user-view': UserView
     }
   })
   export default class SettingsView extends CustomDialog {
@@ -1524,6 +1532,12 @@
 
     setSmartFilter(key: keyof SmartFilterSelection, value: any): void {
       this.risingFilter.smartFilters[key] = value.target.checked;
+    }
+    getCharacter(name: string): Character {
+      return core.characters.get(name);
+    }
+    get shouldShowMarker(): boolean {
+      return core.state.settings.horizonShowGenderMarker;
     }
   }
 </script>

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -1515,9 +1515,12 @@ export default function (this: any): Interfaces.State {
 
   connection.onMessage('IGN', async (data, time) => {
     if (data.action !== 'add' && data.action !== 'delete') return;
-    const text = l(`events.ignore_${data.action}`, data.character);
-    state.selectedConversation.infoText = text;
-    return addEventMessage(new EventMessage(text, time));
+    const key = `events.ignore_${data.action}`;
+    const name = data.character;
+    state.selectedConversation.infoText = l(key, name);
+    return addEventMessage(
+      new EventMessage(l(key, `[user]${name}[/user]`), time)
+    );
   });
   connection.onMessage('RTB', async (data, time) => {
     let url = 'https://www.f-list.net/';

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -1448,29 +1448,45 @@ export default function (this: any): Interfaces.State {
   connection.onMessage('CBU', async (data, time) => {
     const conv = state.channelMap[data.channel.toLowerCase()];
     if (conv === undefined) return core.channels.leave(data.channel);
-    const text = l('events.ban', conv.name, data.character, data.operator);
-    conv.infoText = text;
-    return addEventMessage(new EventMessage(text, time));
+    const logtext = l(
+      'events.ban',
+      conv.name,
+      `[user]${data.character}[/user]`,
+      `[user]${data.operator}[/user]`
+    );
+    conv.infoText = l('events.ban', conv.name, data.character, data.operator);
+    return addEventMessage(new EventMessage(logtext, time));
   });
   connection.onMessage('CKU', async (data, time) => {
     const conv = state.channelMap[data.channel.toLowerCase()];
     if (conv === undefined) return core.channels.leave(data.channel);
-    const text = l('events.kick', conv.name, data.character, data.operator);
-    conv.infoText = text;
-    return addEventMessage(new EventMessage(text, time));
+    const logtext = l(
+      'events.kick',
+      conv.name,
+      `[user]${data.character}[/user]`,
+      `[user]${data.operator}[/user]`
+    );
+    conv.infoText = l('events.kick', conv.name, data.character, data.operator);
+    return addEventMessage(new EventMessage(logtext, time));
   });
   connection.onMessage('CTU', async (data, time) => {
     const conv = state.channelMap[data.channel.toLowerCase()];
     if (conv === undefined) return core.channels.leave(data.channel);
-    const text = l(
+    const logtext = l(
+      'events.timeout',
+      conv.name,
+      `[user]${data.character}[/user]`,
+      `[user]${data.operator}[/user]`,
+      data.length.toString()
+    );
+    conv.infoText = l(
       'events.timeout',
       conv.name,
       data.character,
       data.operator,
       data.length.toString()
     );
-    conv.infoText = text;
-    return addEventMessage(new EventMessage(text, time));
+    return addEventMessage(new EventMessage(logtext, time));
   });
   connection.onMessage('BRO', async (data, time) => {
     if (data.character !== undefined) {

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -1451,7 +1451,7 @@ export default function (this: any): Interfaces.State {
     const logtext = l(
       'events.ban',
       conv.name,
-      `[user]${data.character}[/user]`,
+      data.character,
       `[user]${data.operator}[/user]`
     );
     conv.infoText = l('events.ban', conv.name, data.character, data.operator);
@@ -1463,7 +1463,7 @@ export default function (this: any): Interfaces.State {
     const logtext = l(
       'events.kick',
       conv.name,
-      `[user]${data.character}[/user]`,
+      data.character,
       `[user]${data.operator}[/user]`
     );
     conv.infoText = l('events.kick', conv.name, data.character, data.operator);
@@ -1475,7 +1475,7 @@ export default function (this: any): Interfaces.State {
     const logtext = l(
       'events.timeout',
       conv.name,
-      `[user]${data.character}[/user]`,
+      data.character,
       `[user]${data.operator}[/user]`,
       data.length.toString()
     );


### PR DESCRIPTION
Adds proper user views to the following areas:
- Ignored/Hidden user lists
- Ignore/unignore and kick/ban/timeout chat messages (not the toast messages for security)
- Channel moderator list within the channel manage screen

They behave similarly to the rest of the app, where they'll either show a preview of the user's profile or open a new view of the character if clicked. There's some areas that I couldn't add user linking to (**un**banning users from a channel, etc.) since they seem to be handled as SYS(?) messages and don't have a dedicated handler. 

<img width="203" height="191" alt="image" src="https://github.com/user-attachments/assets/6f707e11-4696-4d25-b9f4-ae5837312359" />
<img width="731" height="79" alt="image" src="https://github.com/user-attachments/assets/b09cf0af-4065-4fac-b67f-088ffa44281a" />
<img width="238" height="87" alt="image" src="https://github.com/user-attachments/assets/83b3c9f8-58d5-42b0-a4ae-49467c76a3c3" />
