### PR TITLE
fix: Log viewer does not allow filtering before conversation is selected

### DIFF
--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -207,6 +207,7 @@
         :placeholder="l('filter')"
         v-show="messages"
         type="text"
+        :disabled="selectedConversation === undefined || messages.length === 0"
       />
       <span v-if="searching" class="input-group-text">
         <span class="fas fa-spinner fa-spin"></span>
@@ -483,6 +484,7 @@
       },
 
       onFilterChanged(): void {
+        if (this.selectedConversation === undefined) return;
         if (this.filterDebounce !== undefined)
           clearTimeout(this.filterDebounce);
         this.filterDebounce = setTimeout(() => {


### PR DESCRIPTION
Fixes #782

This is a PR because I don't want to merge anything that's not related to the current pre-release unless it's an actual critical bug.

Which I don't think this is.