### PR TITLE
fix: respect per-file settings toggles when exporting/importing

### DIFF
--- a/electron/Exporter.vue
+++ b/electron/Exporter.vue
@@ -820,14 +820,6 @@
                       >
                         {{ l('settings.import.zip.pinnedUnavailable') }}
                       </small>
-                      <small
-                        v-else-if="importIncludeCharacterSettings"
-                        class="form-text text-muted"
-                      >
-                        {{
-                          l('settings.import.zip.pinnedIncludedWithSettings')
-                        }}
-                      </small>
                     </div>
                     <div class="form-check mb-2">
                       <input
@@ -849,14 +841,6 @@
                       >
                         {{ l('settings.import.zip.pinnedUnavailable') }}
                       </small>
-                      <small
-                        v-else-if="importIncludeCharacterSettings"
-                        class="form-text text-muted"
-                      >
-                        {{
-                          l('settings.import.zip.pinnedIncludedWithSettings')
-                        }}
-                      </small>
                     </div>
                     <div class="form-check mb-2">
                       <input
@@ -864,10 +848,7 @@
                         type="checkbox"
                         id="importIncludeRecents"
                         v-model="importIncludeRecents"
-                        :disabled="
-                          importIncludeCharacterSettings ||
-                          !importRecentsAvailable
-                        "
+                        :disabled="!importRecentsAvailable"
                       />
                       <label
                         class="form-check-label"
@@ -888,10 +869,7 @@
                         type="checkbox"
                         id="importIncludeHidden"
                         v-model="importIncludeHidden"
-                        :disabled="
-                          importIncludeCharacterSettings ||
-                          !importHiddenAvailable
-                        "
+                        :disabled="!importHiddenAvailable"
                       />
                       <label class="form-check-label" for="importIncludeHidden">
                         {{ l('settings.import.zip.includeHidden') }}

--- a/electron/services/exporter/backup-export-cli.ts
+++ b/electron/services/exporter/backup-export-cli.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import archiver from 'archiver';
-import { createManifest } from './manifest';
+import { createManifest, shouldIncludeSettingsFile } from './manifest';
 
 /**
  * Configuration options for CLI-based export operations.
@@ -112,34 +112,11 @@ function addCharacterSettings(
   const settingsDir = path.join(characterDir, 'settings');
   if (!fs.existsSync(settingsDir)) return;
 
-  if (opts.includeCharacterSettings) {
-    const files = listFilesRecursive(settingsDir);
-    for (const abs of files) {
-      const rel = path.relative(settingsDir, abs).replace(/\\/g, '/');
-      const zipPath = path.posix.join('characters', character, 'settings', rel);
-      archive.file(abs, { name: zipPath });
-    }
-  } else {
-    const includeFiles = new Set<string>();
-    if (opts.includePinnedConversations) includeFiles.add('pinned');
-    if (opts.includePinnedEicons) includeFiles.add('favoriteEIcons');
-    if (opts.includeRecents) {
-      includeFiles.add('recent');
-      includeFiles.add('recentChannels');
-    }
-    if (opts.includeHidden) includeFiles.add('hiddenUsers');
-    for (const file of Array.from(includeFiles)) {
-      const filePath = path.join(settingsDir, file);
-      if (fs.existsSync(filePath)) {
-        const zipPath = path.posix.join(
-          'characters',
-          character,
-          'settings',
-          file
-        );
-        archive.file(filePath, { name: zipPath });
-      }
-    }
+  for (const abs of listFilesRecursive(settingsDir)) {
+    const rel = path.relative(settingsDir, abs).replace(/\\/g, '/');
+    if (!shouldIncludeSettingsFile(rel, opts)) continue;
+    const zipPath = path.posix.join('characters', character, 'settings', rel);
+    archive.file(abs, { name: zipPath });
   }
 }
 
@@ -242,20 +219,9 @@ function countEntries(
 
     const settingsDir = path.join(characterDir, 'settings');
     if (fs.existsSync(settingsDir)) {
-      if (opts.includeCharacterSettings) {
-        count += listFilesRecursive(settingsDir).length;
-      } else {
-        const files = new Set<string>();
-        if (opts.includePinnedConversations) files.add('pinned');
-        if (opts.includePinnedEicons) files.add('favoriteEIcons');
-        if (opts.includeRecents) {
-          files.add('recent');
-          files.add('recentChannels');
-        }
-        if (opts.includeHidden) files.add('hiddenUsers');
-        for (const f of Array.from(files)) {
-          if (fs.existsSync(path.join(settingsDir, f))) count++;
-        }
+      for (const abs of listFilesRecursive(settingsDir)) {
+        const rel = path.relative(settingsDir, abs).replace(/\\/g, '/');
+        if (shouldIncludeSettingsFile(rel, opts)) count++;
       }
     }
   }

--- a/electron/services/exporter/backup-export.ts
+++ b/electron/services/exporter/backup-export.ts
@@ -15,8 +15,12 @@ import path from 'path';
 import log from 'electron-log';
 import archiver from 'archiver';
 import AdmZip from 'adm-zip';
-import { createManifest, isValidManifest } from './manifest';
-import type { ExportManifest } from './manifest';
+import {
+  createManifest,
+  isValidManifest,
+  shouldIncludeSettingsFile
+} from './manifest';
+import type { ExportManifest, SettingsSelection } from './manifest';
 import type { ExporterVm } from '../exporter-vm';
 import { binaryLogToJson } from './backup-export-cli';
 
@@ -177,27 +181,13 @@ function buildExportEntries(
 
     const settingsDir = path.join(characterDir, 'settings');
     if (fs.existsSync(settingsDir)) {
-      if (vm.exportIncludeCharacterSettings) {
-        const files = listFilesRecursive(settingsDir);
-        for (const abs of files) {
-          const rel = path.relative(settingsDir, abs).replace(/\\/g, '/');
-          const zip = path.posix.join('characters', character, 'settings', rel);
-          entries.push({ abs, zip });
-        }
-      } else {
-        const includeFiles = getSettingsFilesToInclude(vm);
-        for (const file of Array.from(includeFiles)) {
-          const filePath = path.join(settingsDir, file);
-          if (fs.existsSync(filePath)) {
-            const zip = path.posix.join(
-              'characters',
-              character,
-              'settings',
-              file
-            );
-            entries.push({ abs: filePath, zip });
-          }
-        }
+      const selection = exportSettingsSelection(vm);
+      const files = listFilesRecursive(settingsDir);
+      for (const abs of files) {
+        const rel = path.relative(settingsDir, abs).replace(/\\/g, '/');
+        if (!shouldIncludeSettingsFile(rel, selection)) continue;
+        const zip = path.posix.join('characters', character, 'settings', rel);
+        entries.push({ abs, zip });
       }
     }
   }
@@ -205,16 +195,14 @@ function buildExportEntries(
   return entries;
 }
 
-function getSettingsFilesToInclude(vm: ExporterVm): Set<string> {
-  const includeFiles = new Set<string>();
-  if (vm.exportIncludePinnedConversations) includeFiles.add('pinned');
-  if (vm.exportIncludePinnedEicons) includeFiles.add('favoriteEIcons');
-  if (vm.exportIncludeRecents) {
-    includeFiles.add('recent');
-    includeFiles.add('recentChannels');
-  }
-  if (vm.exportIncludeHidden) includeFiles.add('hiddenUsers');
-  return includeFiles;
+function exportSettingsSelection(vm: ExporterVm): SettingsSelection {
+  return {
+    includeCharacterSettings: vm.exportIncludeCharacterSettings,
+    includePinnedConversations: vm.exportIncludePinnedConversations,
+    includePinnedEicons: vm.exportIncludePinnedEicons,
+    includeRecents: vm.exportIncludeRecents,
+    includeHidden: vm.exportIncludeHidden
+  };
 }
 
 /**

--- a/electron/services/exporter/manifest.ts
+++ b/electron/services/exporter/manifest.ts
@@ -51,3 +51,52 @@ export function isValidManifest(data: unknown): data is ExportManifest {
     m.includes !== null
   );
 }
+
+/**
+ * Which per-character settings files to include in a backup export/import.
+ *
+ * A character's settings directory holds both generic config (e.g. `settings`,
+ * `modes`, `conversationSettings`) and a handful of "special" files that each
+ * have their own dedicated checkbox. The selection treats them independently:
+ * `characterSettings` governs only the generic files, while each special group
+ * is governed solely by its own flag.
+ */
+export interface SettingsSelection {
+  /** Generic character config — everything that isn't a special file below. */
+  includeCharacterSettings: boolean;
+  /** `pinned` */
+  includePinnedConversations: boolean;
+  /** `favoriteEIcons` */
+  includePinnedEicons: boolean;
+  /** `recent`, `recentChannels` */
+  includeRecents: boolean;
+  /** `hiddenUsers` */
+  includeHidden: boolean;
+}
+
+/**
+ * Decides whether a single settings file should be included, given the user's
+ * selection. The special files are gated by their own flag (independent of
+ * `characterSettings`); anything else counts as generic character config.
+ *
+ * @param relPath - Path of the file within the character's settings dir (posix).
+ * @param sel - The user's per-category selection.
+ */
+export function shouldIncludeSettingsFile(
+  relPath: string,
+  sel: SettingsSelection
+): boolean {
+  switch (relPath) {
+    case 'pinned':
+      return sel.includePinnedConversations;
+    case 'favoriteEIcons':
+      return sel.includePinnedEicons;
+    case 'recent':
+    case 'recentChannels':
+      return sel.includeRecents;
+    case 'hiddenUsers':
+      return sel.includeHidden;
+    default:
+      return sel.includeCharacterSettings;
+  }
+}

--- a/electron/services/importer/backup-import-cli.ts
+++ b/electron/services/importer/backup-import-cli.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import AdmZip from 'adm-zip';
+import { shouldIncludeSettingsFile } from '../exporter/manifest';
 
 /**
  * Configuration options for CLI-based import operations.
@@ -87,15 +88,8 @@ function shouldImportSettingsFile(
   opts: ImportCliOptions,
   segments: string[]
 ): boolean {
-  if (opts.includeCharacterSettings) return true;
   const fileName = segments.slice(3).join('/');
-  return (
-    (fileName === 'pinned' && opts.includePinnedConversations) ||
-    (fileName === 'favoriteEIcons' && opts.includePinnedEicons) ||
-    ((fileName === 'recent' || fileName === 'recentChannels') &&
-      opts.includeRecents) ||
-    (fileName === 'hiddenUsers' && opts.includeHidden)
-  );
+  return shouldIncludeSettingsFile(fileName, opts);
 }
 
 function classifyEntry(

--- a/electron/services/importer/backup-import.ts
+++ b/electron/services/importer/backup-import.ts
@@ -16,8 +16,11 @@ import { ipcRenderer } from 'electron';
 import log from 'electron-log';
 import AdmZip from 'adm-zip';
 import type { IZipEntry } from 'adm-zip';
-import { isValidManifest } from '../exporter/manifest';
-import type { ExportManifest } from '../exporter/manifest';
+import {
+  isValidManifest,
+  shouldIncludeSettingsFile
+} from '../exporter/manifest';
+import type { ExportManifest, SettingsSelection } from '../exporter/manifest';
 import type { ExporterVm } from '../exporter-vm';
 /** Default log directory in the renderer process (avoids instantiating GeneralSettings). */
 const defaultLogDirectory = path.join(remote.app.getPath('userData'), 'data');
@@ -478,32 +481,25 @@ function shouldImportEntry(
     decision.shouldImport = true;
     decision.isDrafts = true;
   } else if (category === 'settings' && info.hasSettings) {
-    decision.shouldImport = shouldImportSettingsFile(vm, segments, info);
+    decision.shouldImport = shouldImportSettingsFile(vm, segments);
   }
 
   return decision;
 }
 
-function shouldImportSettingsFile(
-  vm: ExporterVm,
-  segments: string[],
-  info: BackupCharacterInfo
-): boolean {
-  if (vm.importIncludeCharacterSettings) return true;
-
+function shouldImportSettingsFile(vm: ExporterVm, segments: string[]): boolean {
   const fileName = segments.slice(3).join('/');
-  return (
-    (fileName === 'pinned' &&
-      vm.importIncludePinnedConversations &&
-      info.hasPinnedConversations) ||
-    (fileName === 'favoriteEIcons' &&
-      vm.importIncludePinnedEicons &&
-      info.hasPinnedEicons) ||
-    ((fileName === 'recent' || fileName === 'recentChannels') &&
-      vm.importIncludeRecents &&
-      info.hasRecents) ||
-    (fileName === 'hiddenUsers' && vm.importIncludeHidden && info.hasHidden)
-  );
+  return shouldIncludeSettingsFile(fileName, importSettingsSelection(vm));
+}
+
+function importSettingsSelection(vm: ExporterVm): SettingsSelection {
+  return {
+    includeCharacterSettings: vm.importIncludeCharacterSettings,
+    includePinnedConversations: vm.importIncludePinnedConversations,
+    includePinnedEicons: vm.importIncludePinnedEicons,
+    includeRecents: vm.importIncludeRecents,
+    includeHidden: vm.importIncludeHidden
+  };
 }
 
 /**


### PR DESCRIPTION
Selecting "character settings" exported and imported every file in a character's settings folder (pinned conversations, eicons, recents, hidden users) even with those boxes unchecked, so the per-file toggles did nothing. 

Consolidate the duplicated, drifted special-file logic into a single shouldIncludeSettingsFile predicate that gates each special file on its own toggle, and drop the import UI's "included with character settings" coupling.

<img width="1102" height="1010" alt="260530_17h50m07s_screenshot" src="https://github.com/user-attachments/assets/ecf7eea4-ecfa-4365-950b-4009523dc5f0" />

<img width="912" height="33" alt="image" src="https://github.com/user-attachments/assets/dd50706c-7f25-45d2-be70-f8e55d219b07" />


Fixes #788 