### PR TITLE
fix: improve colorblind mode contrast and highlight visibility

### DIFF
--- a/scss/themes/_colorblind.scss
+++ b/scss/themes/_colorblind.scss
@@ -20,15 +20,36 @@ $scoreStandoutWeakMismatchBorderColor: #888;
 $scoreStandoutWeakMismatchBgColor: rgba(170, 170, 170, 0);
 $scoreStandoutMismatchBorderColor: #ab0000;
 
-$genders: (
-  'shemale': #e2445f,
-  'herm': #d40759,
-  'none': $gray-500,
-  'female': #66ff74,
-  'male': #6699ff,
-  'male-herm': #007fff,
-  'transgender': #ee8822,
-  'cunt-boy': #63ee22
+// Palettes tuned for red/green colour vision deficiency: under protanopia and
+// deuteranopia only the blue-yellow axis and lightness survive, so hues drift
+// from the normal-mode palette to keep every pair distinguishable. Validated
+// with a Machado (2009) CVD simulation; any edit must keep a pairwise CIELAB
+// deltaE of at least 17 (dark) / 13 (light) under normal, protan and deutan
+// vision, and stay readable against the theme background.
+$cvd-light-theme: color.lightness($body-bg) > 50%;
+
+$genders: if(
+  $cvd-light-theme,
+  (
+    'shemale': #8b2500,
+    'herm': #6f3ac7,
+    'none': $gray-500,
+    'female': #8e0e56,
+    'male': #0072b2,
+    'male-herm': #123a75,
+    'transgender': #9a6d00,
+    'cunt-boy': #1f6e46
+  ),
+  (
+    'shemale': #f0e442,
+    'herm': #d55e00,
+    'none': $gray-500,
+    'female': #efa8ce,
+    'male': #56b4e9,
+    'male-herm': #2e86d1,
+    'transgender': #e69f00,
+    'cunt-boy': #0ac48a
+  )
 );
 
 @each $gender, $color in $genders {
@@ -42,9 +63,37 @@ $genders: (
   }
 
   .message-event .gender-#{$gender},
-  .message-event .gender-icon-#{gender} {
+  .message-event .gender-icon-#{$gender} {
     --gender-color: #{color.scale($color, $lightness: 5%)};
   }
+}
+
+// Highlights normally derive from the theme's green $success, the hue R/G
+// colour vision deficiency obscures; restyle with a blue tint and amber
+// border so the cue does not rely on the red-green axis.
+$cvd-highlight-tint: if($cvd-light-theme, #0072b2, #2e86d1);
+$cvd-highlight-accent: if($cvd-light-theme, #9a6d00, #e69f00);
+
+.message-highlight {
+  background-color: rgba($cvd-highlight-tint, 0.25);
+
+  .message-time {
+    background-color: rgba($cvd-highlight-tint, 0.4);
+    color: $black;
+  }
+}
+
+.layout-modern .message-highlight {
+  border-left-color: $cvd-highlight-accent;
+}
+
+.layout-modern .message.message-modern.message-highlight {
+  border-left-color: $cvd-highlight-accent;
+  background-color: rgba($cvd-highlight-tint, 0.25);
+}
+
+.last-read {
+  border-bottom-color: $cvd-highlight-tint !important;
 }
 
 .userlist-item.dimmed {


### PR DESCRIPTION
Fixes #538

## Problem

The colorblind mode palette (shared by all 14 chat themes) contained several pairs that are indistinguishable under red/green color vision deficiency: simulating protanopia/deuteranopia (Machado 2009 matrices) gives a CIELAB deltaE of 9 for shemale vs herm, 13 for transgender vs cunt-boy, and 16-20 for male vs male-herm (below ~20 is hard to tell apart as text color). On the four light themes the palette was also nearly unreadable (female had 1.1:1 contrast against the background). Message highlights derive from each theme's green `$success` and were not touched by colorblind mode at all, which is exactly the hue R/G-colorblind users struggle with.

## Changes

All inside the `.colorblindMode` scope in `scss/themes/_colorblind.scss`; normal mode is untouched.

- Replace the single `$genders` palette with two Okabe-Ito-derived, CVD-tuned palettes, selected per theme via `color.lightness($body-bg)`:
  - Dark themes: every pair keeps deltaE >= 17 under normal, protanopia and deuteranopia vision, with >= 4.0:1 contrast against the background. Male stays a light blue and cunt-boy stays green, as suggested in the issue.
  - Light themes (light, snowed-in, peached, no-exceptions): deltaE >= 15 and >= 3.9:1 contrast for every color.
- Restyle message highlights in colorblind mode with a blue background tint and an amber left border (classic and modern layouts), plus a blue last-read divider, so the highlight cue no longer relies on the red-green axis.
- Fix a pre-existing typo (`#{gender}` missing the `$`) that emitted a broken `.gender-icon-gender` selector for message events.