### PR TITLE
Gallery zoom percentage tweak

### DIFF
--- a/scss/_character_page.scss
+++ b/scss/_character_page.scss
@@ -530,10 +530,12 @@
         .zoom-number {
           flex-grow: 0;
           max-width: 20%;
+          min-width: 4.8em;
+          justify-content: center;
           display: none;
           font-size: 0.9em;
           @include media-breakpoint-up(xl) {
-            display: inline-block;
+            display: flex;
           }
         }
 
@@ -541,13 +543,26 @@
           @include media-breakpoint-down(lg) {
             width: 100% !important;
           }
+          .placeholder {
+            background-color: var(--bs-secondary-bg);
+          }
         }
 
         .zoom-range-container {
           flex-grow: 1;
+          position: relative;
           .zoom-range {
             height: 1em;
             //width: 80%;
+          }
+          .zoom-range-placeholder {
+            position: absolute;
+            left: $input-group-addon-padding-x;
+            right: $input-group-addon-padding-x;
+            top: 50%;
+            transform: translateY(-50%);
+            height: 1em;
+            min-height: 0;
           }
         }
       }

--- a/scss/themes/_chat.scss
+++ b/scss/themes/_chat.scss
@@ -24,6 +24,7 @@
 @import '~bootstrap/scss/popover';
 @import '~bootstrap/scss/badge';
 @import '~bootstrap/scss/spinners';
+@import '~bootstrap/scss/placeholders';
 @import '~bootstrap/scss/utilities';
 @import '~bootstrap/scss/utilities/api';
 @import '~bootstrap/scss/helpers/color-bg';

--- a/site/character_page/images.vue
+++ b/site/character_page/images.vue
@@ -192,16 +192,22 @@
               </button>
 
               <label
-                class="input-group-text bg-body-tertiary zoom-number font-monospace"
+                class="input-group-text bg-body-tertiary zoom-number font-monospace placeholder-glow"
               >
-                {{ `${displayedZoomPercent()}%` }}
+                <span v-if="previewLoading" class="placeholder w-100"></span>
+                <span v-else>{{ `${displayedZoomPercent()}%` }}</span>
               </label>
               <label
-                class="input-group-text bg-body-tertiary zoom-range-container"
+                class="input-group-text bg-body-tertiary zoom-range-container placeholder-glow"
               >
+                <span
+                  v-if="previewLoading"
+                  class="placeholder zoom-range-placeholder"
+                ></span>
                 <input
                   type="range"
                   class="form-range zoom-range"
+                  :class="previewLoading ? 'invisible' : ''"
                   :min="getZoomMin()"
                   :max="getZoomMax()"
                   v-model.number="zoomLevel"

--- a/site/character_page/images.vue
+++ b/site/character_page/images.vue
@@ -194,7 +194,7 @@
               <label
                 class="input-group-text bg-body-tertiary zoom-number font-monospace"
               >
-                {{ `${zoomLevel}%` }}
+                {{ `${displayedZoomPercent()}%` }}
               </label>
               <label
                 class="input-group-text bg-body-tertiary zoom-range-container"
@@ -283,6 +283,7 @@
   const previewNaturalWidth = ref(0);
   const previewNaturalHeight = ref(0);
   const zoomLevel = ref(ZOOM_LEVEL_MIN);
+  const fitPercent = ref(100);
   const forceShowInfo = ref(false);
   const copySuccess = ref(false);
   const images = ref<CharacterImage[]>([]);
@@ -395,6 +396,7 @@
     previewDisplayHeight.value = Math.floor(
       previewNaturalHeight.value * fitScale
     );
+    fitPercent.value = fitScale * 100;
   };
 
   const showAsync = async (): Promise<void> => {
@@ -468,6 +470,7 @@
     previewNaturalHeight.value = 0;
     previewDisplayWidth.value = 0;
     previewDisplayHeight.value = 0;
+    fitPercent.value = 100;
 
     const url = imageUrl(image);
     const pre = new Image();
@@ -507,6 +510,7 @@
     window.removeEventListener('keydown', handleKeydown, { capture: true });
     window.removeEventListener('resize', updatePreviewDimensions);
     zoomLevel.value = ZOOM_LEVEL_MIN;
+    fitPercent.value = 100;
   };
 
   const handleImageClick = (e: MouseEvent, image: CharacterImage): void => {
@@ -517,11 +521,9 @@
   };
 
   const zoomOutClicked = (_e: MouseEvent): void => {
-    if (zoomLevel.value <= ZOOM_LEVEL_MIN) return;
-    zoomLevel.value = Math.max(
-      ZOOM_LEVEL_MIN,
-      zoomLevel.value - ZOOM_LEVEL_STEP
-    );
+    const min = getZoomMin();
+    if (zoomLevel.value <= min) return;
+    zoomLevel.value = Math.max(min, zoomLevel.value - ZOOM_LEVEL_STEP);
   };
 
   const zoomInClicked = (_e: MouseEvent): void => {
@@ -689,11 +691,18 @@
   };
 
   const getZoomMin = (): number => {
+    // if the image is smaller than the window, allow zooming out to 100% of actual size
+    if (fitPercent.value > ZOOM_LEVEL_MIN) {
+      return (ZOOM_LEVEL_MIN * ZOOM_LEVEL_MIN) / fitPercent.value;
+    }
     return ZOOM_LEVEL_MIN;
   };
   const getZoomMax = (): number => {
     return ZOOM_LEVEL_MAX;
   };
+
+  const displayedZoomPercent = (): number =>
+    Math.round((zoomLevel.value * fitPercent.value) / 100);
 
   const getPreviewLinkStyle = (): Record<string, string | number> => {
     //This is kind of ugly, but it keeps the image size itself CSS driven. Which I like.


### PR DESCRIPTION
Coming from how image viewers/editors typically work, I was personally thrown off by the way that the full window height in Horizon's gallery counts as 100% zoom, even if the image definitely isn't scaled to 100%. 

This tweaks it so that the zoom percentage is the actual image scale percentage, additionally letting you zoom out to 100% on small images. Large images have their minimum scale percentage set to the window height (i.e. 75%) so that you'll always see the full thing at minimum zoom.

<img width="1268" height="816" alt="electron_tUrlsAzExs" src="https://github.com/user-attachments/assets/ba287d39-1e3f-4923-a024-b6d9d2e51c91" />
<img width="1258" height="808" alt="mspaint_YBvhdsViFq" src="https://github.com/user-attachments/assets/67cd659e-25c5-400f-83ed-40c0b8131fb1" />
