### PR TITLE
Tweaks to the -/+ matcher button on profile viewer

### DIFF
--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -1012,6 +1012,7 @@
   .match-report {
     background-color: var(--scoreReportBg);
     /* width: 100%; */
+    position: relative;
     margin-top: -1.2rem;
     margin-left: -1.2rem;
     margin-right: -1.2rem;
@@ -1026,12 +1027,9 @@
     }
 
     &.minimized {
-      height: 0;
-      overflow: hidden;
+      min-height: 2rem;
       background-color: transparent;
-
-      .vs,
-      .scores {
+      & > *:not(.minimize-btn) {
         display: none;
       }
     }
@@ -1046,7 +1044,8 @@
     .minimize-btn {
       position: absolute;
       display: block;
-      right: 0.5rem;
+      top: 0.5rem;
+      right: 1.2rem;
       padding: 0.4rem;
       padding-top: 0.2rem;
       padding-bottom: 0.2rem;


### PR DESCRIPTION
Some CSS tweaks to the `-` and `+` button that respectively hides and shows the matcher breakdown/feedback display on the profile viewer. Basically just gives it some room so that it isn't clipping into UI elements or any parts of a character's profile. It also actually aligns with the other UI elements now, since it wasn't before.

A side effect of this change is that there will always be a line of blank space at the top of profiles to make room for the button, but personally I think it looks fine.

### Before
<img width="1162" height="183" alt="Horizon_pIxe6oFqa1" src="https://github.com/user-attachments/assets/085b3e5c-d67a-4ee1-a0f8-5ee60af1312e" />

<img width="1163" height="227" alt="Horizon_zI7ysEj4Nb" src="https://github.com/user-attachments/assets/04fd0646-105e-4662-b400-cd472dfab91c" />

### After
<img width="1165" height="205" alt="electron_wL4iJClLCW" src="https://github.com/user-attachments/assets/07daa868-fe3d-4b34-90af-994fa47dca4f" />
<img width="1160" height="255" alt="image" src="https://github.com/user-attachments/assets/65689b0d-1619-4232-b5d8-d9fd1411c45d" />
