### PR TITLE
fix: Tray icon functionality pt. 2

### DIFF
--- a/chat/locales/en_us.json
+++ b/chat/locales/en_us.json
@@ -28,6 +28,7 @@
   "action.paste": "Paste",
   "action.preferences": "Preferences",
   "action.quit": "Quit",
+  "action.showAllWindows": "Show all windows",
   "action.rename": "Rename...",
   "action.reset": "Reset",
   "action.saveAndClose": "Save and Close",

--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -511,7 +511,13 @@
       electron.ipcRenderer.on(
         'show-tab',
         (_e: Electron.IpcRendererEvent, id: number) => {
-          this.show(this.tabMap[id]);
+          const tab = this.tabMap[id];
+          // finds which window has which specific character when opening via context menu
+          if (!tab) return;
+          if (browserWindow.isMinimized()) browserWindow.restore();
+          if (!browserWindow.isVisible()) browserWindow.show();
+          browserWindow.focus();
+          this.show(tab);
         }
       );
       document.addEventListener('click', () =>

--- a/electron/browser_windows.ts
+++ b/electron/browser_windows.ts
@@ -453,7 +453,22 @@ export function createMainWindow(
   if (!tray) {
     tray = new electron.Tray(trayIcon);
     tray.setToolTip(l('title'));
-    tray.on('click', _e => showAllWindows());
+    // single click opens context menu, double click opens all windows
+    let clickTimeout: NodeJS.Timeout | undefined;
+    tray.on('click', _e => {
+      if (clickTimeout) clearTimeout(clickTimeout);
+      clickTimeout = setTimeout(() => {
+        clickTimeout = undefined;
+        tray.popUpContextMenu();
+      }, 200);
+    });
+    tray.on('double-click', _e => {
+      if (clickTimeout) {
+        clearTimeout(clickTimeout);
+        clickTimeout = undefined;
+      }
+      showAllWindows();
+    });
 
     tray.setContextMenu(electron.Menu.buildFromTemplate(createTrayMenu()));
     log.debug('init.window.add.tray');
@@ -565,13 +580,9 @@ function createTrayMenu(): electron.MenuItemConstructorOptions[] {
   ).map(([tabId, webContents]) => ({
     label: tabId,
     click: () => {
-      // Example: focus this tab, or any action you want
-      windows.forEach(winow => {
-        winow.webContents.focus();
-        winow.show();
-        winow.webContents.send('show-tab', webContents.id);
+      windows.forEach(window => {
+        window.webContents.send('show-tab', webContents.id);
       });
-      webContents.focus();
     }
   }));
   return [

--- a/electron/browser_windows.ts
+++ b/electron/browser_windows.ts
@@ -455,20 +455,26 @@ export function createMainWindow(
     tray.setToolTip(l('title'));
     // single click opens context menu, double click opens all windows
     let clickTimeout: NodeJS.Timeout | undefined;
-    tray.on('click', _e => {
-      if (clickTimeout) clearTimeout(clickTimeout);
-      clickTimeout = setTimeout(() => {
-        clickTimeout = undefined;
-        tray.popUpContextMenu();
-      }, 200);
-    });
-    tray.on('double-click', _e => {
+    const showAll = () => {
       if (clickTimeout) {
         clearTimeout(clickTimeout);
         clickTimeout = undefined;
       }
       showAllWindows();
+    };
+    tray.on('click', _e => {
+      // linux-specific double click fix
+      if (clickTimeout) {
+        showAll();
+      } else {
+        clickTimeout = setTimeout(() => {
+          clickTimeout = undefined;
+          tray.popUpContextMenu();
+        }, 200);
+      }
     });
+    // windows/mac
+    tray.on('double-click', _e => showAll());
 
     tray.setContextMenu(electron.Menu.buildFromTemplate(createTrayMenu()));
     log.debug('init.window.add.tray');
@@ -586,7 +592,8 @@ function createTrayMenu(): electron.MenuItemConstructorOptions[] {
     }
   }));
   return [
-    { label: l('title'), click: () => showAllWindows() },
+    { label: l('title'), enabled: false },
+    { label: l('action.showAllWindows'), click: () => showAllWindows() },
     { type: 'separator' },
     ...tabItems,
     {

--- a/electron/browser_windows.ts
+++ b/electron/browser_windows.ts
@@ -462,9 +462,9 @@ export function createMainWindow(
       }
       showAllWindows();
     };
+    // left clicking on tray icons doesn't do anything in linux and attaching a click handler
+    // messes things up even more, so right clicking to see the context menu is required
     tray.on('click', _e => {
-      // linux-specific double click fix, but because left clicking on tray icons doesn't
-      // do anything in linux, right clicking to see the context menu is required
       if (clickTimeout) {
         showAll();
       } else {
@@ -474,7 +474,7 @@ export function createMainWindow(
         }, 200);
       }
     });
-    // windows/mac
+    // works across windows/mac/linux
     tray.on('double-click', _e => showAll());
 
     tray.setContextMenu(electron.Menu.buildFromTemplate(createTrayMenu()));

--- a/electron/browser_windows.ts
+++ b/electron/browser_windows.ts
@@ -463,7 +463,8 @@ export function createMainWindow(
       showAllWindows();
     };
     tray.on('click', _e => {
-      // linux-specific double click fix
+      // linux-specific double click fix, but because left clicking on tray icons doesn't
+      // do anything in linux, right clicking to see the context menu is required
       if (clickTimeout) {
         showAll();
       } else {
@@ -659,7 +660,7 @@ export async function quitAllWindows() {
 export function showAllWindows() {
   for (const w of windows) {
     if (w.isMinimized()) w.restore();
-    if (!w.isVisible()) w.show();
+    w.show();
     w.focus();
   }
 }


### PR DESCRIPTION
Following the changes in #808, @FatCatClient brought up the fact that some people use wholly separate windows for characters as opposed to the standard tabs, which was an oversight on my end. While single clicking to open the app would probably be fine if it was just one window, having the ability to do multiple windows means that single clicking like that isn't going to feel natural.

The changes here tweak the tray icon to now require a _double click_ in order to focus all windows, while left clicking will still show the context menu like before. Additionally, clicking a specific character will now **only** open that character's window as opposed to all of them if they have multiple windows.