### PR TITLE
Newline consistency fixes

### DIFF
--- a/bbcode/IconView.vue
+++ b/bbcode/IconView.vue
@@ -48,7 +48,7 @@
     },
     methods: {
       getCharacterUrl(): string {
-        return `flist-character://${this.character.name}`;
+        return `flist-character://${this.character.name.replace(/[\r\n]/g, '')}`;
       },
       dismiss(force: boolean = false): void {
         EventBus.$emit('imagepreview-dismiss', {

--- a/bbcode/IconView.vue
+++ b/bbcode/IconView.vue
@@ -23,7 +23,7 @@
   import Vue, { PropType } from 'vue';
   import { EventBus } from '../chat/preview/event-bus';
   import * as Utils from '../site/utils';
-  import { characterImage } from '../chat/common';
+  import { characterImage, normalizeCharacterName } from '../chat/common';
   import { Character } from '../fchat';
 
   export default Vue.extend({
@@ -48,7 +48,7 @@
     },
     methods: {
       getCharacterUrl(): string {
-        return `flist-character://${this.character.name.replace(/[\r\n]/g, '')}`;
+        return `flist-character://${normalizeCharacterName(this.character.name)}`;
       },
       dismiss(force: boolean = false): void {
         EventBus.$emit('imagepreview-dismiss', {

--- a/bbcode/core.ts
+++ b/bbcode/core.ts
@@ -7,6 +7,7 @@ import {
 import * as Utils from '../site/utils';
 import { default as IconView } from '../bbcode/IconView.vue';
 import UrlTagView from './UrlTagView.vue';
+import { normalizeCharacterName } from '../chat/common';
 import core from '../chat/core';
 
 const urlFormat = '((?:https?|ftps?|irc)://[^\\s/$.?#"\']+\\.[^\\s"]+)';
@@ -86,6 +87,7 @@ export class CoreBBCodeParser extends BBCodeParser {
           parser.warning('Unexpected parameter on icon tag.');
         const uregex = /^[a-zA-Z0-9_\-\s]+$/;
         if (!uregex.test(content)) return;
+        const characterName = normalizeCharacterName(content);
         const root = parser.createElement('span');
         const el = parser.createElement('span');
         parent.appendChild(root);
@@ -93,7 +95,7 @@ export class CoreBBCodeParser extends BBCodeParser {
         const view = new IconView({
           el,
           propsData: {
-            character: core.characters.get(content)
+            character: core.characters.get(characterName)
           }
         });
 

--- a/chat/UserMenu.vue
+++ b/chat/UserMenu.vue
@@ -25,7 +25,7 @@
         />
         <div id="userMenu-userInfo">
           <h4 style="margin: 0; line-height: 1" class="userInfo-name">
-            {{ character.name }}
+            {{ displayName || character.name }}
           </h4>
           <span class="userInfo-status">{{
             l('status.' + character.status)
@@ -243,6 +243,7 @@
         showContextMenu: false,
         getByteLength,
         character: undefined as Character | undefined,
+        displayName: undefined as string | undefined,
         position: { left: '', top: '' },
         characterImage: undefined as string | undefined,
         touchedElement: undefined as HTMLElement | undefined,
@@ -365,6 +366,7 @@
           HTMLElement & {
             character?: Character;
             channel?: Channel;
+            displayName?: string;
             touched?: boolean;
           }
         >touch.target;
@@ -398,7 +400,12 @@
             if (node.dataset['character'] === undefined)
               if (node === this.touchedElement)
                 // tslint:disable-next-line no-floating-promises
-                this.openMenu(touch, node.character, node.channel || undefined);
+                this.openMenu(
+                  touch,
+                  node.character,
+                  node.channel || undefined,
+                  node.displayName
+                );
               else this.onClick(node.character);
             e.preventDefault();
             break;
@@ -407,7 +414,12 @@
             break;
           case 'contextmenu':
             // tslint:disable-next-line no-floating-promises
-            this.openMenu(touch, node.character, node.channel || undefined);
+            this.openMenu(
+              touch,
+              node.character,
+              node.channel || undefined,
+              node.displayName
+            );
             e.preventDefault();
         }
       },
@@ -426,10 +438,12 @@
       async openMenu(
         touch: MouseEvent | Touch,
         character: Character,
-        channel: Channel | undefined
+        channel: Channel | undefined,
+        displayName?: string
       ): Promise<void> {
         this.channel = channel;
         this.character = character;
+        this.displayName = displayName;
         this.characterImage = undefined;
         this.showContextMenu = true;
         this.position = {

--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -498,7 +498,7 @@
       },
 
       getCharacterUrl(): string {
-        return `flist-character://${this.character.name}`;
+        return `flist-character://${this.character.name.replace(/[\r\n]/g, '')}`;
       },
 
       dismiss(force: boolean = false): void {

--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -4,6 +4,7 @@
     :class="userClass"
     v-bind:bbcodeTag.prop="'user'"
     v-bind:character.prop="character"
+    v-bind:displayName.prop="resolvedDisplayName"
     v-bind:channel.prop="channel"
     @mouseover.prevent="show()"
     @mouseenter.prevent="show()"
@@ -40,7 +41,7 @@
       :title="sponsorTitle"
     ></span
     ><span v-if="!!smartFilterIcon" :class="smartFilterIcon"></span
-    >{{ character.name
+    >{{ resolvedDisplayName
     }}<span v-if="!!matchClass" :class="matchClass">{{
       getMatchScoreTitle(matchScore)
     }}</span></span
@@ -54,7 +55,7 @@
   import core from './core';
   import { CharacterDataEvent, EventBus } from './preview/event-bus';
   import { kinkMatchWeights, Scoring } from '../learn/matcher-types';
-  import { characterImage } from './common';
+  import { characterImage, normalizeCharacterName } from './common';
   import {
     getContributorAlias,
     getTranslatorAlias,
@@ -328,6 +329,7 @@
     components: {},
     props: {
       character: { type: Object as () => Character, required: true },
+      displayName: { type: String, required: false },
       channel: { type: Object as () => Channel, required: false },
       showStatus: { default: false },
       bookmark: { default: true },
@@ -359,6 +361,9 @@
       };
     },
     computed: {
+      resolvedDisplayName(): string {
+        return this.displayName ?? this.character.name;
+      },
       safeAvatarUrl(): string {
         return this.avatarUrl || '';
       },
@@ -498,7 +503,7 @@
       },
 
       getCharacterUrl(): string {
-        return `flist-character://${this.character.name.replace(/[\r\n]/g, '')}`;
+        return `flist-character://${normalizeCharacterName(this.character.name)}`;
       },
 
       dismiss(force: boolean = false): void {

--- a/chat/bbcode.ts
+++ b/chat/bbcode.ts
@@ -9,6 +9,7 @@ import {
 } from '../bbcode/parser';
 import ChannelView from './ChannelTagView.vue';
 // import {characterImage} from './common';
+import { normalizeCharacterName } from './common';
 import core from './core';
 // import {Character} from './interfaces';
 import UserView from './UserView.vue';
@@ -48,12 +49,14 @@ export default class BBCodeParser extends CoreBBCodeParser {
           parser.warning('Unexpected parameter on user tag.');
         const uregex = /^[a-zA-Z0-9_\-\s]+$/;
         if (!uregex.test(content)) return;
+        const characterName = normalizeCharacterName(content);
         const el = parser.createElement('span');
         parent.appendChild(el);
         const view = new UserView({
           el,
           propsData: {
-            character: core.characters.get(content),
+            character: core.characters.get(characterName),
+            displayName: content, // added so that the non-normalized names are displayed
             isMarkerShown: core.connection.character
               ? core.state.settings.horizonShowGenderMarker
               : false

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -8,8 +8,15 @@ import {
 } from './interfaces';
 import core from './core';
 
+export function normalizeCharacterName(
+  this: any | never,
+  character: string
+): string {
+  return character.replace(/[\r\n]/g, '');
+}
+
 export function profileLink(this: any | never, character: string): string {
-  return `https://www.f-list.net/c/${character}`;
+  return `https://www.f-list.net/c/${normalizeCharacterName(character)}`;
 }
 
 /**
@@ -35,13 +42,14 @@ export function characterImage(
   character: string,
   useOriginalAvatar: boolean = false
 ): string {
-  const c = core.characters.get(character);
+  const normalizedCharacter = normalizeCharacterName(character);
+  const c = core.characters.get(normalizedCharacter);
 
   if (c.overrides.avatarUrl && !useOriginalAvatar) {
     return c.overrides.avatarUrl;
   }
 
-  return `https://static.f-list.net/images/avatar/${character.toLowerCase()}.png`;
+  return `https://static.f-list.net/images/avatar/${normalizedCharacter.toLowerCase()}.png`;
 }
 
 /**

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -287,6 +287,15 @@ abstract class Conversation implements Interfaces.Conversation {
   protected formatEiconMessage(message: string): string {
     const eIconRegex =
       /^(?!\n)(?=.*\[eicon\].*\[\/eicon\].*\n.*\[eicon\].*\[\/eicon\])(.*\n\[eicon\].*\[\/eicon\].*)\s*/;
+
+    if (/^\/me\s+/i.test(message)) {
+      const body = message.replace(/^\/me\s+/i, '');
+      if (eIconRegex.test(body)) {
+        return '/me\n' + body;
+      }
+      return message;
+    }
+
     if (eIconRegex.test(message)) {
       return '\n' + message;
     }

--- a/chat/message_view.ts
+++ b/chat/message_view.ts
@@ -190,10 +190,15 @@ export default Vue.extend({
 
     //3.0 (and Horizon's classic view) users often prepend their message with an empty linefeed to format things like eicon collages
     //Therefore, we filter that out in modern view mode, since it's unnecessary there.
+    const hadLeadingNewline = message.text.startsWith('\n');
     let messageAdjustment = message.text.replace(/^\n/, '');
     switch (message.type) {
       case Conversation.Message.Type.Action:
-        messageAdjustment = ' ' + message.sender.name + messageAdjustment;
+        messageAdjustment =
+          ' ' +
+          message.sender.name +
+          (hadLeadingNewline ? '\n' : '') +
+          messageAdjustment;
         break;
       case Conversation.Message.Type.Roll:
         messageAdjustment = ' ' + message.sender.name + ' ' + messageAdjustment;

--- a/chat/preview/ImagePreview.vue
+++ b/chat/preview/ImagePreview.vue
@@ -536,7 +536,7 @@
         const characterName = decodeURIComponent(
           match[2].replace(/\+/g, '%20')
         );
-        return `flist-character://${characterName}`;
+        return `flist-character://${characterName.replace(/[\r\n]/g, '')}`;
       },
       isMediaUrl(url: string): boolean {
         const cleanUrl = url.split('?')[0].toLowerCase();

--- a/chat/preview/ImagePreview.vue
+++ b/chat/preview/ImagePreview.vue
@@ -70,6 +70,7 @@
   import * as _ from 'lodash';
   import Vue from 'vue';
   import core from '../core';
+  import { normalizeCharacterName } from '../common';
   import { EventBus, EventBusEvent } from './event-bus';
   import { domain } from '../../bbcode/core';
   import { ImageDomMutator } from './image-dom-mutator';
@@ -536,7 +537,7 @@
         const characterName = decodeURIComponent(
           match[2].replace(/\+/g, '%20')
         );
-        return `flist-character://${characterName.replace(/[\r\n]/g, '')}`;
+        return `flist-character://${normalizeCharacterName(characterName)}`;
       },
       isMediaUrl(url: string): boolean {
         const cleanUrl = url.split('?')[0].toLowerCase();


### PR DESCRIPTION
Fixes for some recent newline-related issues that were opened.
- Newlines within `[user]` and `[icon]` tags no longer break the character preview.
  - 6ff32c78877eb03b601809843fe2e37c9bd95b3e fixes #728  
- `/me` messages will now prepend newlines for eicon mosaics correctly. 
  - The fix done for the modern chat view will also make it so that `/me` messages with manually prepended newlines (e.g. user hits shift+enter themselves) will now show the newline. _Personally_ I think this is fine since the current implementation doesn't even add a space after stripping the newline, so it just reads as `*[Character]jumps`
  - f6f50e42b729284ff8ef2ec08d0dda400f3af8ae and 6e2eb216851ee77024264a62c9021841953df425 fixes #727  

<img width="198" height="157" alt="image" src="https://github.com/user-attachments/assets/ca206b5e-e1ca-45bb-9ed0-966773efef71" /> 

This was sent with just the following: 
```
/me [eicon]foxdisappear[/eicon] me 
[eicon]foxappear[/eicon] you
``` 