### PR TITLE
fix: Character previews aren't clickable after pinning

### DIFF
--- a/chat/preview/ImagePreview.vue
+++ b/chat/preview/ImagePreview.vue
@@ -1043,7 +1043,8 @@
 
       .image-preview-toolbar,
       .image-preview-external,
-      .image-preview-local {
+      .image-preview-local,
+      .character-preview {
         pointer-events: auto;
       }
     }


### PR DESCRIPTION
When pinning a character's preview by middle clicking their name, links within their status/logs are now clickable again. CSS moment