### PR TITLE
fix: prevent context submenus from clipping outside of the viewport

### DIFF
--- a/components/CustomContextMenu.vue
+++ b/components/CustomContextMenu.vue
@@ -13,6 +13,7 @@
         'parent-menu-item': item.children && item.children.length > 0
       }"
       :style="item.topBorder ? { borderTopWidth: '1px' } : undefined"
+      @mouseenter="item.children?.length ? positionChild($event) : undefined"
       @click.prevent="onItemClick(item)"
     >
       <span v-if="item.iconClass" :class="item.iconClass" class="fa-fw"></span>
@@ -61,6 +62,27 @@
       onItemClick(item: ContextMenuItemProps): void {
         if (item.disabled) return;
         item.onClick?.();
+      },
+      positionChild(event: MouseEvent): void {
+        const item = event.currentTarget as HTMLElement;
+        const child = item.querySelector<HTMLElement>(':scope > .child-menu');
+        if (!child) return;
+
+        child.style.visibility = 'hidden';
+        child.style.display = 'block';
+        const itemRect = item.getBoundingClientRect();
+        const childW = child.offsetWidth;
+        const childH = child.offsetHeight;
+        child.style.visibility = '';
+        child.style.display = '';
+
+        child.style.left =
+          itemRect.right + childW > window.innerWidth ? 'auto' : '100%';
+        child.style.right =
+          itemRect.right + childW > window.innerWidth ? '100%' : 'auto';
+
+        const overflowBottom = itemRect.top + childH - window.innerHeight;
+        child.style.top = overflowBottom > 0 ? `${-overflowBottom}px` : '0';
       }
     }
   });
@@ -68,6 +90,8 @@
 
 <style scoped lang="scss">
   .parent-menu-item {
+    position: relative;
+
     .child-menu {
       display: none;
       position: absolute;


### PR DESCRIPTION
Fixes #779.

- On `mouseenter`, child menus now measure their own dimensions (briefly shown at `visibility: hidden`) and compare against the viewport bounds before becoming visible
- Flips horizontally to `right: 100%` when opening right would overflow, and shifts `top` upward by the overflow amount when opening down would clip
- Positioning uses `position: absolute` relative to the hovered item, consistent with how `UserMenu` and `ChannelMenu` already bound-check their own root menus

Tried using CSS Achor Positioning but could not get it to work. If anyone wants to try it, go ahead!