### PR TITLE
fix: correct image gallery loading state order

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -450,6 +450,17 @@ async function onReady(): Promise<void> {
           return;
         }
 
+        if (
+          permission === 'clipboard-sanitized-write' &&
+          partitionName === 'persist:fchat'
+        ) {
+          log.debug('permissions.allowed.clipboard-sanitized-write', {
+            partition: partitionName
+          });
+          callback(true);
+          return;
+        }
+
         log.debug('permissions.blocked', {
           partition: partitionName,
           permission: permission
@@ -463,6 +474,13 @@ async function onReady(): Promise<void> {
       (_webContents, permission, _details) => {
         if (
           permission === 'notifications' &&
+          partitionName === 'persist:fchat'
+        ) {
+          return true;
+        }
+
+        if (
+          permission === 'clipboard-sanitized-write' &&
           partitionName === 'persist:fchat'
         ) {
           return true;

--- a/site/character_page/images.vue
+++ b/site/character_page/images.vue
@@ -208,7 +208,6 @@
     try {
       error.value = '';
       shown.value = true;
-      loading.value = true;
       const result = await resolveImagesAsync();
       if (props.character.character.name !== expectedName) {
         shown.value = false;
@@ -236,6 +235,10 @@
     }
 
     images.value = resolveImages();
+
+    if (images.value.length > 0) {
+      loading.value = false;
+    }
 
     // this promise is intentionally not part of a chain
     showAsync().catch(err => log.error('profile.images.error', { err }));


### PR DESCRIPTION
`show()` function was loading images from cache but leaving `loading` as true. Alsoo removed the redundant `loading = true` in `showAsync()` that was re-hiding cached images during the background refresh.