### PR TITLE
fix: channel group drag and drop ordering and persistence 

### DIFF
--- a/chat/ChannelGroupSection.vue
+++ b/chat/ChannelGroupSection.vue
@@ -169,8 +169,37 @@
         },
         onAdd: (e: Sortable.SortableEvent) => {
           const channelId = (e.item as HTMLElement).dataset?.channelId;
-          if (channelId)
-            core.conversations.setChannelGroup(channelId, this.group.id);
+          if (!channelId) return;
+          core.conversations.setChannelGroup(channelId, this.group.id);
+
+          const allConvs = core.conversations.channelConversations;
+          const draggedConv = allConvs.find(c => c.channel.id === channelId);
+          if (!draggedConv) return;
+
+          const groupConvs = allConvs.filter(
+            c =>
+              core.conversations.channelGroupAssignments[c.channel.id] ===
+              this.group.id
+          );
+          const othersInGroup = groupConvs.filter(c => c !== draggedConv);
+          if (othersInGroup.length === 0) return;
+
+          const targetNewIndex = e.newIndex ?? 0;
+          const draggedAbsIdx = allConvs.indexOf(draggedConv);
+          let targetAbsIndex: number;
+
+          if (targetNewIndex >= groupConvs.length - 1) {
+            const lastOther = othersInGroup[othersInGroup.length - 1];
+            const lastOtherAbsIdx = allConvs.indexOf(lastOther);
+            targetAbsIndex =
+              lastOtherAbsIdx - (draggedAbsIdx < lastOtherAbsIdx ? 1 : 0) + 1;
+          } else {
+            const nextInGroup = othersInGroup[targetNewIndex];
+            const nextAbsIdx = allConvs.indexOf(nextInGroup);
+            targetAbsIndex = nextAbsIdx - (draggedAbsIdx < nextAbsIdx ? 1 : 0);
+          }
+
+          void draggedConv.sort(targetAbsIndex);
         },
         onRemove: (e: Sortable.SortableEvent) => {
           const destGroupId = (e.to as HTMLElement).dataset?.groupId;

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -762,7 +762,12 @@
       onKeyDown(e: KeyboardEvent): void {
         const selected = this.conversations.selectedConversation;
         const pms = this.conversations.privateConversations;
-        const channels = this.conversations.channelConversations;
+        const channels = [
+          ...this.sortedChannelGroups.flatMap((g: any) =>
+            this.channelsInGroup(g.id)
+          ),
+          ...this.ungroupedChannels
+        ];
         const console = this.conversations.consoleTab;
         if (getKey(e) === Keys.ArrowUp) {
           if (e.altKey && !e.shiftKey && !e.ctrlKey && !e.metaKey) {

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -246,16 +246,18 @@
           </dropdown>
         </div>
 
-        <channel-group-section
-          v-for="group in sortedChannelGroups"
-          :key="group.id"
-          :group="group"
-          :conversations="channelsInGroup(group.id)"
-          :all-groups="conversations.channelGroups"
-          :start-editing="pendingRenameGroupId === group.id"
-          @editing-started="pendingRenameGroupId = null"
-          @create-and-rename="id => (pendingRenameGroupId = id)"
-        ></channel-group-section>
+        <div ref="channelGroups">
+          <channel-group-section
+            v-for="group in sortedChannelGroups"
+            :key="group.id"
+            :group="group"
+            :conversations="channelsInGroup(group.id)"
+            :all-groups="conversations.channelGroups"
+            :start-editing="pendingRenameGroupId === group.id"
+            @editing-started="pendingRenameGroupId = null"
+            @create-and-rename="id => (pendingRenameGroupId = id)"
+          ></channel-group-section>
+        </div>
 
         <div
           class="list-group conversation-nav"
@@ -629,6 +631,21 @@
           return core.conversations.privateConversations[e.oldIndex!].sort(
             e.newIndex!
           );
+        }
+      });
+      Sortable.create(<HTMLElement>this.$refs['channelGroups'], {
+        handle: '.channel-group-header',
+        animation: 150,
+        fallbackTolerance: 5,
+        onEnd: (e: Sortable.SortableEvent) => {
+          if (e.oldIndex === e.newIndex) return;
+          const sorted = [...core.conversations.channelGroups].sort(
+            (a, b) => a.order - b.order
+          );
+          const [moved] = sorted.splice(e.oldIndex!, 1);
+          sorted.splice(e.newIndex!, 0, moved);
+          sorted.forEach((g, i) => (g.order = i));
+          void core.conversations.saveChannelGroups();
         }
       });
       Sortable.create(<HTMLElement>this.$refs['channelConversations'], {

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -634,6 +634,7 @@
         }
       });
       Sortable.create(<HTMLElement>this.$refs['channelGroups'], {
+        group: { name: 'groups', pull: false, put: false },
         handle: '.channel-group-header',
         animation: 150,
         fallbackTolerance: 5,

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -626,6 +626,8 @@ class ChannelConversation
       1
     );
     state.channelConversations.splice(newIndex, 0, this);
+    state.syncGroupChannels();
+    void state.saveChannelGroups();
     return state.savePinned();
   }
 
@@ -835,6 +837,14 @@ class State implements Interfaces.State {
     return key[0] === '#'
       ? this.channelMap[key.substr(1)]
       : this.privateMap[key];
+  }
+
+  syncGroupChannels(): void {
+    const assignments = this.channelGroupAssignments;
+    for (const group of this.channelGroups)
+      group.channels = this.channelConversations
+        .filter(c => assignments[c.channel.id] === group.id)
+        .map(c => c.channel.id);
   }
 
   async savePinned(): Promise<void> {


### PR DESCRIPTION
- Fixes channel order within groups not persisting across reconnects (#783) 
- Allows user to drag and drop whole channel groups at a time.
- Isolates groups from channels in SortableJS. 

Fixes #783 
Fixes #764 
Fixes #765 
Closes #774 