### PR TITLE
fix: handle dashes in profile names for [url] tag previews

### DIFF
--- a/chat/preview/ImagePreview.vue
+++ b/chat/preview/ImagePreview.vue
@@ -93,7 +93,7 @@
   const screen = remote.screen;
 
   const FLIST_PROFILE_MATCH = _.cloneDeep(
-    /https?:\/\/(www.)?f-list.net\/c\/([a-zA-Z0-9+%_.!~*'()]+)\/?/
+    /https?:\/\/(www.)?f-list.net\/c\/([a-zA-Z0-9+%_.!~*'()-]+)\/?/
   );
 
   interface DidFailLoadEvent extends Event {


### PR DESCRIPTION
## Description

Fixes #694

The regex for matching F-list profile URLs in the image preview functionality did not include dashes in the character class. This caused profile names with dashes (e.g., `second-test`) to only partially match, showing previews for truncated names (e.g., `second` instead of `second-test`).

## Changes

- Added `-` (dash) to the character class in `FLIST_PROFILE_MATCH` regex in `chat/preview/ImagePreview.vue`
- Changed: `[a-zA-Z0-9+%_.!~*'()]` → `[a-zA-Z0-9+%_.!~*'()-]`

## Testing

URLs like `https://www.f-list.net/c/second-test` will now correctly show a preview for the profile `second-test` instead of `second`.