### PR TITLE
fix: Opening logs dialog focuses filter field properly again

### DIFF
--- a/chat/Logs.vue
+++ b/chat/Logs.vue
@@ -207,7 +207,6 @@
         :placeholder="l('filter')"
         v-show="messages"
         type="text"
-        :disabled="selectedConversation === undefined || messages.length === 0"
       />
       <span v-if="searching" class="input-group-text">
         <span class="fas fa-spinner fa-spin"></span>
@@ -484,7 +483,8 @@
       },
 
       onFilterChanged(): void {
-        if (this.selectedConversation === undefined) return;
+        if (this.selectedConversation === undefined || this.messages.length < 1)
+          return;
         if (this.filterDebounce !== undefined)
           clearTimeout(this.filterDebounce);
         this.filterDebounce = setTimeout(() => {


### PR DESCRIPTION
Fixes #834

I kind of do not care about doing this the cumbersome (but ideal) way where I solve the timeline and get the focus method to call after loading logs. It doesn't really matter that much that you can type stuff in the filter before opening a conversation, might as well consider it letting you pre-type the filter.