### PR TITLE
fix: decode HTML entities in character memos

### DIFF
--- a/chat/character/memo.ts
+++ b/chat/character/memo.ts
@@ -1,6 +1,7 @@
 import core from '../core';
 import { CharacterMemo } from '../../site/character_page/interfaces';
 import { EventBus } from '../preview/event-bus';
+import { decodeHTML } from '../../fchat/common';
 
 export class MemoManager {
   memo?: CharacterMemo;
@@ -25,7 +26,7 @@ export class MemoManager {
       note: message
     });
 
-    this.memo!.memo = (response as any).note;
+    this.memo!.memo = decodeHTML((response as any).note || '');
 
     await this.updateStores();
   }
@@ -50,7 +51,7 @@ export class MemoManager {
       note: string | null;
       id: number;
     }>('character-memo-get2.php', { target: this.character });
-    this.memo = { id: memo.id, memo: memo.note || '' };
+    this.memo = { id: memo.id, memo: decodeHTML(memo.note || '') };
 
     if (!skipStoreUpdate) {
       await this.updateStores();

--- a/chat/profile_api.ts
+++ b/chat/profile_api.ts
@@ -38,6 +38,7 @@ import {
 import * as Utils from '../site/utils';
 import core from './core';
 import { EventBus } from './preview/event-bus';
+import { decodeHTML } from '../fchat/common';
 
 let horizonDevs: string[] = [];
 let horizonContributors: Map<string, string | undefined> = new Map();
@@ -378,7 +379,9 @@ async function executeCharacterData(
       timezone: data.timezone,
       deleted: false
     },
-    memo: data.memo,
+    memo: data.memo
+      ? { id: data.memo.id, memo: decodeHTML(data.memo.memo) }
+      : data.memo,
     character_list: data.character_list,
     badges: badges,
     settings: data.settings,

--- a/fchat/common.ts
+++ b/fchat/common.ts
@@ -1,7 +1,16 @@
 const ltRegex = /&lt;/gi,
   gtRegex = /&gt;/gi,
+  quotRegex = /&quot;/gi,
+  aposRegex = /&#0*39;/g,
   ampRegex = /&amp;/gi;
 
 export function decodeHTML(this: void | never, str: string): string {
-  return str.replace(ltRegex, '<').replace(gtRegex, '>').replace(ampRegex, '&');
+  // Inverse of PHP htmlspecialchars(ENT_QUOTES) as sent by the f-list API.
+  // &amp; is replaced last so any literally-escaped entity text survives.
+  return str
+    .replace(ltRegex, '<')
+    .replace(gtRegex, '>')
+    .replace(quotRegex, '"')
+    .replace(aposRegex, "'")
+    .replace(ampRegex, '&');
 }


### PR DESCRIPTION
Character memos rendered raw HTML entities instead of the real characters: apostrophes showed as `&#039;`, quotes as `&quot;`.

Memo text comes from the f-list API HTML-escaped via `htmlspecialchars(ENT_QUOTES)`, but the memo path never ran it through `decodeHTML`, which also only handled the chat WebSocket's `&lt; &gt; &amp;` set.

<img width="365" height="221" alt="image" src="https://github.com/user-attachments/assets/dd478cba-fda4-4739-bfcb-a8aa4fed23c0" />


Fixes #806 