### PR TITLE
Ancient issue fixes

### DIFF
--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -17,6 +17,11 @@ export default class Notifications extends BaseNotifications {
   ): Promise<void> {
     if (!this.shouldNotify(conversation)) return;
     this.playSound(sound);
+    body = body
+      .replace(/\[spoiler\].*?\[\/spoiler\]/gi, '██████')
+      .replace(/\[eicon\](.*?)\[\/eicon\]/gi, ':$1:')
+      .replace(/\[url=([^\]]+)\]\[\/url\]/gi, '$1')
+      .replace(/\[\/?[a-zA-Z][a-zA-Z0-9]*(?:=[^\]]*)?\]/g, '');
     //Since Electron >=31.0.0 this makes the dock icon bounce like crazy on MacOS, which is a million times more annoying (and not the intended use case of the dock bounce anyway) than the flashing taskbar icon on Windows.
     if (
       process.platform !== 'darwin' &&

--- a/electron/notifications.ts
+++ b/electron/notifications.ts
@@ -18,7 +18,7 @@ export default class Notifications extends BaseNotifications {
     if (!this.shouldNotify(conversation)) return;
     this.playSound(sound);
     body = body
-      .replace(/\[spoiler\].*?\[\/spoiler\]/gi, '██████')
+      .replace(/\[spoiler\][\s\S]*?\[\/spoiler\]/gi, '██████')
       .replace(/\[eicon\](.*?)\[\/eicon\]/gi, ':$1:')
       .replace(/\[url=([^\]]+)\]\[\/url\]/gi, '$1')
       .replace(/\[\/?[a-zA-Z][a-zA-Z0-9]*(?:=[^\]]*)?\]/g, '');

--- a/fchat/characters.ts
+++ b/fchat/characters.ts
@@ -184,9 +184,10 @@ export default function (this: void, connection: Connection): Interfaces.State {
       };
     for (const key in state.characters) {
       const character = state.characters[key]!;
-      character.isFriend = state.friendList.indexOf(character.name) !== -1;
-      character.isBookmarked =
-        state.bookmarkList.indexOf(character.name) !== -1;
+      character.isFriend = state.friendList.some(f => f.toLowerCase() === key);
+      character.isBookmarked = state.bookmarkList.some(
+        b => b.toLowerCase() === key
+      );
       character.status = 'offline';
       character.statusText = '';
     }

--- a/fchat/characters.ts
+++ b/fchat/characters.ts
@@ -73,7 +73,7 @@ class State implements Interfaces.State {
       char.isBookmarked = this.bookmarkList.indexOf(name) !== -1;
       char.isChatOp = this.opList.indexOf(name) !== -1;
       char.isIgnored = this.ignoreList.indexOf(key) !== -1;
-      this.characters[key] = char;
+      Vue.set(this.characters, key, char);
     }
     return char;
   }

--- a/fchat/characters.ts
+++ b/fchat/characters.ts
@@ -69,8 +69,8 @@ class State implements Interfaces.State {
     let char = this.characters[key];
     if (char === undefined) {
       char = new Character(name);
-      char.isFriend = this.friendList.indexOf(name) !== -1;
-      char.isBookmarked = this.bookmarkList.indexOf(name) !== -1;
+      char.isFriend = this.friendList.some(f => f.toLowerCase() === key);
+      char.isBookmarked = this.bookmarkList.some(b => b.toLowerCase() === key);
       char.isChatOp = this.opList.indexOf(name) !== -1;
       char.isIgnored = this.ignoreList.indexOf(key) !== -1;
       Vue.set(this.characters, key, char);


### PR DESCRIPTION
Fixes for a few ancient issues on the repo. 

- The bookmark button when right clicking a user is no longer case sensitive.
  - cda8da91ab29c78856cdb525c23c54bfd280aaa6 fixes #143 
- The recent conversations view will update a user's gender color properly when they log in. 
  - In my testing, I noticed that Horizon color is exempt from this logic, oddly.  Characters with Horizon colors will show their custom colors at all times, _even when offline_. Do we care enough to make it consistent?  
  - d096b44f6a347b4b733fa5cc005c84f1a8fec2e9 fixes #109 
- BBCode is stripped from messages for OS notifications. Eicons are surrounded with `:` a la Discord and spoiled text is actually hidden. 
  - 3d525fcfaf840eddcc5312242035d0a198b2470e fixes #112 

<img width="518" height="185" alt="notif" src="https://github.com/user-attachments/assets/c598fa31-b75b-40cb-98e4-402b85318b06" />