### PR TITLE
Filterable select UX improvements:

### DIFF
--- a/components/Dropdown.vue
+++ b/components/Dropdown.vue
@@ -65,7 +65,8 @@
         default: 3
       }
     },
-    setup(props) {
+    emits: ['opened', 'closed'],
+    setup(props, { emit }) {
       const isOpen = ref(false);
       const menuRef = ref<HTMLElement>();
       const buttonRef = ref<HTMLElement>();
@@ -133,7 +134,12 @@
         }
       };
 
-      watch(isOpen, positionMenu);
+      watch(isOpen, (newValue: boolean) => {
+        positionMenu();
+        nextTick(() => {
+          emit(newValue ? 'opened' : 'closed');
+        });
+      });
 
       const blur = (event: FocusEvent) => {
         let elm = event.relatedTarget as HTMLElement | null;

--- a/components/FilterableSelect.vue
+++ b/components/FilterableSelect.vue
@@ -4,6 +4,8 @@
     linkClass="form-select"
     :keepOpen="multiple"
     :gap="0"
+    @opened="selectOpened"
+    ref="dropdown"
   >
     <template slot="title" v-if="multiple">{{ label }}</template>
     <slot v-else slot="title" :option="selected">{{ label }}</slot>
@@ -15,6 +17,8 @@
         :placeholder="placeholder"
         @mousedown.stop
         @click.stop
+        @keydown.enter="enterPressed"
+        ref="filterInput"
       />
     </div>
     <div class="overflow-auto dropdown-items">
@@ -39,6 +43,7 @@
           @click="select(option)"
           v-for="option in filtered"
           class="dropdown-item"
+          :class="value === option ? 'selected' : ''"
         >
           <slot :option="option">{{ option }}</slot>
         </a>
@@ -97,6 +102,21 @@
       return (<object[]>this.selected).indexOf(option) !== -1;
     }
 
+    selectOpened() {
+      this.$nextTick(() => {
+        (this.$refs['filterInput'] as HTMLInputElement).focus();
+      });
+    }
+
+    enterPressed() {
+      if (this.filtered.length > 0) {
+        this.select(this.filtered[0]);
+        if (!this.multiple) {
+          (this.$refs['dropdown'] as any).isOpen = false;
+        }
+      }
+    }
+
     get filtered(): object[] {
       return this.options.filter(x => this.filterFunc(this.filterRegex, x));
     }
@@ -119,6 +139,10 @@
   .filterable-select {
     .dropdown-items {
       max-height: 200px;
+      .dropdown-item.selected {
+        background-color: var(--bs-dropdown-link-active-bg);
+        color: var(--bs-dropdown-link-active-color);
+      }
     }
 
     button {


### PR DESCRIPTION
- Now shows the value selected
- Opening automatically focuses the filter text input
- Pressing enter in the filter input selects the first option

Making this a PR because I don't want to add this to the pile of issues we potentially have to fix in the 1.36.0 pre-release if stuff breaks.