### PR TITLE
hotfix: PMs are no longer able to be grouped 

### DIFF
--- a/chat/ChannelGroupSection.vue
+++ b/chat/ChannelGroupSection.vue
@@ -189,7 +189,7 @@
         });
       }
       Sortable.create(<HTMLElement>this.$refs['channelList'], {
-        group: { name: 'channels', pull: true, put: true },
+        group: { name: 'channels', pull: true, put: ['channels'] },
         animation: 50,
         fallbackTolerance: 5,
         onStart: () => startChannelDragging(),

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -632,7 +632,7 @@
         }
       });
       Sortable.create(<HTMLElement>this.$refs['channelConversations'], {
-        group: { name: 'channels', pull: true, put: true },
+        group: { name: 'channels', pull: true, put: ['channels'] },
         sort: true,
         animation: 150,
         fallbackTolerance: 5,


### PR DESCRIPTION
Although I like the idea, the channel grouping system wasn't (currently) built with grouping PMs in mind. Until we've actually added that as a feature, this prevents PMs from being incorrectly grouped with channels.