### PR TITLE
fix: include general settings in exports/imports with a custom log dir

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -170,6 +170,7 @@ EXAMPLES:
     const dryRun = has('-n') || has('--dry-run');
     const exportResult = await runExportCli({
       dataDir,
+      settingsDir: path.join(app.getPath('userData'), 'data'),
       out,
       includeGeneral: include('--include-general', true),
       includeCharacterSettings: include('--include-character-settings', true),
@@ -213,6 +214,7 @@ EXAMPLES:
     const importResult = await runImportCli({
       zip,
       dataDir,
+      settingsDir: path.join(app.getPath('userData'), 'data'),
       includeGeneral: include('--include-general', true),
       includeCharacterSettings: include('--include-character-settings', true),
       includeLogs: include('--include-logs', true),

--- a/electron/services/exporter/auto-backup.ts
+++ b/electron/services/exporter/auto-backup.ts
@@ -60,6 +60,7 @@ export async function performAutoBackup(
   try {
     await runExportCli({
       dataDir: settings.logDirectory,
+      settingsDir: path.join(baseDir, 'data'),
       out: outPath,
       includeGeneral: settings.autoBackupIncludeGeneralSettings,
       includeCharacterSettings: settings.autoBackupIncludeCharacterSettings,

--- a/electron/services/exporter/backup-export-cli.ts
+++ b/electron/services/exporter/backup-export-cli.ts
@@ -6,7 +6,8 @@ import { createManifest } from './manifest';
 /**
  * Configuration options for CLI-based export operations.
  *
- * @property dataDir - Absolute path to the Horizon data directory
+ * @property dataDir - Absolute path to the Horizon data directory (character data / logs)
+ * @property settingsDir - Absolute path to the general settings directory; defaults to dataDir. Pass the fixed `{userData}/data` when the log directory is custom.
  * @property out - Absolute path where the output ZIP file will be created
  * @property includeGeneral - Include general application settings
  * @property includeCharacterSettings - Include all character-specific settings files
@@ -21,6 +22,7 @@ import { createManifest } from './manifest';
  */
 export interface ExportCliOptions {
   dataDir: string;
+  settingsDir?: string;
   out: string;
   includeGeneral: boolean;
   includeCharacterSettings: boolean;
@@ -185,7 +187,10 @@ function logDryRunDetails(
   console.log('');
 
   console.log('Export options:');
-  const generalSettingsFile = path.join(dataDir, 'settings');
+  const generalSettingsFile = path.join(
+    opts.settingsDir ?? dataDir,
+    'settings'
+  );
   const hasGeneral = fs.existsSync(generalSettingsFile);
   console.log(
     `  - General settings: ${opts.includeGeneral && hasGeneral ? 'YES' : 'NO'}`
@@ -221,7 +226,10 @@ function countEntries(
   let count = 0;
 
   if (opts.includeGeneral) {
-    const generalSettingsFile = path.join(dataDir, 'settings');
+    const generalSettingsFile = path.join(
+      opts.settingsDir ?? dataDir,
+      'settings'
+    );
     if (fs.existsSync(generalSettingsFile)) count++;
   }
 
@@ -301,7 +309,10 @@ async function createArchive(
   });
 
   if (opts.includeGeneral) {
-    const generalSettingsFile = path.join(dataDir, 'settings');
+    const generalSettingsFile = path.join(
+      opts.settingsDir ?? dataDir,
+      'settings'
+    );
     if (fs.existsSync(generalSettingsFile)) {
       archive.file(generalSettingsFile, { name: 'settings' });
     }

--- a/electron/services/exporter/backup-export.ts
+++ b/electron/services/exporter/backup-export.ts
@@ -20,6 +20,13 @@ import type { ExportManifest } from './manifest';
 import type { ExporterVm } from '../exporter-vm';
 import { binaryLogToJson } from './backup-export-cli';
 
+/**
+ * Directory holding the general (app-wide) settings file. This is fixed at
+ * `{userData}/data` regardless of the user's custom `logDirectory`, since the
+ * main process always reads/writes general settings there.
+ */
+const generalSettingsDir = path.join(remote.app.getPath('userData'), 'data');
+
 async function yieldToUi(vm?: ExporterVm): Promise<void> {
   try {
     if (vm && typeof vm.$nextTick === 'function') {
@@ -139,7 +146,8 @@ function buildExportEntries(
   const entries: ExportEntry[] = [];
 
   if (vm.exportIncludeGeneralSettings) {
-    const generalSettingsFile = path.join(dataDir, 'settings');
+    // General settings always live at the fixed location, not under logDirectory.
+    const generalSettingsFile = path.join(generalSettingsDir, 'settings');
     if (fs.existsSync(generalSettingsFile))
       entries.push({ abs: generalSettingsFile, zip: 'settings' });
   }

--- a/electron/services/importer/backup-import-cli.ts
+++ b/electron/services/importer/backup-import-cli.ts
@@ -6,7 +6,8 @@ import AdmZip from 'adm-zip';
  * Configuration options for CLI-based import operations.
  *
  * @property zip - Absolute path to the ZIP backup file to import from
- * @property dataDir - Absolute path to the Horizon data directory where data will be imported
+ * @property dataDir - Absolute path to the Horizon data directory where character data will be imported
+ * @property settingsDir - Absolute path to the general settings directory; defaults to dataDir. Pass the fixed `{userData}/data` when the log directory is custom.
  * @property includeGeneral - Whether to import general application settings
  * @property includeCharacterSettings - Whether to import all character-specific settings files
  * @property includeLogs - Whether to import chat log history for characters
@@ -22,6 +23,7 @@ import AdmZip from 'adm-zip';
 export interface ImportCliOptions {
   zip: string;
   dataDir: string;
+  settingsDir?: string;
   includeGeneral: boolean;
   includeCharacterSettings: boolean;
   includeLogs: boolean;
@@ -137,7 +139,8 @@ function importGeneralSettingsFromZip(
   const general = zip.getEntry('settings');
   if (!general) return false;
 
-  const dst = getSafeDestination(dataDir, 'settings');
+  // General settings belong at the fixed location, not under a custom log dir.
+  const dst = getSafeDestination(opts.settingsDir ?? dataDir, 'settings');
   if (!dst) throw new Error('Invalid settings destination');
 
   fs.mkdirSync(path.dirname(dst), { recursive: true });
@@ -213,7 +216,9 @@ function printDryRunGeneralSettings(
 ): void {
   const general = zip.getEntry('settings');
   const hasGeneral = general !== null;
-  const generalExists = fs.existsSync(path.join(dataDir, 'settings'));
+  const generalExists = fs.existsSync(
+    path.join(opts.settingsDir ?? dataDir, 'settings')
+  );
 
   let generalStatus = opts.includeGeneral && hasGeneral ? 'YES' : 'NO';
   if (opts.includeGeneral && hasGeneral && generalExists) {

--- a/electron/services/importer/backup-import.ts
+++ b/electron/services/importer/backup-import.ts
@@ -21,6 +21,12 @@ import type { ExportManifest } from '../exporter/manifest';
 import type { ExporterVm } from '../exporter-vm';
 /** Default log directory in the renderer process (avoids instantiating GeneralSettings). */
 const defaultLogDirectory = path.join(remote.app.getPath('userData'), 'data');
+/**
+ * Directory holding the general (app-wide) settings file. Fixed at
+ * `{userData}/data` regardless of the user's custom `logDirectory`, matching
+ * where the main process reads/writes general settings.
+ */
+const generalSettingsDir = defaultLogDirectory;
 
 /**
  * Information about a character found in a Horizon backup ZIP file.
@@ -538,7 +544,6 @@ async function checkConnectedCharacters(): Promise<boolean> {
 function importGeneralSettings(
   vm: ExporterVm,
   zip: AdmZip,
-  dataDir: string,
   stats: ImportStats
 ): void {
   if (!vm.importGeneralAvailable || !vm.importIncludeGeneralSettings) return;
@@ -547,7 +552,9 @@ function importGeneralSettings(
   const generalEntry = zip.getEntry('settings');
   if (!generalEntry) return;
 
-  const destination = getSafeDestination(dataDir, 'settings');
+  // General settings always belong at the fixed location, not under a custom
+  // log directory, so the main process can read them back.
+  const destination = getSafeDestination(generalSettingsDir, 'settings');
   if (!destination) return;
 
   fs.mkdirSync(path.dirname(destination), { recursive: true });
@@ -752,7 +759,7 @@ export async function runZipImport(vm: ExporterVm): Promise<void> {
       charactersTouched: new Set<string>()
     };
 
-    importGeneralSettings(vm, zip, dataDir, stats);
+    importGeneralSettings(vm, zip, stats);
     importCharacterData(
       vm,
       zip,


### PR DESCRIPTION
Separate the general-settings dir (fixed `{userData}/data`) from the character data/log dir. The CLI exporter/importer take an optional `settingsDir` (defaulting to `dataDir`); the GUI tools, auto-backup, and export/import CLI commands pass the canonical path.

Fixes #721

<img width="800" height="600" alt="260530_14h12m59s_screenshot" src="https://github.com/user-attachments/assets/a49a05f9-7b16-4fee-a6a1-259b54631e35" />
