### PR TITLE
fix: key message drafts by conversation key instead of display name

### DIFF
--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -1262,6 +1262,9 @@ async function initConversationCache(this: Conversation): Promise<void> {
   // Restore message draft if it exists (e.g. accidentally closing the tab). Be sure the cache is reset for a new character if needed.
   await core.cache.conversationDraftCache.resetCacheIfNeeded();
 
+  // Only an open conversation knows both the display name pre-key drafts were stored under and its unique key.
+  core.cache.migrateConversationDraft(this.name, this.key);
+
   const draft = core.cache.getConversationDraft(this.key);
   this.enteredText = draft;
 

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -137,7 +137,7 @@ abstract class Conversation implements Interfaces.Conversation {
   clearText(): void {
     setImmediate(() => {
       this.enteredText = '';
-      core.cache.conversationDraftCache.deregister(this.name);
+      core.cache.conversationDraftCache.deregister(this.key);
     });
   }
 
@@ -475,7 +475,7 @@ class PrivateConversation
       this.safeAddMessage(message);
 
       await this.logMessage(message, false);
-      core.cache.deregisterConversationDraft(this.name);
+      core.cache.deregisterConversationDraft(this.key);
       this.markRead();
     });
   }
@@ -1262,7 +1262,7 @@ async function initConversationCache(this: Conversation): Promise<void> {
   // Restore message draft if it exists (e.g. accidentally closing the tab). Be sure the cache is reset for a new character if needed.
   await core.cache.conversationDraftCache.resetCacheIfNeeded();
 
-  const draft = core.cache.getConversationDraft(this.name);
+  const draft = core.cache.getConversationDraft(this.key);
   this.enteredText = draft;
 
   if (!this.cacheActive) {
@@ -1282,8 +1282,8 @@ async function initConversationCache(this: Conversation): Promise<void> {
       }
 
       this.enteredText
-        ? core.cache.registerConversationDraft(this.name, this.enteredText)
-        : core.cache.deregisterConversationDraft(this.name);
+        ? core.cache.registerConversationDraft(this.key, this.enteredText)
+        : core.cache.deregisterConversationDraft(this.key);
     }, CONVERSATION_CACHE_UPDATE_FREQ_IN_MS);
   }
 }

--- a/learn/cache-manager.ts
+++ b/learn/cache-manager.ts
@@ -560,42 +560,42 @@ export class CacheManager {
   /**
    * Register the given draft in the draft cache.
    * @function
-   * @param {string} channel
-   * The intended recipient of the message, either a character name or a channel name.
+   * @param {string} key
+   * The unique key of the conversation the draft belongs to, e.g. `#adh-...` for a channel or a lowercased character name for a PM.
    * @param {string} message
    * The draft text as it currently exists in the input textbox.
    * @internal
    */
-  public registerConversationDraft(channel: string, message: string): void {
+  public registerConversationDraft(key: string, message: string): void {
     this.conversationDraftCache.register({
-      channel,
+      key,
       message
     });
   }
 
   /**
-   * Removes any existing draft from the cache for a given channel.
+   * Removes any existing draft from the cache for a given conversation.
    * @function
-   * @param {string} channel
-   * The intended recipient of the message, either a character name or a channel name.
+   * @param {string} key
+   * The unique key of the conversation the draft belongs to, e.g. `#adh-...` for a channel or a lowercased character name for a PM.
    * @internal
    */
-  public deregisterConversationDraft(channel: string): void {
-    this.conversationDraftCache.deregister(channel);
+  public deregisterConversationDraft(key: string): void {
+    this.conversationDraftCache.deregister(key);
   }
 
   /**
-   * Retrieves the draft message for a given channel.
+   * Retrieves the draft message for a given conversation.
    * @function
-   * @param {string} channel
-   * The intended recipient of the message, either a character name or a channel name.
+   * @param {string} key
+   * The unique key of the conversation the draft belongs to, e.g. `#adh-...` for a channel or a lowercased character name for a PM.
    * @returns {string}
-   * The text of the saved draft in the requested channel.
+   * The text of the saved draft in the requested conversation.
    * @internal
    */
-  public getConversationDraft(channel: string): string {
+  public getConversationDraft(key: string): string {
     const draft: ConversationDraftRecord | null =
-      this.conversationDraftCache.get(channel);
+      this.conversationDraftCache.get(key);
     return draft?.message || '';
   }
 

--- a/learn/cache-manager.ts
+++ b/learn/cache-manager.ts
@@ -600,6 +600,19 @@ export class CacheManager {
   }
 
   /**
+   * Migrate any pre-key draft stored under a conversation's display name to the conversation's unique key.
+   * @function
+   * @param {string} name
+   * The display name of the conversation, which pre-key drafts were stored under.
+   * @param {string} key
+   * The unique key of the conversation the draft belongs to, e.g. `#adh-...` for a channel or a lowercased character name for a PM.
+   * @internal
+   */
+  public migrateConversationDraft(name: string, key: string): void {
+    this.conversationDraftCache.migrateLegacyDraft(name, key);
+  }
+
+  /**
    * Match a character, score their message (if provided), and return their scored Character.
    * @param skipStore Don't store profile in cache; just retrieve scoring info
    * @param char Character who posted the message

--- a/learn/conversation-draft-cache.ts
+++ b/learn/conversation-draft-cache.ts
@@ -20,6 +20,15 @@ export interface ConversationCachedMessage {
   message: string;
 }
 
+/**
+ * A draft record in the pre-key on-disk format, where drafts were stored under the conversation's display name.
+ * Kept around solely so these records can be migrated to conversation keys as their conversations are opened.
+ */
+export interface LegacyDraftRecord {
+  channel: string;
+  message: string;
+}
+
 export class ConversationDraftRecord {
   key: string;
   message: string;
@@ -40,32 +49,46 @@ export class ConversationDraftRecord {
 }
 
 /**
- * Rebuild the cache from raw draft data parsed off disk, keeping only records that match the current `{key, message}` shape.
- * Records in the pre-key format (`{channel, message}`, stored under the conversation's display name) are dropped: their
- * name-based keys share the namespace PM lookups use, which is exactly the collision behind issue #409, and old-format files
- * can reappear at any time through backup import, so this has to filter on every load rather than migrate once. Kept records
- * are re-keyed from the record itself, making the file robust against hand-edited or mismatched map keys.
+ * Rebuild the cache from raw draft data parsed off disk. Records matching the current `{key, message}` shape go into the
+ * lookup cache, re-keyed from the record itself so the file is robust against hand-edited or mismatched map keys. Records
+ * in the pre-key format (`{channel, message}`, stored under the conversation's display name) are quarantined into a
+ * separate legacy map instead: their name-based keys share the namespace PM lookups use, which is exactly the collision
+ * behind issue #409, so they must never be looked up directly. They stay quarantined until a conversation whose display
+ * name matches claims them via migrateLegacyDraft. Old-format files can reappear at any time through backup import, so
+ * this splits on every load rather than migrating once. Anything matching neither shape is dropped.
  * @function
  * @param {any} drafts
  * The parsed contents of the draft file, or null if it was missing or unreadable.
  * @internal
  */
-function sanitizeDrafts(drafts: any): CacheCollection<ConversationDraftRecord> {
-  const map = emptyMap<ConversationDraftRecord>();
-  if (typeof drafts !== 'object' || drafts === null) return map;
+function sanitizeDrafts(drafts: any): {
+  current: CacheCollection<ConversationDraftRecord>;
+  legacy: CacheCollection<LegacyDraftRecord>;
+} {
+  const current = emptyMap<ConversationDraftRecord>();
+  const legacy = emptyMap<LegacyDraftRecord>();
+  if (typeof drafts !== 'object' || drafts === null) return { current, legacy };
 
   for (const record of Object.values<any>(drafts)) {
-    if (typeof record?.key === 'string' && typeof record?.message === 'string')
-      map[Cache.nameKey(record.key)] = new ConversationDraftRecord(
+    if (typeof record?.message !== 'string') continue;
+
+    if (typeof record.key === 'string')
+      current[Cache.nameKey(record.key)] = new ConversationDraftRecord(
         record.key,
         record.message
       );
+    else if (typeof record.channel === 'string' && record.message !== '')
+      legacy[Cache.nameKey(record.channel)] = {
+        channel: record.channel,
+        message: record.message
+      };
   }
 
-  return map;
+  return { current, legacy };
 }
 
 export class ConversationDraftCache extends Cache<ConversationDraftRecord> {
+  private legacyDrafts: CacheCollection<LegacyDraftRecord> = emptyMap();
   private lastCacheSave = Date.now();
   private cacheAlreadyLoaded = false;
   private useCache = true;
@@ -121,7 +144,9 @@ export class ConversationDraftCache extends Cache<ConversationDraftRecord> {
     if (this.diskSaveTimerInSeconds < MIN_CACHE_DISK_SAVE_IN_SECONDS)
       this.diskSaveTimerInSeconds = MIN_CACHE_DISK_SAVE_IN_SECONDS;
 
-    this.cache = sanitizeDrafts(getDrafts());
+    const { current, legacy } = sanitizeDrafts(getDrafts());
+    this.cache = current;
+    this.legacyDrafts = legacy;
 
     this.cacheAlreadyLoaded = true;
     this.currentlyCachedCharacter = core.connection.character;
@@ -150,6 +175,7 @@ export class ConversationDraftCache extends Cache<ConversationDraftRecord> {
       // In the future, we could consider keeping all characters in-memory as people jump around in one tab and just reference the "current"
       // cache. A cacheCache, if you will. For now, the on-disk cache should be sufficient, but it's an option for later.
       this.cache = emptyMap();
+      this.legacyDrafts = emptyMap();
       this.cacheAlreadyLoaded = false;
     }
 
@@ -169,6 +195,33 @@ export class ConversationDraftCache extends Cache<ConversationDraftRecord> {
     const k = Cache.nameKey(draft.key);
 
     this.cache[k] = new ConversationDraftRecord(draft.key, draft.message);
+  }
+
+  /**
+   * Claim any quarantined pre-key draft stored under a conversation's display name and re-key it under the conversation's
+   * unique key. Old records only say which name they were stored under, not whether that name was a PM or a channel, so
+   * this can only run once a conversation is open and knows both. If a draft already exists under the new key it wins and
+   * the legacy record is simply discarded. No forced disk save: the periodic save persists the claim, and if the app dies
+   * first the migration just re-runs on the next load with the same result.
+   * @function
+   * @param {string} name
+   * The display name of the conversation, which pre-key drafts were stored under.
+   * @param {string} key
+   * The unique key of the conversation the draft belongs to.
+   * @internal
+   */
+  migrateLegacyDraft(name: string, key: string): void {
+    if (!this.useCache) return;
+
+    const legacyKey = Cache.nameKey(name);
+    const legacy = this.legacyDrafts[legacyKey];
+    if (!legacy) return;
+
+    delete this.legacyDrafts[legacyKey];
+
+    const k = Cache.nameKey(key);
+    if (!(k in this.cache))
+      this.cache[k] = new ConversationDraftRecord(key, legacy.message);
   }
 
   /**
@@ -208,6 +261,8 @@ export class ConversationDraftCache extends Cache<ConversationDraftRecord> {
       return;
 
     this.lastCacheSave = now;
-    saveDrafts(this.cache);
+    // Unclaimed legacy drafts are written back in their original shape so they survive until their conversation is
+    // opened (and stay usable on a downgrade). Current records win map-key collisions, which only happen for PMs.
+    saveDrafts({ ...this.legacyDrafts, ...this.cache });
   }
 }

--- a/learn/conversation-draft-cache.ts
+++ b/learn/conversation-draft-cache.ts
@@ -3,8 +3,8 @@
  * Maintains an in-memory cache of draft messages, and occasionally saves them to disk.
  */
 
-import { Cache } from './cache';
-import { emptyMap, toMap } from '../fchat/common';
+import { Cache, CacheCollection } from './cache';
+import { emptyMap } from '../fchat/common';
 import { getDrafts, saveDrafts } from '../electron/filesystem';
 import core from '../chat/core';
 
@@ -37,6 +37,32 @@ export class ConversationDraftRecord {
     this.key = key;
     this.message = message || '';
   }
+}
+
+/**
+ * Rebuild the cache from raw draft data parsed off disk, keeping only records that match the current `{key, message}` shape.
+ * Records in the pre-key format (`{channel, message}`, stored under the conversation's display name) are dropped: their
+ * name-based keys share the namespace PM lookups use, which is exactly the collision behind issue #409, and old-format files
+ * can reappear at any time through backup import, so this has to filter on every load rather than migrate once. Kept records
+ * are re-keyed from the record itself, making the file robust against hand-edited or mismatched map keys.
+ * @function
+ * @param {any} drafts
+ * The parsed contents of the draft file, or null if it was missing or unreadable.
+ * @internal
+ */
+function sanitizeDrafts(drafts: any): CacheCollection<ConversationDraftRecord> {
+  const map = emptyMap<ConversationDraftRecord>();
+  if (typeof drafts !== 'object' || drafts === null) return map;
+
+  for (const record of Object.values<any>(drafts)) {
+    if (typeof record?.key === 'string' && typeof record?.message === 'string')
+      map[Cache.nameKey(record.key)] = new ConversationDraftRecord(
+        record.key,
+        record.message
+      );
+  }
+
+  return map;
 }
 
 export class ConversationDraftCache extends Cache<ConversationDraftRecord> {
@@ -95,8 +121,7 @@ export class ConversationDraftCache extends Cache<ConversationDraftRecord> {
     if (this.diskSaveTimerInSeconds < MIN_CACHE_DISK_SAVE_IN_SECONDS)
       this.diskSaveTimerInSeconds = MIN_CACHE_DISK_SAVE_IN_SECONDS;
 
-    const drafts = getDrafts();
-    this.cache = toMap(drafts);
+    this.cache = sanitizeDrafts(getDrafts());
 
     this.cacheAlreadyLoaded = true;
     this.currentlyCachedCharacter = core.connection.character;

--- a/learn/conversation-draft-cache.ts
+++ b/learn/conversation-draft-cache.ts
@@ -16,25 +16,25 @@ import core from '../chat/core';
 const MIN_CACHE_DISK_SAVE_IN_SECONDS = 5;
 
 export interface ConversationCachedMessage {
-  channel: string;
+  key: string;
   message: string;
 }
 
 export class ConversationDraftRecord {
-  channel: string;
+  key: string;
   message: string;
 
   /**
    * Fundamental layout of an F-Chat message. Sender is currently implied by core.connection.character.
    * @function
-   * @param {string} channel
-   * The intended recipient of the message, either a character name or a channel name.
+   * @param {string} key
+   * The unique key of the conversation the draft belongs to, e.g. `#adh-...` for a channel or a lowercased character name for a PM.
    * @param {string} message
    * The draft text as it currently exists in the input textbox.
    * @internal
    */
-  constructor(channel: string, message?: string) {
-    this.channel = channel;
+  constructor(key: string, message?: string) {
+    this.key = key;
     this.message = message || '';
   }
 }
@@ -135,28 +135,28 @@ export class ConversationDraftCache extends Cache<ConversationDraftRecord> {
    * Add or overwrite an entry in the cache.
    * @function
    * @param {ConversationCachedMessage} draft
-   * The message and intended recipient name (whether a private message, channel, or the console itself).
+   * The message and the key of the conversation it belongs to (whether a private message, channel, or the console itself).
    * @internal
    */
   register(draft: ConversationCachedMessage): void {
     if (!this.useCache) return;
 
-    const k = Cache.nameKey(draft.channel);
+    const k = Cache.nameKey(draft.key);
 
-    this.cache[k] = new ConversationDraftRecord(draft.channel, draft.message);
+    this.cache[k] = new ConversationDraftRecord(draft.key, draft.message);
   }
 
   /**
    * Remove an entry from the cache, then immediately remove from disk to prevent it from re-appearing.
    * @function
-   * @param {string} channel
-   * The character name or channel name that the draft was intended for.
+   * @param {string} key
+   * The unique key of the conversation that the draft was intended for.
    * @internal
    */
-  deregister(channel: string): void {
+  deregister(key: string): void {
     if (!this.useCache) return;
 
-    const k = Cache.nameKey(channel);
+    const k = Cache.nameKey(key);
     if (!(k in this.cache)) return;
 
     delete this.cache[k];


### PR DESCRIPTION
Drafts were cached under the lowercased conversation display name, so a user-made channel and a PM (or another channel) sharing that name would cross drafts. Conversations already carry a collision-safe key (#<channel.id> for channels, lowercased character name for PMs, _ for the console) that logs and per-conversation settings use, so drafts now use it too. Existing name-keyed channel drafts on disk are intentionally not migrated.

Fixes #409