### PR TITLE
Quick Switcher visual improvements

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -1294,6 +1294,7 @@
           img {
             height: 40px;
             width: 40px;
+            object-fit: contain;
             margin: 0;
           }
 
@@ -1349,6 +1350,7 @@
       img {
         height: 40px;
         width: 40px;
+        object-fit: contain;
         margin: -1px 5px -1px -1px;
       }
       &:first-child img,
@@ -1410,6 +1412,7 @@
     img {
       width: 32px;
       height: 32px;
+      object-fit: contain;
       flex-shrink: 0;
     }
 

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -338,7 +338,7 @@
           >
             {{ conversations.consoleTab.unreadCount }}
           </span>
-          {{ conversations.consoleTab.name }}
+          <div class="name">{{ conversations.consoleTab.name }}</div>
         </a>
         <a
           v-for="conversation in conversations.privateConversations"
@@ -1364,7 +1364,8 @@
 
   #quick-switcher {
     margin: 0 45px 5px;
-    overflow: auto;
+    overflow-x: auto;
+    overflow-y: hidden;
     display: none;
     align-items: stretch;
     flex-direction: row;
@@ -1380,11 +1381,15 @@
     }
 
     a {
-      width: 40px;
+      width: 54px;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 3px;
+      padding: 5px 4px;
       position: relative;
-      text-align: center;
       line-height: 1;
-      padding: 5px 5px 0;
       overflow: hidden;
       flex-shrink: 0;
       &:first-child {
@@ -1399,28 +1404,36 @@
     }
 
     img {
-      width: 30px;
-      height: 30px;
-      object-fit: contain;
-    }
-
-    .name {
-      overflow: hidden;
-      white-space: nowrap;
+      width: 34px;
+      height: 34px;
+      flex-shrink: 0;
     }
 
     .conversation-icon {
-      font-size: 1.6rem;
-      height: 30px;
+      font-size: 1.7rem;
+      width: 34px;
+      height: 34px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+
+    .name {
+      max-width: 100%;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      font-size: 0.7rem;
     }
 
     .badge {
       position: absolute;
       top: 2px;
       right: 2px;
-      font-size: 0.9em;
-      min-width: 2em;
-      height: 2em;
+      font-size: 0.8em;
+      min-width: 1.6em;
+      height: 1.6em;
       padding: 0 4px;
       border-radius: 9px;
       display: inline-flex;
@@ -1428,7 +1441,7 @@
       justify-content: center;
       line-height: 1;
       z-index: 1;
-      box-shadow: 0 0 0 3px var(--bs-list-group-bg, var(--bs-body-bg));
+      box-shadow: 0 0 0 2px var(--bs-list-group-bg, var(--bs-body-bg));
     }
   }
 

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -1381,7 +1381,7 @@
     }
 
     a {
-      width: 54px;
+      width: 50px;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -1401,18 +1401,22 @@
       &:last-child {
         border-radius: 0 4px 4px 0;
       }
+      &.active {
+        z-index: 1;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
+      }
     }
 
     img {
-      width: 34px;
-      height: 34px;
+      width: 32px;
+      height: 32px;
       flex-shrink: 0;
     }
 
     .conversation-icon {
-      font-size: 1.7rem;
-      width: 34px;
-      height: 34px;
+      font-size: 1.6rem;
+      width: 32px;
+      height: 32px;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -1400,6 +1400,8 @@
 
     img {
       width: 30px;
+      height: 30px;
+      object-fit: contain;
     }
 
     .name {

--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -13,7 +13,12 @@
     <div style="display: flex" v-if="isPrivate(conversation)" class="header">
       <img
         :src="characterImage"
-        style="height: 60px; width: 60px; margin-right: 10px"
+        style="
+          height: 60px;
+          width: 60px;
+          margin-right: 10px;
+          object-fit: contain;
+        "
         v-if="settings.showAvatars"
       />
       <div

--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -41,7 +41,7 @@
                   height: 20px;
                   border-radius: 3px;
                   margin-right: 6px;
-                  object-fit: cover;
+                  object-fit: contain;
                 "
                 loading="lazy"
               />
@@ -94,7 +94,7 @@
                   height: 20px;
                   border-radius: 3px;
                   margin-right: 6px;
-                  object-fit: cover;
+                  object-fit: contain;
                 "
                 @error="$event.target.style.display = 'none'"
                 loading="lazy"
@@ -247,7 +247,12 @@
   import FilterableSelect from '../components/FilterableSelect.vue';
   import Modal from '../components/Modal.vue';
   import { Keys } from '../keys';
-  import { formatTime, getKey, messageToString } from './common';
+  import {
+    characterImage,
+    formatTime,
+    getKey,
+    messageToString
+  } from './common';
   import core from './core';
   import { Conversation, Logs as LogInterface } from './interfaces';
   import l from './localize';
@@ -908,7 +913,7 @@
       },
 
       getAvatarUrl(character: string): string {
-        return `https://static.f-list.net/images/avatar/${encodeURIComponent(character.toLowerCase())}.png`;
+        return characterImage(character);
       }
     }
   });

--- a/scss/_chat.scss
+++ b/scss/_chat.scss
@@ -209,6 +209,9 @@ $bookmark-color: #66cc33 !default;
 #userInfo-avatar {
   object-fit: contain;
 }
+.user-avatar {
+  object-fit: contain;
+}
 .userInfo-buttons-container {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Quick fix for the mobile-style quick switcher that prevents it from growing in size if someone uses a Horizon portrait that's taller than it is wide. I tried with `object-fit:  cover` at first, but didn't really like how it just displayed a square selection in the middle of the Horizon portrait, so I went with `contain` instead so that nothing is cut out. We can _also_ just make it behave the same as non-quick switcher tabs where it just gets stretched to fit the 30x30 size, so let me know what you guys would prefer.
 
Admittedly I think the quick switcher could use some visual improvements in general, but this is a simple solution until then. 
### Before
<img width="420" height="182" alt="image" src="https://github.com/user-attachments/assets/a42bfad4-0dfc-4d91-a755-0d4c95c2a322" />

### After
<img width="321" height="126" alt="image" src="https://github.com/user-attachments/assets/5dc7a1b3-bafc-4179-a223-7f29acc0cb80" />
