### PR TITLE
fix: prune unjoinable channels from groups after startup join

### DIFF
--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -32,6 +32,15 @@ import isChannel = Interfaces.isChannel;
  */
 const CONVERSATION_CACHE_UPDATE_FREQ_IN_MS = 1000;
 
+/**
+ * @constant
+ * How long the startup auto-join must be quiet (no new channel join arriving)
+ * before pinned channels that never joined are treated as removed and pruned.
+ * The timer resets on every successful join, so a slow connection that delivers
+ * joins gradually keeps deferring the cleanup until the joins actually stop.
+ */
+const PINNED_CLEANUP_SETTLE_IN_MS = 10000;
+
 function createMessage(
   this: any,
   type: MessageType,
@@ -782,6 +791,8 @@ class State implements Interfaces.State {
   settings!: { [key: string]: Interfaces.Settings };
   modes!: { [key: string]: Channel.Mode | undefined };
   channelGroups: Interfaces.ChannelGroup[] = [];
+  pinnedCleanupTimer?: ReturnType<typeof setTimeout>;
+  pinnedCleanupArmed = false;
 
   get channelGroupAssignments(): { [channelId: string]: string } {
     const map: { [id: string]: string } = emptyMap();
@@ -845,6 +856,47 @@ class State implements Interfaces.State {
       group.channels = this.channelConversations
         .filter(c => assignments[c.channel.id] === group.id)
         .map(c => c.channel.id);
+  }
+
+  /**
+   * Arms (or, if already armed, restarts) the settle timer that prunes pinned
+   * channels which failed to join. Called once after the startup auto-join and
+   * again on every successful join, so the prune only runs once joins have
+   * stopped arriving — never while a slow connection is still delivering them.
+   */
+  schedulePinnedCleanup(): void {
+    if (!this.pinnedCleanupArmed) return;
+    clearTimeout(this.pinnedCleanupTimer);
+    this.pinnedCleanupTimer = setTimeout(() => {
+      this.pinnedCleanupArmed = false;
+      this.pruneRemovedChannels();
+    }, PINNED_CLEANUP_SETTLE_IN_MS);
+  }
+
+  /**
+   * Removes pinned/grouped channels that could not be joined on startup. FServ
+   * does not report failed joins, so once the startup join burst has settled,
+   * any grouped channel that never produced a live conversation is treated as
+   * removed server-side. Mirrors the pre-grouping behavior where the pinned
+   * list was re-derived from live conversations, and additionally tells the
+   * user which channels were dropped.
+   */
+  pruneRemovedChannels(): void {
+    if (!core.connection.isOpen) return;
+    const removed = Object.keys(this.channelGroupAssignments).filter(
+      id => this.channelMap[id] === undefined
+    );
+    if (removed.length === 0) return;
+    this.syncGroupChannels();
+    void this.saveChannelGroups();
+    void this.savePinned();
+    const names = removed.map(id => {
+      const recent = this.recentChannels.find(c => c.channel === id);
+      return recent !== undefined ? recent.name : id;
+    });
+    void this.consoleTab.addMessage(
+      new EventMessage(l('channel.group.removedUnjoinable', names.join(', ')))
+    );
   }
 
   async savePinned(): Promise<void> {
@@ -1250,6 +1302,8 @@ export default function (this: any): Interfaces.State {
   });
   const connection = core.connection;
   connection.onEvent('connecting', async isReconnect => {
+    state.pinnedCleanupArmed = false;
+    clearTimeout(state.pinnedCleanupTimer);
     state.channelConversations = [];
     state.channelMap = emptyMap();
     if (!isReconnect) {
@@ -1268,6 +1322,11 @@ export default function (this: any): Interfaces.State {
     for (const item of state.pinned.private)
       state.getPrivate(core.characters.get(item));
     queuedJoin(state.pinned.channels.slice());
+    // Arm the settle timer; it restarts on every join (see the join handler
+    // below) and only fires once joins have stopped arriving, then prunes any
+    // pinned channels that never joined (removed server-side).
+    state.pinnedCleanupArmed = true;
+    state.schedulePinnedCleanup();
   });
   core.channels.onEvent(async (type, channel, member) => {
     if (type === 'join')
@@ -1276,6 +1335,9 @@ export default function (this: any): Interfaces.State {
         state.channelMap[channel.id] = conv;
         state.channelConversations.push(conv);
         void state.savePinned();
+        // A pinned channel joined: defer the dead-channel cleanup until the
+        // join burst goes quiet, so slow connections aren't pruned mid-join.
+        state.schedulePinnedCleanup();
         const index = state.recentChannels.findIndex(
           c => c.channel === channel.id
         );

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -890,12 +890,15 @@ class State implements Interfaces.State {
     this.syncGroupChannels();
     void this.saveChannelGroups();
     void this.savePinned();
-    const names = removed.map(id => {
+    const links = removed.map(id => {
       const recent = this.recentChannels.find(c => c.channel === id);
-      return recent !== undefined ? recent.name : id;
+      const name = recent !== undefined ? recent.name : id;
+      return id.startsWith('adh-')
+        ? `[session=${name}]${id}[/session]`
+        : `[channel]${name}[/channel]`;
     });
     void this.consoleTab.addMessage(
-      new EventMessage(l('channel.group.removedUnjoinable', names.join(', ')))
+      new EventMessage(l('channel.group.removedUnjoinable', links.join(', ')))
     );
   }
 

--- a/chat/locales/en_us.json
+++ b/chat/locales/en_us.json
@@ -142,7 +142,7 @@
   "channel.group.newGroup.counter": "New Group ({0})",
   "channel.group.noticePinned": "[b]Your pinned channels have gotten an upgrade, and now you can categorize them in groups.\n\nClick the + button in the channel list to create a new group. You can also drag your channels around, or right click channels and groups if you have any. Go ahead and give it a try!\n\nCheck out [url=https://horizn.moe/docs/channel-groups.html]our website[/url] for more info.[/b]",
   "channel.group.pinned": "Pinned",
-  "channel.group.removedUnjoinable": "[b]The following channels could no longer be joined (they were likely deleted) and have been removed from your groups:[/b] {0}",
+  "channel.group.removedUnjoinable": "[b]The following channels could no longer be joined, as they were likely deleted, and have been removed from your groups:[/b] {0}",
   "channel.menu.addToNewGroup": "Add to new group",
   "channel.menu.copyCode": "Copy channel code",
   "channel.menu.markRead": "Mark as read",

--- a/chat/locales/en_us.json
+++ b/chat/locales/en_us.json
@@ -142,6 +142,7 @@
   "channel.group.newGroup.counter": "New Group ({0})",
   "channel.group.noticePinned": "[b]Your pinned channels have gotten an upgrade, and now you can categorize them in groups.\n\nClick the + button in the channel list to create a new group. You can also drag your channels around, or right click channels and groups if you have any. Go ahead and give it a try!\n\nCheck out [url=https://horizn.moe/docs/channel-groups.html]our website[/url] for more info.[/b]",
   "channel.group.pinned": "Pinned",
+  "channel.group.removedUnjoinable": "[b]The following channels could no longer be joined (they were likely deleted) and have been removed from your groups:[/b] {0}",
   "channel.menu.addToNewGroup": "Add to new group",
   "channel.menu.copyCode": "Copy channel code",
   "channel.menu.markRead": "Mark as read",


### PR DESCRIPTION
## What

Reworks how pinned/grouped channels that can no longer be joined (e.g. deleted server-side) are cleaned up. Horizon currently re-attempts to join removed channels on **every** startup. FServ never reports which joins failed, and the incidental cleanup that used to mask this disappeared when channel grouping landed. This reimplements that cleanup as a deliberate step.

## Background

The old auto-removal was never an intentional feature; it was a side-effect of how `savePinned()` worked. It rebuilt the pinned list from the channels that actually had live conversations:

```ts
this.pinned.channels = this.channelConversations.filter(x => x.isPinned).map(x => x.channel.id);
```

A removed channel never opens a conversation, so it quietly dropped out the next time the list was saved. It worked, but only by accident. Channel grouping changed `savePinned()` to derive the list from persisted group membership instead, which removed that side-effect, and with it the cleanup. Dead channels now sit in a group forever and keep getting re-joined.

## How it works

Rather than leaning on a side-effect again, the cleanup is now explicit. A short "settle" timer is armed after the startup auto-join and **restarted on every successful join**. When joins stop arriving, any grouped channel that never produced a live conversation is treated as removed: it's pruned from its group (via the existing `syncGroupChannels` + `saveChannelGroups` + `savePinned` path) and the user is shown a console notice listing the dropped channels.

## Slow connections

The timer measures *silence between joins*, not time since login, so it can't fire while channels are still trickling in. On a slow link the cleanup just happens later, never mid-join. It also disarms on disconnect/reconnect and no-ops if the socket is closed, so a flaky connection cancels the cleanup rather than misfiring. The window is a single tunable constant (`PINNED_CLEANUP_SETTLE_IN_MS`, 10s).

## Testing

- Pinned/grouped a mix of valid channels and one removed server-side; confirmed the valid ones join, and ~10s after the last join the removed one is pruned from its group with a console notice, and is no longer attempted on restart.
Fixes #864 