### PR TITLE
chore: Upgrade Electron to 40.10.0 (was 39.8.3)

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -100,7 +100,7 @@
   },
   "devDependencies": {
     "commander": "^14.0.0",
-    "electron": "39.8.3",
+    "electron": "40.10.0",
     "electron-builder": "^26.8.1"
   },
   "dependencies": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774386573,
-        "narHash": "sha256-4hAV26quOxdC6iyG7kYaZcM3VOskcPUrdCQd/nx8obc=",
+        "lastModified": 1778443072,
+        "narHash": "sha256-zi7/fsqM/kFdNuED//4WOCUtezGtKKqRNORjMvfwjnA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46db2e09e1d3f113a13c0d7b81e2f221c63b8ce9",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -12,8 +12,8 @@
       let
         pkgs = nixpkgs.legacyPackages.${system};
         nodejs = pkgs.nodejs_24;
-        pnpm = nodejs.pkgs. pnpm;
-        electron = pkgs.electron_39;
+        pnpm = pkgs.pnpm;
+        electron = pkgs.electron_40;
       in
       {
         devShells.default = pkgs. mkShell {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "css-loader": "^5.2.7",
     "css-minimizer-webpack-plugin": "^7.0.0",
     "date-fns": "2.30.0",
-    "electron": "39.8.3",
+    "electron": "40.10.0",
     "electron-builder": "^26.8.1",
     "electron-log": "^4.4.8",
     "electron-settings": "~4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,10 +27,10 @@ importers:
         version: 2.14.1
       '@ghostery/adblocker-electron':
         specifier: ^2.14.1
-        version: 2.14.1(electron@39.8.3(supports-color@10.0.0))
+        version: 2.14.1(electron@40.10.0(supports-color@10.0.0))
       '@ghostery/adblocker-electron-preload':
         specifier: ^2.14.1
-        version: 2.14.1(electron@39.8.3(supports-color@10.0.0))
+        version: 2.14.1(electron@40.10.0(supports-color@10.0.0))
       '@ghostery/adblocker-extended-selectors':
         specifier: ^2.14.1
         version: 2.14.1
@@ -49,7 +49,7 @@ importers:
     devDependencies:
       '@electron/remote':
         specifier: ^2.1.3
-        version: 2.1.3(electron@39.8.3(supports-color@10.0.0))
+        version: 2.1.3(electron@40.10.0(supports-color@10.0.0))
       '@fortawesome/fontawesome-free':
         specifier: ^7.2.0
         version: 7.2.0
@@ -117,8 +117,8 @@ importers:
         specifier: 2.30.0
         version: 2.30.0
       electron:
-        specifier: 39.8.3
-        version: 39.8.3(supports-color@10.0.0)
+        specifier: 40.10.0
+        version: 40.10.0(supports-color@10.0.0)
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)(supports-color@10.0.0)
@@ -127,7 +127,7 @@ importers:
         version: 4.4.8
       electron-settings:
         specifier: ~4.0.4
-        version: 4.0.4(electron@39.8.3(supports-color@10.0.0))
+        version: 4.0.4(electron@40.10.0(supports-color@10.0.0))
       esbuild-loader:
         specifier: ^4.4.3
         version: 4.4.3(webpack@5.99.9)
@@ -218,7 +218,7 @@ importers:
     dependencies:
       '@ghostery/adblocker-electron-preload':
         specifier: ^2.14.1
-        version: 2.14.1(electron@39.8.3(supports-color@10.0.0))
+        version: 2.14.1(electron@40.10.0(supports-color@10.0.0))
       '@mdit/plugin-alert':
         specifier: ^0.22.2
         version: 0.22.3(markdown-it@14.1.1)
@@ -230,8 +230,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.2
       electron:
-        specifier: 39.8.3
-        version: 39.8.3(supports-color@10.0.0)
+        specifier: 40.10.0
+        version: 40.10.0(supports-color@10.0.0)
       electron-builder:
         specifier: ^26.8.1
         version: 26.8.1(electron-builder-squirrel-windows@26.8.1)(supports-color@10.0.0)
@@ -271,8 +271,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@7.29.2':
-    resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -2192,8 +2192,8 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
-  electron@39.8.3:
-    resolution: {integrity: sha512-ZhetvWz2qbI2WbBHdK/utR8I5bi1pYWJdit9tP0sGzs42CpsAFyu/FirXE88NWSh+3U8X6Wuf9jjDEYvAyrxNw==}
+  electron@40.10.0:
+    resolution: {integrity: sha512-e7XVcAfyWoFQGS7ZhgxeNn0AijHaqgRCa6uA6TYOrvBWv8smI6JILvMR/8DYBIn07oqvxDLRC90tu/xa2cJCow==}
     engines: {node: '>= 12.20.55'}
     hasBin: true
 
@@ -2497,6 +2497,10 @@ packages:
 
   fs-extra@11.3.4:
     resolution: {integrity: sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.5:
+    resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -2959,6 +2963,9 @@ packages:
   jsonfile@6.2.0:
     resolution: {integrity: sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==}
 
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
   jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
@@ -3287,6 +3294,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3782,8 +3794,8 @@ packages:
     resolution: {integrity: sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==}
     engines: {node: '>=6.0.0'}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.14:
+    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -4785,7 +4797,7 @@ packages:
 
   uuid@3.4.0:
     resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==}
-    deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   varint@6.0.0:
@@ -5011,7 +5023,7 @@ snapshots:
     dependencies:
       '@babel/types': 7.27.7
 
-  '@babel/parser@7.29.2':
+  '@babel/parser@7.29.3':
     dependencies:
       '@babel/types': 7.29.0
     optional: true
@@ -5128,9 +5140,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@electron/remote@2.1.3(electron@39.8.3(supports-color@10.0.0))':
+  '@electron/remote@2.1.3(electron@40.10.0(supports-color@10.0.0))':
     dependencies:
-      electron: 39.8.3(supports-color@10.0.0)
+      electron: 40.10.0(supports-color@10.0.0)
 
   '@electron/universal@2.0.3(supports-color@10.0.0)':
     dependencies:
@@ -5148,7 +5160,7 @@ snapshots:
     dependencies:
       cross-dirname: 0.1.0
       debug: 4.4.3(supports-color@10.0.0)
-      fs-extra: 11.3.4
+      fs-extra: 11.3.5
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
@@ -5241,16 +5253,16 @@ snapshots:
     dependencies:
       '@ghostery/adblocker-extended-selectors': 2.14.1
 
-  '@ghostery/adblocker-electron-preload@2.14.1(electron@39.8.3(supports-color@10.0.0))':
+  '@ghostery/adblocker-electron-preload@2.14.1(electron@40.10.0(supports-color@10.0.0))':
     dependencies:
       '@ghostery/adblocker-content': 2.14.1
-      electron: 39.8.3(supports-color@10.0.0)
+      electron: 40.10.0(supports-color@10.0.0)
 
-  '@ghostery/adblocker-electron@2.14.1(electron@39.8.3(supports-color@10.0.0))':
+  '@ghostery/adblocker-electron@2.14.1(electron@40.10.0(supports-color@10.0.0))':
     dependencies:
       '@ghostery/adblocker': 2.14.1
-      '@ghostery/adblocker-electron-preload': 2.14.1(electron@39.8.3(supports-color@10.0.0))
-      electron: 39.8.3(supports-color@10.0.0)
+      '@ghostery/adblocker-electron-preload': 2.14.1(electron@40.10.0(supports-color@10.0.0))
+      electron: 40.10.0(supports-color@10.0.0)
       tldts-experimental: 7.0.28
 
   '@ghostery/adblocker-extended-selectors@2.14.1': {}
@@ -5826,7 +5838,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.17':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@vue/shared': 3.5.17
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -5849,14 +5861,14 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.17':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.3
       '@vue/compiler-core': 3.5.17
       '@vue/compiler-dom': 3.5.17
       '@vue/compiler-ssr': 3.5.17
       '@vue/shared': 3.5.17
       estree-walker: 2.0.2
       magic-string: 0.30.21
-      postcss: 8.5.10
+      postcss: 8.5.14
       source-map-js: 1.2.1
     optional: true
 
@@ -6993,9 +7005,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron-settings@4.0.4(electron@39.8.3(supports-color@10.0.0)):
+  electron-settings@4.0.4(electron@40.10.0(supports-color@10.0.0)):
     dependencies:
-      electron: 39.8.3(supports-color@10.0.0)
+      electron: 40.10.0(supports-color@10.0.0)
       lodash: 4.17.21
       mkdirp: 1.0.4
       write-file-atomic: 3.0.3
@@ -7031,7 +7043,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@39.8.3(supports-color@10.0.0):
+  electron@40.10.0(supports-color@10.0.0):
     dependencies:
       '@electron/get': 2.0.3(supports-color@10.0.0)
       '@types/node': 24.12.0
@@ -7421,6 +7433,13 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fs-extra@11.3.5:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -7914,6 +7933,13 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+    optional: true
+
   jsprim@1.4.2:
     dependencies:
       assert-plus: 1.0.0
@@ -8230,6 +8256,9 @@ snapshots:
   mute-stream@2.0.0: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.12:
+    optional: true
 
   negotiator@0.6.3: {}
 
@@ -8699,9 +8728,9 @@ snapshots:
       picocolors: 0.2.1
       source-map: 0.6.1
 
-  postcss@8.5.10:
+  postcss@8.5.14:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
     optional: true


### PR DESCRIPTION
[Electron 39 is deprecated since early May 2026](https://releases.electronjs.org/schedule), so we should move to a more supported version now.