### PR TITLE
fix: Tray icon functionality

### DIFF
--- a/electron/browser_windows.ts
+++ b/electron/browser_windows.ts
@@ -453,7 +453,7 @@ export function createMainWindow(
   if (!tray) {
     tray = new electron.Tray(trayIcon);
     tray.setToolTip(l('title'));
-    tray.on('click', _e => tray.popUpContextMenu());
+    tray.on('click', _e => showAllWindows());
 
     tray.setContextMenu(electron.Menu.buildFromTemplate(createTrayMenu()));
     log.debug('init.window.add.tray');
@@ -575,7 +575,7 @@ function createTrayMenu(): electron.MenuItemConstructorOptions[] {
     }
   }));
   return [
-    { label: l('title'), enabled: false },
+    { label: l('title'), click: () => showAllWindows() },
     { type: 'separator' },
     ...tabItems,
     {
@@ -635,11 +635,15 @@ export async function quitAllWindows() {
 }
 
 /**
- * Shows all browser windows.
+ * Restores, shows, and focuses all browser windows.
  * @function
  */
 export function showAllWindows() {
-  for (const w of windows) w.show();
+  for (const w of windows) {
+    if (w.isMinimized()) w.restore();
+    if (!w.isVisible()) w.show();
+    w.focus();
+  }
 }
 /**
  * Toggles the update notice in all browser windows through an IPC message.


### PR DESCRIPTION
Considering this a fix since @FatCatClient mentioned it should've been working properly before.

Fixes the tray icon functionality so that clicking it will actually open the app instead of just showing the context menu. Right clicking will still show a context menu which brings the user to the specified character. Clicking the 'Horizon' tooltip title in the context menu will also open the app in the same way as just left-clicking the icon.