### PR TITLE
fix: Alerts now use Electron Message box in Electron build.

### DIFF
--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -1092,7 +1092,7 @@
     updateMemo(): void {
       this.memoManager
         ?.set(this.editorMemo)
-        .catch((e: object) => alert(errorToString(e)));
+        .catch((e: object) => core.notifications.alert(errorToString(e)));
       this.userMemo = this.editorMemo;
     }
 
@@ -1115,7 +1115,7 @@
           this.userMemo = this.memoManager.get().memo;
           this.editorMemo = this.userMemo;
         } catch (e) {
-          alert(errorToString(e));
+          core.notifications.alert(errorToString(e));
         }
       }
     }

--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -711,7 +711,7 @@
       const targetChar = core.characters.get(targetName);
 
       if (targetChar.status === 'offline') {
-        alert(l('logs.shareOffline', targetName));
+        core.notifications.alert(l('logs.shareOffline', targetName));
         return;
       }
 
@@ -739,13 +739,13 @@
         .join('');
 
       if (formatted.length > core.connection.vars.priv_max) {
-        alert(l('logs.shareTooLong'));
+        core.notifications.alert(l('logs.shareTooLong'));
         return;
       }
 
       const conv = core.conversations.getPrivate(targetChar);
       await conv.sendMessageEx(formatted);
-      alert(l('logs.shareSuccess'));
+      core.notifications.alert(l('logs.shareSuccess'));
       this.setSelectionMode(false);
     }
 

--- a/chat/UserMenu.vue
+++ b/chat/UserMenu.vue
@@ -268,7 +268,7 @@
           `bookmark-${this.character!.isBookmarked ? 'remove' : 'add'}.php`,
           { name: this.character!.name }
         )
-        .catch((e: object) => alert(errorToString(e)));
+        .catch((e: object) => core.notifications.alert(errorToString(e)));
     }
 
     setHidden(): void {
@@ -305,14 +305,14 @@
         this.memo = this.memoManager.get().memo;
         this.memoLoading = false;
       } catch (e) {
-        alert(errorToString(e));
+        core.notifications.alert(errorToString(e));
       }
     }
 
     updateMemo(): void {
       this.memoManager
         ?.set(this.memo)
-        .catch((e: object) => alert(errorToString(e)));
+        .catch((e: object) => core.notifications.alert(errorToString(e)));
     }
 
     showAdLogs(): void {

--- a/chat/ads/AdLauncher.vue
+++ b/chat/ads/AdLauncher.vue
@@ -287,13 +287,13 @@
 
       if (tags.length === 0) {
         e.preventDefault();
-        alert(l('ads.selectTagRequired'));
+        core.notifications.alert(l('ads.selectTagRequired'));
         return;
       }
 
       if (channelIds.length === 0) {
         e.preventDefault();
-        alert(l('ads.selectChannelRequired'));
+        core.notifications.alert(l('ads.selectChannelRequired'));
         return;
       }
 

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -344,6 +344,7 @@ export interface Notifications {
   playSound(sound: string): void;
   requestPermission(): Promise<void>;
   initSounds(sounds: ReadonlyArray<string>): Promise<void>;
+  alert(message: string): void;
 }
 
 export interface State {

--- a/chat/notifications.ts
+++ b/chat/notifications.ts
@@ -127,6 +127,10 @@ export default class Notifications implements Interface {
     this.hasInitialized = true;
   }
 
+  alert(message: string): void {
+    alert(message);
+  }
+
   private getSoundTheme(): string {
     return (
       (core.state as any).generalSettings?.soundTheme ||

--- a/electron/Index.vue
+++ b/electron/Index.vue
@@ -702,7 +702,7 @@
             ) &&
             process.env.NODE_ENV === 'production'
           ) {
-            alert(l('login.alreadyLoggedIn'));
+            core.notifications.alert(l('login.alreadyLoggedIn'));
             return core.connection.close();
           }
           parent.send('connect', webContents.id, core.connection.character);
@@ -759,12 +759,12 @@
 
     fixLogs(): void {
       if (!electron.ipcRenderer.sendSync('connect', this.fixCharacter))
-        return alert(l('login.alreadyLoggedIn'));
+        return core.notifications.alert(l('login.alreadyLoggedIn'));
       try {
         fixLogs(this.fixCharacter);
-        alert(l('fixLogs.success'));
+        core.notifications.alert(l('fixLogs.success'));
       } catch (e) {
-        alert(l('fixLogs.error'));
+        core.notifications.alert(l('fixLogs.error'));
         throw e;
       } finally {
         electron.ipcRenderer.send('disconnect', this.fixCharacter);

--- a/electron/filesystem.ts
+++ b/electron/filesystem.ts
@@ -250,7 +250,7 @@ function loadIndex(name: string): Index {
         index[file.slice(0, -4).toLowerCase()] = item;
       } catch (e) {
         console.error(e);
-        alert(l('logs.corruption.desktop'));
+        core.notifications.alert(l('logs.corruption.desktop'));
       }
   return index;
 }
@@ -289,7 +289,7 @@ export class Logs implements Logging {
       return messages;
     } catch (e) {
       console.error(e);
-      alert(l('logs.corruption.desktop'));
+      core.notifications.alert(l('logs.corruption.desktop'));
       return [];
     } finally {
       fs.closeSync(fd);
@@ -349,7 +349,7 @@ export class Logs implements Logging {
       return messages;
     } catch (e) {
       console.error(e);
-      alert(l('logs.corruption.desktop'));
+      core.notifications.alert(l('logs.corruption.desktop'));
       return [];
     } finally {
       fs.closeSync(fd);

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -3,6 +3,7 @@ import core from '../chat/core';
 import { Conversation } from '../chat/interfaces';
 //tslint:disable-next-line:match-default-export-name
 import BaseNotifications from '../chat/notifications';
+import l from '../chat/localize';
 
 const browserWindow = remote.getCurrentWindow();
 
@@ -38,5 +39,13 @@ export default class Notifications extends BaseNotifications {
         notification.close();
       };
     }
+  }
+
+  //My bad this also uses Electron remote (for now). We will have to restructure it to use IPC messaging later, but for now at least you can be glad it's only a single reference I added
+  alert(message: string) {
+    remote.dialog.showMessageBox(browserWindow, {
+      title: l('title'),
+      message
+    });
   }
 }


### PR DESCRIPTION
This fixes lockups from ``alert()`` on Windows

Fixes #654
Fixes #234

Making this a PR because I did not go through every single instance of ``alert()`` by hand and tested if replacing it with another synchronous messagebox function would have a negative impact-- though it likely wouldn't.