### PR TITLE
fix: Refreshing a profile correctly stores the new data to the disk database

### DIFF
--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -540,6 +540,11 @@
 
       this.parseTextToAscii(this.character);
 
+      //save to cache if we fetched fresh data
+      if (!cache || skipCache) {
+        await core.cache.profileCache.register(this.character);
+      }
+
       if (cache && cache.meta) {
         this.guestbook = cache.meta.guestbook;
         this.friends = cache.meta.friends;
@@ -602,6 +607,7 @@
         this.character = character;
 
         standardParser.inlines = this.character.character.inlines;
+        await core.cache.profileCache.register(this.character);
 
         this.updateMatches();
 


### PR DESCRIPTION
Literally why did it never do this?? Why is everything related to interfacing with the cache such a dreadful nightmare?

This is the same method used when memos are saved, so if it sucks here then it sucks there too.

Fixes #668