### PR TITLE
feat: enhance character-select component with avatars

### DIFF
--- a/components/character_select.vue
+++ b/components/character_select.vue
@@ -1,20 +1,34 @@
 <template>
-  <select :value="selected" @change="onSelectChange" class="form-select">
-    <option
-      v-for="character in characters"
-      :key="character.id"
-      :value="character.id"
-    >
-      {{ character.name }}
-    </option>
-    <slot></slot>
-  </select>
+  <filterable-select
+    class="character-select-component"
+    v-model="selectedObj"
+    :options="characters"
+    :filterFunc="filterCharacter"
+    :placeholder="l('filter')"
+  >
+    <template slot-scope="s">
+      <template v-if="s.option">
+        <img
+          :src="avatarUrl(s.option.name)"
+          class="character-select-avatar"
+          loading="lazy"
+          @error="hideBrokenAvatar"
+        />
+        <span class="text-truncate">{{ s.option.name }}</span>
+      </template>
+      <template v-else>
+        <span class="text-truncate">{{ l('friends.character') }}</span>
+      </template>
+    </template>
+  </filterable-select>
 </template>
 
 <script setup lang="ts">
   import { computed } from 'vue';
   import { SimpleCharacter } from '../interfaces';
   import * as Utils from '../site/utils';
+  import FilterableSelect from './FilterableSelect.vue';
+  import l from '../chat/localize';
 
   const props = defineProps<{
     // Maintaining Vue 2 backwards-compat, remove after full Vue 3 migration
@@ -33,18 +47,66 @@
   }>();
 
   const characters = computed<SimpleCharacter[]>(() => Utils.characters);
-  const selected = computed<number>(() => {
-    return props.modelValue !== undefined ? props.modelValue : props.value;
+  const selectedObj = computed<SimpleCharacter | undefined>({
+    get() {
+      const id =
+        props.modelValue !== undefined ? props.modelValue : props.value;
+      return characters.value.find(character => character.id === id);
+    },
+    set(character) {
+      if (character === undefined) return;
+
+      // Maintaining Vue 2 backwards-compat, remove after full Vue 3 migration
+      emit('input', character.id);
+
+      // Forward-compat for Vue 3
+      emit('update:modelValue', character.id);
+    }
   });
 
-  const onSelectChange = (evt: Event): void => {
-    const target = evt.target as HTMLSelectElement;
-    const newValue = parseInt(target.value, 10);
+  const filterCharacter = (
+    filter: RegExp,
+    character: SimpleCharacter
+  ): boolean => {
+    return filter.test(character.name);
+  };
 
-    // Maintaining Vue 2 backwards-compat, remove after full Vue 3 migration
-    emit('input', newValue);
+  const avatarUrl = Utils.avatarURL;
 
-    // Forward-compat for Vue 3
-    emit('update:modelValue', newValue);
+  const hideBrokenAvatar = (evt: Event): void => {
+    (evt.target as HTMLImageElement).style.display = 'none';
   };
 </script>
+
+<style lang="scss">
+  .character-select-avatar {
+    width: 20px;
+    height: 20px;
+    border-radius: 3px;
+    margin-right: 6px;
+    object-fit: cover;
+  }
+
+  .input-group > .character-select-component {
+    position: relative;
+    flex: 1 1 auto;
+    width: 1%;
+    min-width: 0;
+
+    & > .form-select {
+      display: flex;
+      align-items: center;
+      overflow: hidden;
+    }
+
+    &:not(:first-child) > .form-select {
+      border-top-left-radius: 0;
+      border-bottom-left-radius: 0;
+    }
+
+    &:not(:last-child) > .form-select {
+      border-top-right-radius: 0;
+      border-bottom-right-radius: 0;
+    }
+  }
+</style>

--- a/site/character_page/kinks.vue
+++ b/site/character_page/kinks.vue
@@ -22,27 +22,6 @@
       >
         <character-select v-model="characterToCompare"></character-select>
 
-        <div
-          class="form-label mb-0"
-          :style="`
-            aspect-ratio: 1;
-            height: 100%;
-            background-size: cover;
-            background-repeat: no-repeat;
-            background-position: center;
-            background-image: url(${getCompareAvatarUrl()});
-            `"
-        >
-          <a
-            v-if="compareCharacter"
-            :href="compareHref"
-            target="_blank"
-            class="compare-avatar-wrapper"
-            style="height: 100%; width: 100%"
-          >
-          </a>
-        </div>
-
         <!-- small filter icon merged into compare area; highlighted when active -->
         <button
           type="button"
@@ -330,43 +309,6 @@
         await compareKinks();
       };
 
-      const getCompareAvatarUrl = (): string => {
-        //There should be a site util for sanitizing avatars like this tbqh.
-        return Utils.avatarURL(compareName.value).replace(/ /g, '%20');
-      };
-
-      const compareCharacter = computed(() => {
-        try {
-          const id = characterToCompare.value;
-          if (id === undefined || id === null) return undefined;
-
-          const scs = Utils.characters || [];
-          const found = scs.find((c: any) => c.id === id);
-          const name = found ? found.name : undefined;
-          if (!name) return undefined;
-
-          return core.characters.get(name);
-        } catch (e) {
-          return undefined;
-        }
-      });
-
-      const compareName = computed(() => {
-        try {
-          const cc = compareCharacter.value as any;
-          if (!cc) return undefined;
-          return cc.name || (cc.character && cc.character.name) || undefined;
-        } catch (e) {
-          return undefined;
-        }
-      });
-
-      const compareHref = computed(() => {
-        const name = compareName.value;
-        if (!name) return '#';
-        return Utils.characterURL(name);
-      });
-
       const groupedKinks = computed(
         (): { [key in KinkChoice]: DisplayKink[] } => {
           const kinks = Store.shared.kinks;
@@ -578,10 +520,6 @@
       return {
         shared,
         characterToCompare,
-        compareCharacter,
-        compareName,
-        compareHref,
-        getCompareAvatarUrl,
         highlightGroup,
         search,
         sortByViewerPriorities,
@@ -638,25 +576,5 @@
   }
   .quick-compare-block > button {
     flex: 0 0 auto;
-  }
-
-  .compare-avatar {
-    flex: 0 0 auto;
-    width: 37px;
-    height: 37px;
-    max-height: 37px;
-    max-width: 37px;
-    object-fit: cover;
-    align-self: center;
-  }
-
-  .compare-avatar-wrapper {
-    display: inline-flex;
-    align-items: center;
-  }
-  .compare-avatar-wrapper {
-    width: auto;
-    height: auto;
-    justify-content: center;
   }
 </style>


### PR DESCRIPTION
**What does this PR do?**
- Replaces the native `<select>` element in `character_select.vue` with the `<filterable-select>` component, allowing the display of character avatars directly inline within the dropdown.
- Cleans up `kinks.vue` by removing the redundant, standalone avatar display block and its associated computed properties/CSS classes, since the select component now handles it natively.