### PR TITLE
fix: Auto Ad minimum delay issues

### DIFF
--- a/chat/ads/ad-manager.ts
+++ b/chat/ads/ad-manager.ts
@@ -159,9 +159,12 @@ export class AdManager {
     );
 
     // tslint:disable-next-line: no-unnecessary-type-assertion
-    this.interval = setTimeout(async () => {
-      await this.sendNextPost();
-    }, nextInMs) as Timer;
+    this.interval = setTimeout(
+      async () => {
+        await this.sendNextPost();
+      },
+      Math.max(0, this.nextPostDue.getTime() - Date.now())
+    ) as Timer;
   }
 
   generateAdMap(): number[] {

--- a/chat/ads/ad-manager.ts
+++ b/chat/ads/ad-manager.ts
@@ -27,6 +27,7 @@ export interface RecoverableAd {
   nextPostDue: Date | undefined;
   firstPost: Date | undefined;
   expireDue: Date | undefined;
+  minPostDelaySeconds: number;
 }
 
 export class AdManager {
@@ -306,7 +307,8 @@ export class AdManager {
           index: adManager.adIndex,
           nextPostDue: adManager.nextPostDue,
           firstPost: adManager.firstPost,
-          expireDue: adManager.expireDue
+          expireDue: adManager.expireDue,
+          minPostDelaySeconds: adManager.minPostDelaySeconds
         };
       }
     );
@@ -340,7 +342,7 @@ export class AdManager {
     const adManager = channel.adManager;
 
     adManager.stop();
-    adManager.start();
+    adManager.start(AdManager.POSTING_PERIOD, ra.minPostDelaySeconds);
 
     adManager.adIndex = ra.index;
     adManager.firstPost = ra.firstPost;

--- a/chat/ads/ad-manager.ts
+++ b/chat/ads/ad-manager.ts
@@ -244,11 +244,14 @@ export class AdManager {
     this.adMap = this.generateAdMap();
 
     // tslint:disable-next-line: no-unnecessary-type-assertion
-    this.interval = setTimeout(async () => {
-      this.firstPost = new Date();
+    this.interval = setTimeout(
+      async () => {
+        this.firstPost = new Date();
 
-      await this.sendNextPost();
-    }, initialWait) as Timer;
+        await this.sendNextPost();
+      },
+      Math.max(0, this.nextPostDue.getTime() - Date.now())
+    ) as Timer;
   }
 
   protected forceTimeout(waitTime: number): void {


### PR DESCRIPTION
Apparently, the auto ad minimum delay setting has been mostly cosmetic. Even if the timer said "Next ad in 23m 42s" after the user sets a 30 minute delay, it would post ads at whatever the minimum delay set in the channel's description is, or the default F-Chat ad cooldown if the channel didn't have one set. 

The changes here make auto ads **actually** respect the minimum delay that's set, including cases where a user manually posts an ad, then enables auto ads right after. Additionally, any auto ads set before an automatic reconnect (after network issue or whatever) should now keep the original delay that was set.

Fixes #780, fixes #507, fixes #511