### PR TITLE
Add a jump to message button to logs.

### DIFF
--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -111,16 +111,28 @@
       tabindex="-1"
       @scroll="onMessagesScroll"
     >
-      <message-view
+      <div
         v-for="(message, i) in displayedMessages"
-        :message="message"
         :key="message.id"
-        :logs="true"
-        :previous="displayedMessages[i - 1]"
-        :selectable="selectionMode"
-        :selected="selectedMessages.has(message.id)"
-        @toggle-select="onToggleSelect(message, i, $event)"
-      ></message-view>
+        class="message-container"
+        :ref="'message-' + message.id"
+      >
+        <span
+          class="message-jump-icon"
+          @click="jumpToMessage(message.id)"
+          title="Jump to this message"
+        >
+          <i class="fa-solid fa-arrow-up-right-from-square fa-fw"></i>
+        </span>
+        <message-view
+          :message="message"
+          :logs="true"
+          :previous="displayedMessages[i - 1]"
+          :selectable="selectionMode"
+          :selected="selectedMessages.has(message.id)"
+          @toggle-select="onToggleSelect(message, i, $event)"
+        ></message-view>
+      </div>
     </div>
     <div class="input-group" style="flex-shrink: 0">
       <span class="input-group-text">
@@ -644,6 +656,51 @@
     lockScroll = false;
     lastScroll = -1;
 
+    async jumpToMessage(messageId: string): Promise<void> {
+      const targetMessageId = messageId;
+      this.filter = '';
+      await this.$nextTick();
+
+      const messageIndex = this.messages.findIndex(
+        msg => msg.id === targetMessageId
+      );
+
+      if (messageIndex === -1) return;
+      if (this.selectedDate !== undefined) {
+        await this.$nextTick();
+        //This timeout is probably unnecessary when a date is selected.
+        await new Promise(resolve => setTimeout(resolve, 50));
+
+        const messageRef = this.$refs['message-' + targetMessageId];
+        if (messageRef && Array.isArray(messageRef) && messageRef[0]) {
+          const messageElement = messageRef[0] as HTMLElement;
+          messageElement.scrollIntoView({
+            behavior: 'smooth',
+            block: 'center'
+          });
+        }
+        return;
+      }
+
+      const totalMessages = this.messages.length;
+      this.windowStart = Math.max(0, messageIndex - 100);
+      this.windowEnd = Math.min(totalMessages, messageIndex + 100);
+
+      /*
+       * If we remove this timeout the jump will not work with some of the messages.
+       * I've tried getting it to work but it seemingly jumps to a random message.
+       * It's safer to give the messages a little to load and then do the jump.
+       */
+      await this.$nextTick();
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const messageRef = this.$refs['message-' + targetMessageId];
+      if (messageRef && Array.isArray(messageRef) && messageRef[0]) {
+        const messageElement = messageRef[0] as HTMLElement;
+        messageElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }
+
     async onMessagesScroll(ev?: Event): Promise<void> {
       const list = <HTMLElement | undefined>this.$refs['messages'];
       if (this.lockScroll) return;
@@ -717,6 +774,34 @@
   .logs-dialog .modal-body {
     display: flex;
     flex-direction: column;
+  }
+
+  .message-container {
+    position: relative;
+  }
+
+  .message-jump-icon {
+    position: absolute;
+    right: 4px;
+    top: 4px;
+    cursor: pointer;
+    opacity: 0;
+    z-index: 10;
+    padding: 2px 4px;
+    background-color: rgba(0, 0, 0, 0.6);
+    border-radius: 3px;
+    color: #fff;
+    font-size: 0.75rem;
+    line-height: 1;
+  }
+
+  .message-container:hover .message-jump-icon {
+    opacity: 0.7;
+  }
+
+  .message-jump-icon:hover {
+    opacity: 1 !important;
+    background-color: rgba(0, 0, 0, 0.8);
   }
 
   .message-selectable {


### PR DESCRIPTION
Adds a jump to message icon/button to log viewer, I've done some testing and it seems to work with all messages no matter how old it is.

<img width="1868" height="206" alt="image" src="https://github.com/user-attachments/assets/4b77ef58-43b7-402a-b659-9e662bc46c26" />

Alternatively this could have been done in message_view by adding a displaySearchIcon property or something like that but I prefer this.