### PR TITLE
Brings back pin buttons and makes singular groups 'invisible'

### DIFF
--- a/chat/ChannelGroupSection.vue
+++ b/chat/ChannelGroupSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="channel-group">
+  <div class="channel-group" :class="{ collapsed: group.collapsed }">
     <div class="channel-group-header" @click="toggleCollapse">
       <span
         class="fas fa-fw fa-chevron-right channel-group-chevron"
@@ -78,17 +78,27 @@
             v-show="shouldShowNotificationBadge(conversation)"
             >{{ conversation.unreadCount }}</span
           >
+
           <span
             v-if="conversation.hasAutomatedAds()"
             class="fas fa-ad ads"
             :class="{ active: conversation.isSendingAutomatedAds() }"
             :aria-label="l('chat.toggleAds')"
             @click.stop="conversation.toggleAutomatedAds()"
+            role="button"
           ></span>
+          <span
+            class="fas fa-thumbtack pin active"
+            @click="unpinConversation(conversation)"
+            :aria-label="l('chat.pin.remove')"
+            role="button"
+          >
+          </span>
           <span
             class="fas fa-times leave"
             @click.stop="conversation.close()"
             :aria-label="l('chat.closeTab')"
+            role="button"
           ></span>
         </span>
       </a>
@@ -247,6 +257,9 @@
       deleteGroup() {
         core.conversations.deleteChannelGroup(this.group.id);
       },
+      unpinConversation(conversation: Conversation.ChannelConversation) {
+        core.conversations.setChannelGroup(conversation.channel.id, null);
+      },
       getClasses(conversation: Conversation.Conversation): string {
         return conversation === core.conversations.selectedConversation
           ? ' active'
@@ -274,6 +287,14 @@
 </script>
 
 <style>
+  .channel-group:only-child:not(.editing):not(.collapsed) {
+    .channel-group-header {
+      display: none;
+    }
+    .channel-group-list .list-group-item.item-channel {
+      margin-left: 0px;
+    }
+  }
   .channel-group-header {
     display: flex;
     align-items: center;
@@ -331,8 +352,5 @@
   }
   .channel-group-delete:hover {
     opacity: 1 !important;
-  }
-  .channel-group-list {
-    padding-left: 8px;
   }
 </style>

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -290,6 +290,11 @@
                 @click.stop="conversation.toggleAutomatedAds()"
               ></span>
               <span
+                class="pin fas fa-thumbtack"
+                @click="pinConversation(conversation)"
+                :aria-label="l('chat.pin')"
+              ></span>
+              <span
                 class="fas fa-times leave"
                 @click.stop="conversation.close()"
                 :aria-label="l('chat.closeTab')"
@@ -450,6 +455,7 @@
   import CustomDialog from '../components/custom_dialog';
   import Modal from '../components/Modal.vue';
   import QuickJump from './QuickJump.vue';
+  import { group, log } from 'node:console';
 
   const unreadClasses = {
     [Conversation.UnreadState.None]: '',
@@ -1050,6 +1056,19 @@
         }
 
         userMenu.handleEvent(e);
+      },
+
+      pinConversation(conversation: Conversation.ChannelConversation): void {
+        let groupId = '';
+        if (core.conversations.channelGroups.length < 1) {
+          groupId = core.conversations.createChannelGroup(
+            l('channel.group.ungrouped')
+          );
+        } else {
+          groupId = core.conversations.channelGroups[0].id;
+        }
+        console.log(`id: ${groupId}`);
+        this.onChannelAssign(conversation.channel.id, groupId);
       },
 
       onChannelAssign(channelId: string, groupId: string | null): void {

--- a/chat/locales/en_us.json
+++ b/chat/locales/en_us.json
@@ -155,6 +155,7 @@
   "chat.logout": "Log out",
   "chat.menu": "Menu",
   "chat.pin": "Pin",
+  "chat.pin.remove": "Ungroup",
   "chat.pinTab": "Pin this tab",
   "chat.pms": "Private messages",
   "chat.pms.short": "PMs",


### PR DESCRIPTION
Closes #776

The idea here is that we want to make the transition between basic pins and our new grouping system a lot smoother. But at the moment both me and @Kannamoris don't know if this is the way we want to go yet, or if this is what users want.

The best course of action rn is to wait for ``2.2.0-beta.2`` and then we poll if this is what people want in the Discord.


https://github.com/user-attachments/assets/6700e7db-0c66-463f-af7c-9ae4031baaa7



