### PR TITLE
fix: Escape in image preview no longer closes the entire profile

### DIFF
--- a/site/character_page/images.vue
+++ b/site/character_page/images.vue
@@ -441,7 +441,7 @@
   const showPreview = (image: CharacterImage): void => {
     ignoreNextClick.value = false;
     setPreviewImage(image);
-    window.addEventListener('keydown', handleKeydown);
+    window.addEventListener('keydown', handleKeydown, { capture: true });
     window.addEventListener('resize', updatePreviewDimensions);
     browseTimeOut();
   };
@@ -498,7 +498,7 @@
     previewDisplayHeight.value = 0;
     stopPreviewPan(true);
     ignoreNextClick.value = false;
-    window.removeEventListener('keydown', handleKeydown);
+    window.removeEventListener('keydown', handleKeydown, { capture: true });
     window.removeEventListener('resize', updatePreviewDimensions);
     zoomLevel.value = ZOOM_LEVEL_MIN;
   };
@@ -625,6 +625,8 @@
 
     if (key === Keys.Escape) {
       hidePreview();
+      e.stopImmediatePropagation();
+      e.preventDefault();
     } else if (key === Keys.ArrowLeft) {
       previewPrev();
       e.preventDefault();


### PR DESCRIPTION
Pressing escape on an image preview now closes the preview instead of the whole profile