### PR TITLE
Fixes pinned previews causing unclickable areas of the UI

### DIFF
--- a/chat/preview/ImagePreview.vue
+++ b/chat/preview/ImagePreview.vue
@@ -1029,10 +1029,8 @@
     position: absolute;
     left: 0;
     top: 0;
-    width: max-content;
-    max-width: 50%;
-    height: max-content;
-    max-height: 70%;
+    width: 50%;
+    height: 70%;
     pointer-events: none;
     overflow: visible;
 
@@ -1041,10 +1039,11 @@
     }
 
     &.interactive {
-      pointer-events: auto;
+      pointer-events: none;
 
-      .image-preview-local,
-      .image-preview-auto {
+      .image-preview-toolbar,
+      .image-preview-external,
+      .image-preview-local {
         pointer-events: auto;
       }
     }

--- a/chat/preview/helper/external.ts
+++ b/chat/preview/helper/external.ts
@@ -9,8 +9,6 @@ export class ExternalImagePreviewHelper extends ImagePreviewHelper {
 
   protected urlMutator = new ImageUrlMutator(this.parent.debug);
 
-  protected ratio: number | null = null;
-
   hide(): void {
     const wasVisible = this.visible;
 
@@ -35,10 +33,6 @@ export class ExternalImagePreviewHelper extends ImagePreviewHelper {
 
       this.visible = false;
     }
-  }
-
-  setRatio(ratio: number): void {
-    this.ratio = ratio;
   }
 
   getName(): string {
@@ -139,40 +133,6 @@ export class ExternalImagePreviewHelper extends ImagePreviewHelper {
       ImagePreviewHelper.HTTP_TESTER.test(url) &&
       !(domainName === 'f-list.net' || domainName === 'static.f-list.net')
     );
-  }
-
-  determineScalingRatio(): Record<string, any> {
-    // ratio = width / height
-    const ratio = this.ratio;
-
-    if (!ratio) {
-      return {};
-    }
-
-    const ww = window.innerWidth;
-    const wh = window.innerHeight;
-
-    const maxWidth = Math.round(ww * 0.5);
-    const maxHeight = Math.round(wh * 0.7);
-
-    if (ratio >= 1) {
-      const presumedWidth = maxWidth;
-      const presumedHeight = presumedWidth / ratio;
-
-      return {
-        width: `${presumedWidth}px`,
-        height: `${presumedHeight}px`
-      };
-      // tslint:disable-next-line:unnecessary-else
-    } else {
-      const presumedHeight = maxHeight;
-      const presumedWidth = presumedHeight * ratio;
-
-      return {
-        width: `${presumedWidth}px`,
-        height: `${presumedHeight}px`
-      };
-    }
   }
 
   renderStyle(): Record<string, any> {

--- a/chat/preview/helper/helper.ts
+++ b/chat/preview/helper/helper.ts
@@ -7,6 +7,7 @@ export abstract class ImagePreviewHelper {
   protected url: string | undefined = 'about:blank';
   protected parent: ImagePreview;
   protected debug: boolean;
+  protected ratio: number | null = null;
 
   abstract show(url: string | undefined): void;
   abstract hide(): void;
@@ -18,9 +19,40 @@ export abstract class ImagePreviewHelper {
   abstract getName(): string;
 
   abstract reactsToSizeUpdates(): boolean;
-  abstract setRatio(ratio: number): void;
   abstract shouldTrackLoading(): boolean;
   abstract usesWebView(): boolean;
+
+  setRatio(ratio: number): void {
+    this.ratio = ratio;
+  }
+
+  determineScalingRatio(): Record<string, any> {
+    if (!this.ratio) {
+      return {};
+    }
+
+    const ww = window.innerWidth;
+    const wh = window.innerHeight;
+
+    const maxWidth = Math.round(ww * 0.5);
+    const maxHeight = Math.round(wh * 0.7);
+
+    if (this.ratio >= 1) {
+      const presumedWidth = Math.min(maxWidth, maxHeight * this.ratio);
+      const presumedHeight = presumedWidth / this.ratio;
+      return {
+        width: `${Math.round(presumedWidth)}px`,
+        height: `${Math.round(presumedHeight)}px`
+      };
+    } else {
+      const presumedHeight = Math.min(maxHeight, maxWidth / this.ratio);
+      const presumedWidth = presumedHeight * this.ratio;
+      return {
+        width: `${Math.round(presumedWidth)}px`,
+        height: `${Math.round(presumedHeight)}px`
+      };
+    }
+  }
 
   constructor(parent: ImagePreview) {
     if (!parent) {

--- a/chat/preview/helper/local.ts
+++ b/chat/preview/helper/local.ts
@@ -4,6 +4,7 @@ export class LocalImagePreviewHelper extends ImagePreviewHelper {
   hide(): void {
     this.visible = false;
     this.url = undefined;
+    this.ratio = null;
   }
 
   getName(): string {
@@ -13,14 +14,21 @@ export class LocalImagePreviewHelper extends ImagePreviewHelper {
   show(url: string | undefined): void {
     this.visible = true;
     this.url = url;
-  }
+    this.ratio = null;
 
-  setRatio(_ratio: number): void {
-    // do nothing
+    if (url) {
+      const img = new Image();
+      img.onload = () => {
+        if (this.url === url && img.naturalWidth && img.naturalHeight) {
+          this.parent.updatePreviewSize(img.naturalWidth, img.naturalHeight);
+        }
+      };
+      img.src = url;
+    }
   }
 
   reactsToSizeUpdates(): boolean {
-    return false;
+    return true;
   }
 
   shouldTrackLoading(): boolean {
@@ -44,7 +52,11 @@ export class LocalImagePreviewHelper extends ImagePreviewHelper {
 
   renderStyle(): Record<string, any> {
     return this.isVisible()
-      ? { backgroundImage: `url(${this.getUrl()})`, display: 'block' }
+      ? {
+          backgroundImage: `url(${this.getUrl()})`,
+          display: 'block',
+          ...this.determineScalingRatio()
+        }
       : { display: 'none' };
   }
 }


### PR DESCRIPTION
Pinned image and video embeds will no longer cause 50% of the screen's width to be an unclickable area. Closes #663 