### PR TITLE
feat: Push ignored and hidden users to the bottom of the channel member list

### DIFF
--- a/chat/CharacterSearch.vue
+++ b/chat/CharacterSearch.vue
@@ -362,9 +362,7 @@
       core.connection.onMessage('FKS', async data => {
         const results = data.characters
           .map(x => ({ character: core.characters.get(x), profile: null }))
-          .filter(
-            x => !core.isHidden(x.character.name) && !x.character.isIgnored
-          )
+          .filter(x => !x.character.isHidden && !x.character.isIgnored)
           .filter(
             x =>
               this.isSpeciesMatch(x) &&

--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -89,7 +89,9 @@
           v-for="member in filteredMembers"
           :key="member.character.name"
           class="userlist-item"
-          :class="{ dimmed: member.character.isIgnored }"
+          :class="{
+            dimmed: member.character.isIgnored || member.character.isHidden
+          }"
         >
           <user
             :character="member.character"

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -1461,7 +1461,7 @@ export default function (this: any): Interfaces.State {
     const char = core.characters.get(data.character);
     const conv = state.channelMap[data.channel.toLowerCase()];
     if (conv === undefined) return core.channels.leave(data.channel);
-    if (char.isIgnored || core.isHidden(char.name)) return;
+    if (char.isIgnored || char.isHidden) return;
 
     const msg = new Message(
       MessageType.Ad,

--- a/electron/filesystem.ts
+++ b/electron/filesystem.ts
@@ -199,6 +199,7 @@ export function fixLogs(character: string): void {
           isCharacterFriend: false,
           isChatOp: false,
           isIgnored: false,
+          isHidden: false,
           name,
           overrides: {},
           hasStatusTextChanged: () => false

--- a/fchat/channels.ts
+++ b/fchat/channels.ts
@@ -25,6 +25,10 @@ function sortMember(
     const other = array[i];
     if (other.character.isChatOp && !member.character.isChatOp) continue;
     if (member.character.isChatOp && !other.character.isChatOp) break;
+    if (member.character.isIgnored && !other.character.isIgnored) continue;
+    if (other.character.isIgnored && !member.character.isIgnored) break;
+    if (member.character.isHidden && !other.character.isHidden) continue;
+    if (other.character.isHidden && !member.character.isHidden) break;
     if (other.rank > member.rank) continue;
     if (member.rank > other.rank) break;
     if (!member.character.isFriend) {
@@ -33,9 +37,6 @@ function sortMember(
         continue;
       if (member.character.isBookmarked && !other.character.isBookmarked) break;
     } else if (!other.character.isFriend) break;
-    if (!core.isHidden(member.character.name))
-      if (member.key < other.key) break;
-    if (!core.isHidden(other.character.name)) continue;
     if (member.key < other.key) break;
   }
   array.splice(i, 0, member);

--- a/fchat/channels.ts
+++ b/fchat/channels.ts
@@ -33,6 +33,9 @@ function sortMember(
         continue;
       if (member.character.isBookmarked && !other.character.isBookmarked) break;
     } else if (!other.character.isFriend) break;
+    if (!core.isHidden(member.character.name))
+      if (member.key < other.key) break;
+    if (!core.isHidden(other.character.name)) continue;
     if (member.key < other.key) break;
   }
   array.splice(i, 0, member);

--- a/fchat/characters.ts
+++ b/fchat/characters.ts
@@ -16,6 +16,7 @@ class Character implements Interfaces.Character {
   isCharacterFriend = false;
   isChatOp = false;
   isIgnored = false;
+  isHidden = false;
   overrides: CharacterOverrides = {};
   previousStatusText = '';
 
@@ -75,6 +76,7 @@ class State implements Interfaces.State {
       char.isBookmarked = this.bookmarkList.some(b => b.toLowerCase() === key);
       char.isChatOp = this.opList.indexOf(name) !== -1;
       char.isIgnored = this.ignoreList.indexOf(key) !== -1;
+      char.isHidden = core.isHidden(name);
       this.characters[key] = char;
     }
     return char;
@@ -200,6 +202,7 @@ export default function (this: void, connection: Connection): Interfaces.State {
     for (const key in state.characters) {
       const char = state.characters[key]!;
       char.isIgnored = state.ignoreList.indexOf(key) !== -1;
+      char.isHidden = core.isHidden(char.name);
       char.isChatOp = state.opList.indexOf(char.name) !== -1;
     }
   });

--- a/fchat/interfaces.ts
+++ b/fchat/interfaces.ts
@@ -341,6 +341,7 @@ export namespace Character {
     readonly isCharacterFriend: boolean;
     readonly isChatOp: boolean;
     readonly isIgnored: boolean;
+    readonly isHidden: boolean;
     readonly overrides: CharacterOverrides;
     hasStatusTextChanged(): boolean;
   }

--- a/learn/character-profiler.ts
+++ b/learn/character-profiler.ts
@@ -44,6 +44,8 @@ export class CharacterProfiler {
 
     if (c.isBookmarked) return 0.5;
 
+    if (c.isHidden) return -0.5;
+
     if (c.isIgnored) return -1;
 
     return 0;


### PR DESCRIPTION
Issue #150 discusses establishing feature parity between SlimCat's "Not Interested" and Horizon's "Hide Ads" functionality. Part of what is discussed in that issue is the prospect of resorting the full list of members in a channel to place "hidden" users at the bottom - as SlimCat does.

This PR augments the current default sort methodology - the one that places operators and friends at the top of the list - to also place hidden _and ignored_ users at the bottom of the list.

One hypothetical discussed in #150 was dimming hidden users similar to ignored users. To accomplish this, I have refactored the manner in which "isHidden" is consumed to be a property of characters similar to "isIgnored". I have also added a new hidden weight to the character profiler of -0.5.

As written, this will place all hidden users below "normal" users, and all ignored users below hidden users within the channel member list. However, ignoring or hiding a user does not cause them to be resorted within the list. Some other event must cause the list sort order to be updated before the hidden or ignored user is pushed to the bottom. Similarly, unignored or unhidden users will not return to their "normal" sort status until another sort event is triggered.

Some visual behavior within SlimCat already results in "eventual concurrence"; for example, bookmarking or unbookmarking a user causes their sort order to change, but does not update their color until the tab is reselected. I would provide the behavior to rerender the component myself, but I confess I'm not familiar enough with Vue to feel confident in an idiomatic implementation. 

Closes #150 