### PR TITLE
fix: Smart Filtering + ads consistency

### DIFF
--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -1551,6 +1551,9 @@
             );
           }
         });
+
+        // if a sender's filtered status is stale (not in memory), rematch them
+        void core.cache.rematchStaleAdsInConversations();
       },
       getAsNumber(input: any): number | null {
         if (_.isNil(input) || input === '') {

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -1348,7 +1348,7 @@
         this.horizonShowDuplicateStatusNotifications =
           settings.horizonShowDuplicateStatusNotifications;
         this.horizonHighlightUsers = settings.horizonHighlightUsers.join(',');
-        this.risingFilter = settings.risingFilter;
+        this.risingFilter = JSON.parse(JSON.stringify(settings.risingFilter));
 
         this.risingAvailableThemes = fs
           .readdirSync(path.join(__dirname, 'themes'))

--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -243,7 +243,10 @@
         core.characters.setOverride(character.name, 'characterColor', null);
         core.cache.addProfile(character.name, true, true);
       }
-      if (cache === null && showMatch) {
+      if (
+        cache === null &&
+        (showMatch || core.state.settings.risingFilter.showFilterIcon)
+      ) {
         void core.cache.addProfile(character.name);
       }
 

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -200,24 +200,24 @@ export class Settings implements ISettings {
   soundTheme = 'default';
   // Per-theme per-sound volume overrides. Structure: { [themeName]: { [soundName]: volumeNumber(0-1) } }
   soundThemeSoundVolumes: { [theme: string]: { [sound: string]: number } } = {};
+}
 
-  // settings that still require filtering even if the "colorize ads" setting is disabled
-  get requiresProfileMatching(): boolean {
-    const f = this.risingFilter;
-    return (
-      this.risingAdScore ||
-      f.hideAds ||
-      f.hideSearchResults ||
-      f.hideChannelMembers ||
-      f.hidePublicChannelMessages ||
-      f.hidePrivateChannelMessages ||
-      f.hidePrivateMessages ||
-      f.showFilterIcon ||
-      f.penalizeMatches ||
-      f.rewardNonMatches ||
-      f.autoReply
-    );
-  }
+// settings that still require filtering even if the "colorize ads" setting is disabled
+export function requiresProfileMatching(settings: ISettings): boolean {
+  const f = settings.risingFilter;
+  return (
+    settings.risingAdScore ||
+    f.hideAds ||
+    f.hideSearchResults ||
+    f.hideChannelMembers ||
+    f.hidePublicChannelMessages ||
+    f.hidePrivateChannelMessages ||
+    f.hidePrivateMessages ||
+    f.showFilterIcon ||
+    f.penalizeMatches ||
+    f.rewardNonMatches ||
+    f.autoReply
+  );
 }
 
 export class AdSettings implements Conversation.AdSettings {

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -200,6 +200,24 @@ export class Settings implements ISettings {
   soundTheme = 'default';
   // Per-theme per-sound volume overrides. Structure: { [themeName]: { [soundName]: volumeNumber(0-1) } }
   soundThemeSoundVolumes: { [theme: string]: { [sound: string]: number } } = {};
+
+  // settings that still require filtering even if the "colorize ads" setting is disabled
+  get requiresProfileMatching(): boolean {
+    const f = this.risingFilter;
+    return (
+      this.risingAdScore ||
+      f.hideAds ||
+      f.hideSearchResults ||
+      f.hideChannelMembers ||
+      f.hidePublicChannelMessages ||
+      f.hidePrivateChannelMessages ||
+      f.hidePrivateMessages ||
+      f.showFilterIcon ||
+      f.penalizeMatches ||
+      f.rewardNonMatches ||
+      f.autoReply
+    );
+  }
 }
 
 export class AdSettings implements Conversation.AdSettings {

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -348,6 +348,7 @@ export namespace Settings {
     readonly horizonUseColorPicker: boolean;
 
     readonly risingFilter: SmartFilterSettings;
+    readonly requiresProfileMatching: boolean;
 
     readonly risingCharacterTheme: string | undefined;
     readonly soundTheme: string;

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -348,7 +348,6 @@ export namespace Settings {
     readonly horizonUseColorPicker: boolean;
 
     readonly risingFilter: SmartFilterSettings;
-    readonly requiresProfileMatching: boolean;
 
     readonly risingCharacterTheme: string | undefined;
     readonly soundTheme: string;

--- a/chat/message_view.ts
+++ b/chat/message_view.ts
@@ -307,10 +307,11 @@ export default Vue.extend({
       filterClasses: (this as any).getMessageFilterClasses(
         (this as any).message
       ),
-      scoreWatcher: ((this as any).message.type ===
-        Conversation.Message.Type.Ad && (this as any).message.score === 0
-        ? (this as any).$watch('message.score', () =>
-            (this as any).scoreUpdate()
+      scoreWatcher: ((this as any).message.type === Conversation.Message.Type.Ad
+        ? (this as any).$watch(
+            () =>
+              `${(this as any).message.score}|${(this as any).message.filterMatch}`,
+            () => (this as any).scoreUpdate()
           )
         : null) as (() => void) | null
     };
@@ -335,11 +336,6 @@ export default Vue.extend({
         this.filterClasses !== oldFilterClasses
       ) {
         this.$forceUpdate();
-      }
-
-      if (this.scoreWatcher) {
-        this.scoreWatcher(); // stop watching
-        this.scoreWatcher = null;
       }
     },
 

--- a/learn/cache-manager.ts
+++ b/learn/cache-manager.ts
@@ -8,6 +8,7 @@ import {
   SelectConversationEvent
 } from '../chat/preview/event-bus';
 import { Channel, Conversation } from '../chat/interfaces';
+import { requiresProfileMatching } from '../chat/common';
 import { methods } from '../site/character_page/data_store';
 import { Character as ComplexCharacter } from '../site/character_page/interfaces';
 import { AdCache } from './ad-cache';
@@ -116,7 +117,7 @@ export class CacheManager {
     skipCacheCheck: boolean = false,
     channelId?: string
   ): Promise<void> {
-    if (!core.state.settings.requiresProfileMatching) {
+    if (!requiresProfileMatching(core.state.settings)) {
       return;
     }
 
@@ -689,6 +690,29 @@ export class CacheManager {
         });
       }
     );
+  }
+
+  // refreshes the filtered and matching status for any profiles that were no longer in memory
+  // should help cases where your filters changed in a way that'd change their match status
+  async rematchStaleAdsInConversations(): Promise<void> {
+    const ownName = core.characters.ownCharacter.name;
+    const seen = new Set<string>();
+
+    for (const conv of core.conversations.channelConversations) {
+      for (const m of conv.messages) {
+        if (m.type !== Message.Type.Ad || !m.sender) continue;
+
+        const name = m.sender.name;
+        if (name === ownName || seen.has(name)) continue;
+        seen.add(name);
+
+        if (this.profileCache.getSync(name)) continue;
+
+        // loads profile from disk store, then recalculates filter status
+        const p = await this.resolveProfileScore(false, m.sender, conv, m);
+        if (!p) await this.queueForFetching(name, false, conv.channel.id);
+      }
+    }
   }
 
   async stop(): Promise<void> {

--- a/learn/cache-manager.ts
+++ b/learn/cache-manager.ts
@@ -323,9 +323,17 @@ export class CacheManager {
   }
 
   calculateScore(e: ProfileCacheQueueEntry): number {
-    return this.characterProfiler
-      ? this.characterProfiler.calculateInterestScoreForQueueEntry(e)
-      : 0;
+    // adds FIFO ranking so that older calculation attempts are prioritized
+    const ageBonus = (Date.now() - e.added.getTime()) / 10000;
+
+    // if ad colorization is off, just check for filtering by FIFO
+    if (!core.state.settings.risingAdScore || !this.characterProfiler) {
+      return ageBonus;
+    }
+
+    return (
+      this.characterProfiler.calculateInterestScoreForQueueEntry(e) + ageBonus
+    );
   }
 
   async start(settings: GeneralSettings, skipFlush: boolean): Promise<void> {

--- a/learn/cache-manager.ts
+++ b/learn/cache-manager.ts
@@ -116,7 +116,7 @@ export class CacheManager {
     skipCacheCheck: boolean = false,
     channelId?: string
   ): Promise<void> {
-    if (!core.state.settings.risingAdScore) {
+    if (!core.state.settings.requiresProfileMatching) {
       return;
     }
 


### PR DESCRIPTION
Fixes some issues with the smart filter system not working as consistently as it should, causing a bunch of cases where matching characters just don't get filtered at all.

- Having Smart Filters enabled, but the "Colorize ads" setting disabled, wouldn't do anything. Seems like the entire ad scoring system relies on that toggle being enabled, which doesn't feel right imo. Now, specific smart filter settings will still use scoring even if the colorize setting is disabled, allowing filtering and hiding to work as intended, just without the color change.
- The matcher could have a hard time keeping up with a lot of ads coming in at once, resulting in some ads just never getting filtered, so I added some FIFO rules to encourage older ads to be prioritized first.
- Ads will now be shown/hidden retroactively whenever filter settings change. If you change the settings to filter out a gender, previous ads from that filtered gender will now be hidden immediately. 

These changes don't touch the channel member list, so you'll still likely see a lot of characters that _should_ be filtered and/or hidden, but aren't because of the way match checking currently works. I'm not really sure what's a good way of doing that in the first place without fetching the profile of everybody in a channel which sounds like a nightmare, so I didn't touch it.

Although the filters and ad hiding/showing functionality seems to work a lot better in the cases I checked, I'd still love more testing on this from others in case I'm missing something.