### PR TITLE
Add/re-implement autoFetchGroupChats

### DIFF
--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -840,6 +840,20 @@
           ></settings-checkbox>
         </div>
       </div>
+
+      <div class="mb-3">
+        <div class="d-flex p-2 justify-content-between align-items-start">
+          <div class="w-50">
+            <label class="control-label" for="risingAutoFetchGroupChatProfiles">
+              {{ l('settings.profile.autoFetchGroupChats') }}
+            </label>
+          </div>
+          <settings-checkbox
+            v-model="risingAutoFetchGroupChatProfiles"
+            :name="'risingAutoFetchGroupChatProfiles'"
+          ></settings-checkbox>
+        </div>
+      </div>
       <h5>{{ l('settings.profile.ignoredList') }}</h5>
       <div class="mb-3 p-2">
         <template v-if="ignored.length">
@@ -1216,6 +1230,7 @@
         risingAdScore: undefined as any as boolean,
         risingLinkPreview: undefined as any as boolean,
         risingAutoCompareKinks: undefined as any as boolean,
+        risingAutoFetchGroupChatProfiles: undefined as any as boolean,
 
         risingAutoExpandCustomKinks: undefined as any as boolean,
         risingCharacterPreview: undefined as any as boolean,
@@ -1311,6 +1326,8 @@
         this.risingAdScore = settings.risingAdScore;
         this.risingLinkPreview = settings.risingLinkPreview;
         this.risingAutoCompareKinks = settings.risingAutoCompareKinks;
+        this.risingAutoFetchGroupChatProfiles =
+          settings.risingAutoFetchGroupChatProfiles;
 
         this.risingAutoExpandCustomKinks = settings.risingAutoExpandCustomKinks;
         this.risingCharacterPreview = settings.risingCharacterPreview;
@@ -1458,6 +1475,8 @@
           risingAdScore: this.risingAdScore,
           risingLinkPreview: this.risingLinkPreview,
           risingAutoCompareKinks: this.risingAutoCompareKinks,
+          risingAutoFetchGroupChatProfiles:
+            this.risingAutoFetchGroupChatProfiles,
 
           risingAutoExpandCustomKinks: this.risingAutoExpandCustomKinks,
           risingCharacterPreview: this.risingCharacterPreview,

--- a/chat/SettingsView.vue
+++ b/chat/SettingsView.vue
@@ -844,13 +844,16 @@
       <div class="mb-3">
         <div class="d-flex p-2 justify-content-between align-items-start">
           <div class="w-50">
-            <label class="control-label" for="risingAutoFetchGroupChatProfiles">
+            <label
+              class="control-label"
+              for="horizonAutoFetchGroupChatProfiles"
+            >
               {{ l('settings.profile.autoFetchGroupChats') }}
             </label>
           </div>
           <settings-checkbox
-            v-model="risingAutoFetchGroupChatProfiles"
-            :name="'risingAutoFetchGroupChatProfiles'"
+            v-model="horizonAutoFetchGroupChatProfiles"
+            :name="'horizonAutoFetchGroupChatProfiles'"
           ></settings-checkbox>
         </div>
       </div>
@@ -1230,7 +1233,7 @@
         risingAdScore: undefined as any as boolean,
         risingLinkPreview: undefined as any as boolean,
         risingAutoCompareKinks: undefined as any as boolean,
-        risingAutoFetchGroupChatProfiles: undefined as any as boolean,
+        horizonAutoFetchGroupChatProfiles: undefined as any as boolean,
 
         risingAutoExpandCustomKinks: undefined as any as boolean,
         risingCharacterPreview: undefined as any as boolean,
@@ -1326,8 +1329,8 @@
         this.risingAdScore = settings.risingAdScore;
         this.risingLinkPreview = settings.risingLinkPreview;
         this.risingAutoCompareKinks = settings.risingAutoCompareKinks;
-        this.risingAutoFetchGroupChatProfiles =
-          settings.risingAutoFetchGroupChatProfiles;
+        this.horizonAutoFetchGroupChatProfiles =
+          settings.horizonAutoFetchGroupChatProfiles;
 
         this.risingAutoExpandCustomKinks = settings.risingAutoExpandCustomKinks;
         this.risingCharacterPreview = settings.risingCharacterPreview;
@@ -1475,8 +1478,8 @@
           risingAdScore: this.risingAdScore,
           risingLinkPreview: this.risingLinkPreview,
           risingAutoCompareKinks: this.risingAutoCompareKinks,
-          risingAutoFetchGroupChatProfiles:
-            this.risingAutoFetchGroupChatProfiles,
+          horizonAutoFetchGroupChatProfiles:
+            this.horizonAutoFetchGroupChatProfiles,
 
           risingAutoExpandCustomKinks: this.risingAutoExpandCustomKinks,
           risingCharacterPreview: this.risingCharacterPreview,

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -112,6 +112,7 @@ export class Settings implements ISettings {
   risingAdScore = true;
   risingLinkPreview = true;
   risingAutoCompareKinks = true;
+  risingAutoFetchGroupChatProfiles = false;
 
   risingAutoExpandCustomKinks = true;
   risingCharacterPreview = true;

--- a/chat/common.ts
+++ b/chat/common.ts
@@ -112,8 +112,6 @@ export class Settings implements ISettings {
   risingAdScore = true;
   risingLinkPreview = true;
   risingAutoCompareKinks = true;
-  risingAutoFetchGroupChatProfiles = false;
-
   risingAutoExpandCustomKinks = true;
   risingCharacterPreview = true;
   risingComparisonInUserMenu = true;
@@ -124,6 +122,8 @@ export class Settings implements ISettings {
   risingShowPortraitNearInput = true;
   risingShowPortraitInMessage = true;
   risingShowHighQualityPortraits = true;
+
+  horizonAutoFetchGroupChatProfiles = false;
   horizonMessagePortraitHighQuality: boolean = true;
   horizonShowCustomCharacterColors = true;
   horizonShowDeveloperBadges = true;

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -313,6 +313,7 @@ export namespace Settings {
     readonly risingAdScore: boolean;
     readonly risingLinkPreview: boolean;
     readonly risingAutoCompareKinks: boolean;
+    readonly risingAutoFetchGroupChatProfiles: boolean;
 
     readonly risingAutoExpandCustomKinks: boolean;
     readonly risingCharacterPreview: boolean;

--- a/chat/interfaces.ts
+++ b/chat/interfaces.ts
@@ -313,8 +313,6 @@ export namespace Settings {
     readonly risingAdScore: boolean;
     readonly risingLinkPreview: boolean;
     readonly risingAutoCompareKinks: boolean;
-    readonly risingAutoFetchGroupChatProfiles: boolean;
-
     readonly risingAutoExpandCustomKinks: boolean;
     readonly risingCharacterPreview: boolean;
     readonly risingComparisonInUserMenu: boolean;
@@ -325,6 +323,8 @@ export namespace Settings {
     readonly risingShowPortraitNearInput: boolean;
     readonly risingShowPortraitInMessage: boolean;
     readonly risingShowHighQualityPortraits: boolean;
+
+    readonly horizonAutoFetchGroupChatProfiles: boolean;
     readonly horizonMessagePortraitHighQuality: boolean;
     readonly horizonShowCustomCharacterColors: boolean;
     readonly horizonShowDeveloperBadges: boolean;

--- a/chat/locales/de.json
+++ b/chat/locales/de.json
@@ -904,6 +904,7 @@
   "settings.preview.link": "Link-/Bildvorschau durch Hovern über dem Link anzeigen",
   "settings.profile": "Profil",
   "settings.profile.autoCompareKinks": "Kinks beim Ansehen von Charakterprofilen automatisch vergleichen",
+  "settings.profile.autoFetchGroupChats": "...",
   "settings.profile.autoExpandCustoms": "Custom Kinks automatisch ausklappen",
   "settings.profile.ignoredList": "Ignorierte Charaktere",
   "settings.profile.ignoredList.empty": "Du ignorierst derzeit keine Nutzer.",

--- a/chat/locales/en_us.json
+++ b/chat/locales/en_us.json
@@ -911,6 +911,7 @@
   "settings.preview.link": "Show a link/ image preview when the mouse hovers over a link",
   "settings.profile": "Profile",
   "settings.profile.autoCompareKinks": "Automatically compare kinks when viewing a character profile",
+  "settings.profile.autoFetchGroupChats": "Auto fetch profiles in group chats",
   "settings.profile.autoExpandCustoms": "Automatically expand custom kinks",
   "settings.profile.ignoredList": "Ignored characters",
   "settings.profile.ignoredList.empty": "You aren't currently ignoring any users.",

--- a/chat/locales/en_uwu.json
+++ b/chat/locales/en_uwu.json
@@ -797,6 +797,7 @@
   "settings.preview.link": "Show a wink/ image pweview when the mouse hovews ovew a wink",
   "settings.profile": "Pwofile",
   "settings.profile.autoCompareKinks": "Automatically compawe kinks when viewing a chawactew pwofile",
+  "settings.profile.autoFetchGroupChats": "...",
   "settings.profile.autoExpandCustoms": "Ky-kyaa, your automatically expanded custom is so big...",
   "settings.profile.ignoredList": "Ignowed chawactews",
   "settings.profile.ignoredList.empty": "U awen't cuwwentwy ignowing any usews.",

--- a/chat/locales/es.json
+++ b/chat/locales/es.json
@@ -905,6 +905,7 @@
   "settings.preview.link": "Mostrar una vista previa de enlace/imagen al pasar el cursor sobre un enlace",
   "settings.profile": "Perfil",
   "settings.profile.autoCompareKinks": "Comparar kinks automáticamente al ver el perfil de un personaje",
+  "settings.profile.autoFetchGroupChats": "...",
   "settings.profile.autoExpandCustoms": "Expandir automáticamente los kinks personalizados",
   "settings.profile.ignoredList": "Personajes ignorados",
   "settings.profile.ignoredList.empty": "No estás ignorando a ningún personaje actualmente.",

--- a/chat/locales/fr.json
+++ b/chat/locales/fr.json
@@ -905,6 +905,7 @@
   "settings.preview.link": "Montrer un aperçu de lien/image lorsque la souris passe sur un lien",
   "settings.profile": "Profil",
   "settings.profile.autoCompareKinks": "Comparer les kinks automatiquement quand vous regardez un profil",
+  "settings.profile.autoFetchGroupChats": "...",
   "settings.profile.autoExpandCustoms": "Étendre automatiquement les kinks personnalisés",
   "settings.profile.ignoredList": "Personnages ignorés",
   "settings.profile.ignoredList.empty": "Vous n'ignorez aucun utilisateur actuellement.",

--- a/chat/locales/hu.json
+++ b/chat/locales/hu.json
@@ -905,6 +905,7 @@
   "settings.preview.link": "Előnézetet mutat hivatkozásról / képről, ha a kurzor hivatkozás fölé mozdul",
   "settings.profile": "Profil",
   "settings.profile.autoCompareKinks": "Automatikusan hasonlítsa össze a kinkeket karakterprofil megtekintése közben",
+  "settings.profile.autoFetchGroupChats": "...",
   "settings.profile.autoExpandCustoms": "Személyre szabott kinkek automatikus kitárása",
   "settings.profile.ignoredList": "Mellőzött karakterek",
   "settings.profile.ignoredList.empty": "Jelenleg nem mellőzöl egy felhasználót sem.",

--- a/chat/locales/it.json
+++ b/chat/locales/it.json
@@ -904,6 +904,7 @@
   "settings.preview.link": "Mostra l'anteprima di un link o immagine quando passi il mouse su un link",
   "settings.profile": "Profilo",
   "settings.profile.autoCompareKinks": "Confronta automaticamente i kink quando visualizzi il profilo di un personaggio",
+  "settings.profile.autoFetchGroupChats": "...",
   "settings.profile.autoExpandCustoms": "Espandi automaticamente i kink personalizzati",
   "settings.profile.ignoredList": "Personaggi ignorati",
   "settings.profile.ignoredList.empty": "Non stai ignorando nessun utente al momento.",

--- a/learn/cache-manager.ts
+++ b/learn/cache-manager.ts
@@ -461,7 +461,9 @@ export class CacheManager {
       message: message.text
     });
 
-    // await this.addProfile(message.sender.name);
+    if (core.state.settings.risingAutoFetchGroupChatProfiles) {
+      await this.addProfile(message.sender.name);
+    }
   }
 
   async onChannelAd(data: ChannelAdEvent): Promise<void> {

--- a/learn/cache-manager.ts
+++ b/learn/cache-manager.ts
@@ -461,7 +461,7 @@ export class CacheManager {
       message: message.text
     });
 
-    if (core.state.settings.risingAutoFetchGroupChatProfiles) {
+    if (core.state.settings.horizonAutoFetchGroupChatProfiles) {
       await this.addProfile(message.sender.name);
     }
   }


### PR DESCRIPTION
Inspired by my sis Leanne!

This functionality looked like it existed before/was commented out. So I totally understand if there are good and real reasons to not include such a feature. autoFetchGroupChats is disabled by default here, like with received ads in channels, it will add a profile to the cache queue automatically when you have this option turned on.