### PR TITLE
fix: user menu stays open when clicking inside status area

### DIFF
--- a/bbcode/core.ts
+++ b/bbcode/core.ts
@@ -174,6 +174,7 @@ export class CoreBBCodeParser extends BBCodeParser {
         link.onclick = e => {
           const target = e.target as HTMLElement;
           target.parentElement!.replaceChild(content, target);
+          e.stopPropagation();
           return false;
         };
         link.appendChild(document.createTextNode('[click to show spoiler]'));

--- a/chat/UserMenu.vue
+++ b/chat/UserMenu.vue
@@ -34,7 +34,7 @@
           id="userMenuStatus"
           :text="character.statusText"
           v-show="character.statusText"
-          class="list-group-item"
+          class="list-group-item bbcode"
           style="max-height: 200px; overflow: auto; clear: both"
         ></bbcode>
 
@@ -344,8 +344,15 @@
       },
       close(): void {
         if (!this.showContextMenu) return;
+        document.removeEventListener('click', this.closeOnOutsideClick);
         this.showContextMenu = false;
         this.$emit('close');
+      },
+      closeOnOutsideClick(e: MouseEvent): void {
+        const menu = this.getMenuElement();
+        if (menu && menu.contains(e.target as Node)) return;
+        document.removeEventListener('click', this.closeOnOutsideClick);
+        this.close();
       },
       openConversation(jump: boolean): void {
         const conversation = core.conversations.getPrivate(this.character!);
@@ -583,7 +590,8 @@
             this.position.top = `${window.innerHeight - menu.offsetHeight - 1}px`;
         });
 
-        document.addEventListener('click', this.close, { once: true });
+        document.removeEventListener('click', this.closeOnOutsideClick);
+        document.addEventListener('click', this.closeOnOutsideClick);
       }
     }
   });


### PR DESCRIPTION
Fixes #792 

Fixes a regression from a984714c. The old `openMenu` had no document-level click listener at all. Closing only happened when `handleEvent`'s DOM traversal reached `document.body` without finding a character. Clicks inside `#userMenuStatus` never got that far since the loop bails early there, so the menu stayed open.

The refactor threw in `document.addEventListener('click', this.close, { once: true })` which just kills the menu on the very next click no matter where it lands, completely ignoring the early-return logic in `handleEvent`.

The fix replaces it with `closeOnOutsideClick` which checks `menu.contains(e.target)` first, so clicks inside the menu are ignored.