### PR TITLE
On connection, your character's cache refreshes automatically

### DIFF
--- a/fchat/characters.ts
+++ b/fchat/characters.ts
@@ -262,6 +262,8 @@ export default function (this: void, connection: Connection): Interfaces.State {
       // tslint:disable-next-line no-unnecessary-type-assertion
       core.cache.setProfile(state.ownProfile as CharacterProfile);
 
+      core.cache.profileCache.updateOverrides(state.ownProfile as any);
+
       const hqPortraitUrl = ProfileCache.extractHighQualityPortraitURL(
         state.ownProfile.character.description
       );


### PR DESCRIPTION
Title. No more having to open the profile viewer and refresh just to see any color/portrait/matcher-influencing changes you made. Fixes #660