### PR TITLE
Tweaks for mobile-size quick switcher on top:

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -278,7 +278,11 @@
         padding-bottom: 10px;
       "
     >
-      <div id="quick-switcher" class="list-group">
+      <div
+        id="quick-switcher"
+        class="list-group"
+        :class="{ forced: forceQuickConvoList }"
+      >
         <a
           :class="getClasses(conversations.consoleTab)"
           href="#"
@@ -286,30 +290,48 @@
           class="list-group-item list-group-item-action"
         >
           <span class="fas fa-home conversation-icon"></span>
+          <span
+            class="position-absolute top-50 start-50 translate-middle badge rounded-pill text-bg-danger"
+            v-if="shouldShowNotificationBadge(conversations.consoleTab)"
+          >
+            {{ conversations.consoleTab.unreadCount }}
+          </span>
           {{ conversations.consoleTab.name }}
         </a>
         <a
           v-for="conversation in conversations.privateConversations"
           href="#"
           @click.prevent="conversation.show()"
+          @click.middle.prevent.stop="conversation.close()"
+          :data-character="conversation.character.name"
+          data-bs-touch="false"
           :class="getClasses(conversation)"
           class="list-group-item list-group-item-action"
           :key="conversation.key"
+          :title="conversation.character.name"
         >
           <img
             :src="characterImage(conversation.character.name)"
             v-if="showAvatars"
           />
           <span class="far fa-user-circle conversation-icon" v-else></span>
+          <span
+            class="position-absolute top-50 start-50 translate-middle badge rounded-pill text-bg-danger"
+            v-if="shouldShowNotificationBadge(conversation)"
+          >
+            {{ conversation.unreadCount }}
+          </span>
           <div class="name">{{ conversation.character.name }}</div>
         </a>
         <a
           v-for="conversation in conversations.channelConversations"
           href="#"
           @click.prevent="conversation.show()"
+          @click.middle.prevent.stop="conversation.close()"
           :class="getClasses(conversation)"
           class="list-group-item list-group-item-action"
           :key="conversation.key"
+          :title="conversation.name"
         >
           <span
             class="conversation-icon"
@@ -319,6 +341,12 @@
                 : 'fas fa-hashtag'
             "
           ></span>
+          <span
+            class="position-absolute top-50 start-50 translate-middle badge rounded-pill text-bg-danger"
+            v-if="shouldShowNotificationBadge(conversation)"
+          >
+            {{ conversation.unreadCount }}
+          </span>
           <div class="name">{{ conversation.name }}</div>
         </a>
       </div>
@@ -430,6 +458,9 @@
       },
       ownCharacter(): Character {
         return core.characters.ownCharacter;
+      },
+      forceQuickConvoList(): boolean {
+        return core.state.settings.forceQuickConvoList;
       },
       ownCharacterLink(): string {
         return profileLink(core.characters.ownCharacter.name);
@@ -882,7 +913,6 @@
       isColorblindModeActive(): boolean {
         return core.state.settings.risingColorblindMode;
       },
-
       getImagePreview(): ImagePreview | undefined {
         return this.$refs['imagePreview'] as ImagePreview;
       },
@@ -1022,6 +1052,12 @@
     @media (max-width: breakpoint-max(md)) {
       display: flex;
     }
+    &.forced {
+      display: flex;
+      @media (min-width: breakpoint-min(md)) {
+        margin: 0 5px 5px;
+      }
+    }
 
     a {
       width: 40px;
@@ -1051,8 +1087,11 @@
     }
 
     .conversation-icon {
-      font-size: 2em;
+      font-size: 1.6rem;
       height: 30px;
+    }
+    .badge {
+      --bs-badge-font-size: 0.9em;
     }
   }
 

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -382,6 +382,20 @@
         </div>
       </div>
 
+      <div class="mb-3">
+        <div class="d-flex p-2 justify-content-between align-items-start">
+          <div class="w-50">
+            <label class="control-label" for="forceQuickConvoList">
+              {{ l('settings.forceQuickConvoList') }}
+            </label>
+          </div>
+          <settings-checkbox
+            v-model="forceQuickConvoList"
+            :name="'forceQuickConvoList'"
+          ></settings-checkbox>
+        </div>
+      </div>
+
       <h5>{{ l('settings.appearance.messages') }}</h5>
 
       <div class="mb-3 p-2">
@@ -1207,6 +1221,7 @@
         horizonHighlightUsers: undefined as any as string,
         chatLayoutMode: undefined as any as 'classic' | 'modern',
         messageGrouping: undefined as any as boolean,
+        forceQuickConvoList: undefined as any as boolean,
         horizonUseColorPicker: undefined as any as boolean,
 
         horizonCacheDraftMessages: undefined as any as boolean,
@@ -1288,6 +1303,7 @@
         this.horizonChangeOfflineColor = settings.horizonChangeOfflineColor;
         this.chatLayoutMode = settings.chatLayoutMode || 'classic';
         this.messageGrouping = settings.messageGrouping;
+        this.forceQuickConvoList = settings.forceQuickConvoList;
         this.horizonUseColorPicker = settings.horizonUseColorPicker;
 
         this.horizonCacheDraftMessages = settings.horizonCacheDraftMessages;
@@ -1441,6 +1457,7 @@
             .filter(x => x.length),
           chatLayoutMode: this.chatLayoutMode,
           messageGrouping: this.messageGrouping,
+          forceQuickConvoList: this.forceQuickConvoList,
           horizonCacheDraftMessages: this.horizonCacheDraftMessages,
           horizonSaveDraftMessagesToDiskTimer:
             diskDraftTimer === null

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -133,6 +133,7 @@ export class Settings implements ISettings {
 
   chatLayoutMode: 'classic' | 'modern' = 'classic';
   messageGrouping = true;
+  forceQuickConvoList = false;
 
   horizonCacheDraftMessages = true;
   horizonSaveDraftMessagesToDiskTimer = 60;

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -320,6 +320,7 @@ export namespace Settings {
 
     readonly chatLayoutMode: 'classic' | 'modern';
     readonly messageGrouping: boolean;
+    readonly forceQuickConvoList: boolean;
 
     readonly horizonCacheDraftMessages: boolean;
     readonly horizonSaveDraftMessagesToDiskTimer: number;

--- a/chat/locales/en_us.json
+++ b/chat/locales/en_us.json
@@ -662,6 +662,7 @@
   "settings.flashWindow.note": "On Linux, this feature might not be supported by your window manager or desktop environment.",
   "settings.fontSize": "Font size",
   "settings.forceNativeWindowControls": "Force native window controls (requires restart)",
+  "settings.forceQuickConvoList": "Force mobile-style 'quick switcher' conversation list",
   "settings.genderIconUseOriginalColor": "Make gender icon use the original gender color instead of the custom name color",
   "settings.hideAds.empty": "You aren't currently hiding the ads of any users.",
   "settings.hideNonCharacterFriends": "Additionally hide non-character friends",


### PR DESCRIPTION
- Mouse controls (middle and right click match the lefthand side)
- Layout centered correctly
- Visible unread badges
- Setting to forcefully enable

Closes #698