### PR TITLE
rebuild log indexes and preserve conversation names

### DIFF
--- a/electron/filesystem.ts
+++ b/electron/filesystem.ts
@@ -12,6 +12,7 @@ import {
 } from '../chat/interfaces';
 import l from '../chat/localize';
 import { GeneralSettings } from './common';
+import { isFilesystemArtifact } from './services/log-backup';
 
 declare module '../chat/interfaces' {
   interface State {
@@ -165,6 +166,7 @@ export function fixLogs(character: string): void {
   const files = fs.readdirSync(dir);
   const buffer = Buffer.allocUnsafe(50100);
   for (const file of files) {
+    if (isFilesystemArtifact(file)) continue;
     const full = path.join(dir, file);
     if (file.substr(-4) === '.idx') {
       if (!fs.existsSync(full.slice(0, -4))) fs.unlinkSync(full);
@@ -234,7 +236,7 @@ function loadIndex(name: string): Index {
   const dir = getLogDir(name);
   const files = fs.readdirSync(dir);
   for (const file of files)
-    if (file.substr(-4) === '.idx')
+    if (file.substr(-4) === '.idx' && !isFilesystemArtifact(file))
       try {
         const content = fs.readFileSync(path.join(dir, file));
         let offset = content.readUInt8(0) + 1;

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -238,10 +238,11 @@ EXAMPLES:
         dryRun,
         zip,
         touchedCharacters: importResult.touchedCharacters.length,
-        generalImported: importResult.generalImported
+        generalImported: importResult.generalImported,
+        filesErrored: importResult.filesErrored
       })
     );
-    app.exit(0);
+    app.exit(importResult.filesErrored > 0 ? 1 : 0);
     return true;
   }
   return false;

--- a/electron/services/exporter/backup-export-cli.ts
+++ b/electron/services/exporter/backup-export-cli.ts
@@ -37,36 +37,6 @@ export interface ExportCliOptions {
   onProgress?: (fraction: number) => void;
 }
 
-export function binaryLogToJson(
-  buffer: Buffer
-): { time: number; type: number; sender: string; text: string }[] {
-  const messages: {
-    time: number;
-    type: number;
-    sender: string;
-    text: string;
-  }[] = [];
-  let offset = 0;
-  while (offset + 10 <= buffer.length) {
-    const time = buffer.readUInt32LE(offset);
-    const type = buffer.readUInt8(offset + 4);
-    const senderLength = buffer.readUInt8(offset + 5);
-    if (offset + 6 + senderLength + 2 > buffer.length) break;
-    const sender = buffer.toString(
-      'utf8',
-      offset + 6,
-      offset + 6 + senderLength
-    );
-    const textLength = buffer.readUInt16LE(offset + 6 + senderLength);
-    const textStart = offset + 6 + senderLength + 2;
-    if (textStart + textLength + 2 > buffer.length) break;
-    const text = buffer.toString('utf8', textStart, textStart + textLength);
-    messages.push({ time, type, sender, text });
-    offset = textStart + textLength + 2;
-  }
-  return messages;
-}
-
 function getCharacters(dataDir: string, filter?: string[]): string[] {
   const list: string[] = [];
   try {

--- a/electron/services/exporter/backup-export.ts
+++ b/electron/services/exporter/backup-export.ts
@@ -25,6 +25,7 @@ import type { ExporterVm } from '../exporter-vm';
 import {
   binaryLogToJson,
   conversationNamesFile,
+  isFilesystemArtifact,
   readLogIndexName
 } from '../log-backup';
 
@@ -187,6 +188,7 @@ function buildExportEntries(
         for (const abs of files) {
           if (abs.endsWith('.idx')) continue;
           const rel = path.relative(logsDir, abs).replace(/\\/g, '/');
+          if (rel.split('/').some(isFilesystemArtifact)) continue;
           const zip = path.posix.join(
             'characters',
             character,

--- a/electron/services/exporter/backup-export.ts
+++ b/electron/services/exporter/backup-export.ts
@@ -22,7 +22,11 @@ import {
 } from './manifest';
 import type { ExportManifest, SettingsSelection } from './manifest';
 import type { ExporterVm } from '../exporter-vm';
-import { binaryLogToJson } from './backup-export-cli';
+import {
+  binaryLogToJson,
+  conversationNamesFile,
+  readLogIndexName
+} from '../log-backup';
 
 /**
  * Directory holding the general (app-wide) settings file. This is fixed at
@@ -140,7 +144,22 @@ function listFilesRecursive(rootDir: string): string[] {
   return results;
 }
 
-type ExportEntry = { abs: string; zip: string; isLog?: boolean };
+type ExportEntry = {
+  zip: string;
+  abs?: string;
+  isLog?: boolean;
+  data?: string;
+};
+
+// ^ The .idx name is the only copy of ad-hoc names and capitalization; it
+//   must travel with the export (#886).
+function readLogName(logPath: string): string | undefined {
+  try {
+    return readLogIndexName(fs.readFileSync(`${logPath}.idx`));
+  } catch {
+    return undefined;
+  }
+}
 
 function buildExportEntries(
   dataDir: string,
@@ -164,6 +183,7 @@ function buildExportEntries(
       const logsDir = path.join(characterDir, 'logs');
       if (fs.existsSync(logsDir)) {
         const files = listFilesRecursive(logsDir);
+        const names: Record<string, string> = {};
         for (const abs of files) {
           if (abs.endsWith('.idx')) continue;
           const rel = path.relative(logsDir, abs).replace(/\\/g, '/');
@@ -173,8 +193,19 @@ function buildExportEntries(
             'logs',
             rel + '.json'
           );
+          const name = readLogName(abs);
+          if (name !== undefined) names[rel] = name;
           entries.push({ abs, zip, isLog: true });
         }
+        if (Object.keys(names).length > 0)
+          entries.push({
+            zip: path.posix.join(
+              'characters',
+              character,
+              conversationNamesFile
+            ),
+            data: JSON.stringify(names)
+          });
       }
     }
 
@@ -346,18 +377,25 @@ export async function runExport(vm: ExporterVm): Promise<void> {
     const failedFiles: string[] = [];
     for (const e of entries) {
       try {
-        if (fs.existsSync(e.abs)) {
+        if (e.data !== undefined) {
+          archive.append(e.data, { name: e.zip });
+          count++;
+        } else if (e.abs !== undefined && fs.existsSync(e.abs)) {
           if (e.isLog) {
             const buf = fs.readFileSync(e.abs);
-            const json = binaryLogToJson(buf);
-            archive.append(JSON.stringify(json), { name: e.zip });
+            // ! Bare arrays only: released clients write other shapes verbatim.
+            archive.append(JSON.stringify(binaryLogToJson(buf)), {
+              name: e.zip
+            });
           } else {
             archive.file(e.abs, { name: e.zip });
           }
           count++;
-          if (count % 10 === 0) {
-            await yieldToUi(vm);
-          }
+        } else {
+          continue;
+        }
+        if (count % 10 === 0) {
+          await yieldToUi(vm);
         }
       } catch (err) {
         failedFiles.push(e.zip);

--- a/electron/services/importer/backup-import-cli.ts
+++ b/electron/services/importer/backup-import-cli.ts
@@ -2,6 +2,16 @@ import fs from 'fs';
 import path from 'path';
 import AdmZip from 'adm-zip';
 import { shouldIncludeSettingsFile } from '../exporter/manifest';
+import {
+  buildLogImportContext,
+  ensureLogIndex,
+  jsonLogToBinary,
+  parseJsonLog,
+  recoverLogName,
+  removeStaleJsonLogArtifact,
+  writeLogWithIndex
+} from '../log-backup';
+import type { LogImportContext } from '../log-backup';
 
 /**
  * Configuration options for CLI-based import operations.
@@ -163,18 +173,22 @@ function shouldSkipExistingFile(
   return true;
 }
 
+interface CliImportStats {
+  logsCopied: number;
+  logsSkipped: number;
+  settingsCopied: number;
+  settingsSkipped: number;
+  filesErrored: number;
+  touched: Set<string>;
+}
+
 function processZipEntry(
   entry: AdmZip.IZipEntry,
   dataDir: string,
   allowed: Set<string>,
   opts: ImportCliOptions,
-  stats: {
-    logsCopied: number;
-    logsSkipped: number;
-    settingsCopied: number;
-    settingsSkipped: number;
-    touched: Set<string>;
-  }
+  context: LogImportContext,
+  stats: CliImportStats
 ): void {
   if (entry.isDirectory) return;
 
@@ -184,23 +198,76 @@ function processZipEntry(
 
   if (!decision.should || !decision.character) return;
 
-  const relative = normalized.substring('characters/'.length);
-  const destination = getSafeDestination(dataDir, relative);
-  if (!destination) return;
+  let relative = normalized.substring('characters/'.length);
 
-  fs.mkdirSync(path.dirname(destination), { recursive: true });
+  try {
+    let data: Buffer | undefined;
+    let converted = false;
+    let logName: string | undefined;
+    let recoveredName: string | undefined;
 
-  if (shouldSkipExistingFile(destination, decision, opts)) {
-    if (decision.isLog) stats.logsSkipped++;
-    else stats.settingsSkipped++;
-    return;
+    // JSON logs re-serialize to binary; anything else .json copies through.
+    if (decision.isLog && normalized.endsWith('.json')) {
+      const logKey = segments.slice(3).join('/').slice(0, -5);
+      if (logKey && !logKey.endsWith('/')) {
+        // ^ A binary twin in the ZIP is authoritative; the .json is stale.
+        if (context.binaryLogs.has(`${decision.character}/${logKey}`)) {
+          stats.logsSkipped++;
+          return;
+        }
+        data = entry.getData();
+        const parsedLog = parseJsonLog(data);
+        if (parsedLog) {
+          data = jsonLogToBinary(parsedLog.messages);
+          relative = relative.slice(0, -5);
+          converted = true;
+          logName =
+            context.names.get(decision.character)?.get(logKey) ??
+            parsedLog.name;
+          if (logName === undefined)
+            recoveredName = recoverLogName(
+              logKey,
+              decision.character,
+              context,
+              parsedLog.messages
+            );
+        }
+      }
+    }
+
+    const destination = getSafeDestination(dataDir, relative);
+    if (!destination) return;
+
+    fs.mkdirSync(path.dirname(destination), { recursive: true });
+
+    if (shouldSkipExistingFile(destination, decision, opts)) {
+      if (decision.isLog) {
+        stats.logsSkipped++;
+        // Heal pre-2.4 imports that never wrote indexes (#886).
+        if (converted) {
+          const healed = ensureLogIndex(destination, logName ?? recoveredName);
+          if (removeStaleJsonLogArtifact(destination) || healed)
+            stats.touched.add(decision.character);
+        }
+      } else stats.settingsSkipped++;
+      return;
+    }
+
+    if (data === undefined) data = entry.getData();
+    if (converted) {
+      writeLogWithIndex(destination, data, logName, recoveredName);
+      removeStaleJsonLogArtifact(destination);
+    } else fs.writeFileSync(destination, data);
+    stats.touched.add(decision.character);
+    if (decision.isLog) stats.logsCopied++;
+    else stats.settingsCopied++;
+  } catch (err) {
+    stats.filesErrored++;
+    console.warn(
+      `Failed to import ${normalized}:`,
+      err instanceof Error ? err.message : err
+    );
   }
-
-  const data = entry.getData();
-  fs.writeFileSync(destination, data);
-  stats.touched.add(decision.character);
-  if (decision.isLog) stats.logsCopied++;
-  else stats.settingsCopied++;
 }
 
 function printDryRunGeneralSettings(
@@ -268,7 +335,11 @@ function handleDryRun(
   zip: AdmZip,
   dataDir: string,
   wantedChars: string[]
-): { touchedCharacters: string[]; generalImported: boolean } {
+): {
+  touchedCharacters: string[];
+  generalImported: boolean;
+  filesErrored: number;
+} {
   console.log('=== DRY RUN MODE - No files will be modified ===');
   console.log(`Source ZIP: ${opts.zip}`);
   console.log(`Target directory: ${dataDir}`);
@@ -286,7 +357,8 @@ function handleDryRun(
 
   return {
     touchedCharacters: wantedChars,
-    generalImported: opts.includeGeneral && hasGeneral
+    generalImported: opts.includeGeneral && hasGeneral,
+    filesErrored: 0
   };
 }
 
@@ -295,31 +367,38 @@ function performActualImport(
   dataDir: string,
   wantedChars: string[],
   opts: ImportCliOptions
-): { touchedCharacters: string[]; generalImported: boolean } {
+): {
+  touchedCharacters: string[];
+  generalImported: boolean;
+  filesErrored: number;
+} {
   fs.mkdirSync(dataDir, { recursive: true });
 
   const generalImported = importGeneralSettingsFromZip(zip, dataDir, opts);
 
   const allowed = new Set<string>(wantedChars);
 
-  const stats = {
+  const stats: CliImportStats = {
     logsCopied: 0,
     logsSkipped: 0,
     settingsCopied: 0,
     settingsSkipped: 0,
+    filesErrored: 0,
     touched: new Set<string>()
   };
 
   const entries = zip.getEntries();
+  const context = buildLogImportContext(entries);
   for (const entry of entries) {
-    processZipEntry(entry, dataDir, allowed, opts, stats);
+    processZipEntry(entry, dataDir, allowed, opts, context, stats);
   }
 
   return {
     touchedCharacters: Array.from(stats.touched.values()).sort((a, b) =>
       a.localeCompare(b)
     ),
-    generalImported
+    generalImported,
+    filesErrored: stats.filesErrored
   };
 }
 
@@ -328,12 +407,13 @@ function performActualImport(
  * Supports both dry-run mode (preview only) and actual import with selective data import and conflict handling.
  *
  * @param opts - Configuration options specifying what to import and how to handle conflicts
- * @returns A promise that resolves with the list of imported characters and whether general settings were imported
+ * @returns A promise that resolves with the list of imported characters, whether general settings were imported, and how many files failed
  * @throws {Error} If the data directory is not provided or the ZIP file cannot be opened
  */
 export async function runImportCli(opts: ImportCliOptions): Promise<{
   touchedCharacters: string[];
   generalImported: boolean;
+  filesErrored: number;
 }> {
   const dataDir = opts.dataDir;
   if (!dataDir) throw new Error('No data dir provided');

--- a/electron/services/importer/backup-import-cli.ts
+++ b/electron/services/importer/backup-import-cli.ts
@@ -5,6 +5,7 @@ import { shouldIncludeSettingsFile } from '../exporter/manifest';
 import {
   buildLogImportContext,
   ensureLogIndex,
+  isFilesystemArtifact,
   jsonLogToBinary,
   parseJsonLog,
   recoverLogName,
@@ -197,6 +198,7 @@ function processZipEntry(
   const decision = classifyEntry(normalized, segments, allowed, opts);
 
   if (!decision.should || !decision.character) return;
+  if (decision.isLog && segments.slice(3).some(isFilesystemArtifact)) return;
 
   let relative = normalized.substring('characters/'.length);
 

--- a/electron/services/importer/backup-import.ts
+++ b/electron/services/importer/backup-import.ts
@@ -22,6 +22,16 @@ import {
 } from '../exporter/manifest';
 import type { ExportManifest, SettingsSelection } from '../exporter/manifest';
 import type { ExporterVm } from '../exporter-vm';
+import {
+  buildLogImportContext,
+  ensureLogIndex,
+  jsonLogToBinary,
+  parseJsonLog,
+  recoverLogName,
+  removeStaleJsonLogArtifact,
+  writeLogWithIndex
+} from '../log-backup';
+import type { LogImportContext } from '../log-backup';
 /** Default log directory in the renderer process (avoids instantiating GeneralSettings). */
 const defaultLogDirectory = path.join(remote.app.getPath('userData'), 'data');
 /**
@@ -430,29 +440,6 @@ function isEffectivelyEmptyDraftsFile(p: string): boolean {
   }
 }
 
-export function jsonLogToBinary(
-  json: { time: number; type: number; sender: string; text: string }[]
-): Buffer {
-  const chunks: Buffer[] = [];
-  for (const msg of json) {
-    const sender = msg.sender || '';
-    const senderLength = Buffer.byteLength(sender);
-    const textLength = Buffer.byteLength(msg.text);
-    const buf = Buffer.allocUnsafe(senderLength + textLength + 10);
-    buf.writeUInt32LE(msg.time, 0);
-    buf.writeUInt8(msg.type, 4);
-    buf.writeUInt8(senderLength, 5);
-    buf.write(sender, 6);
-    let offset = 6 + senderLength;
-    buf.writeUInt16LE(textLength, offset);
-    buf.write(msg.text, offset + 2);
-    offset += 2 + textLength;
-    buf.writeUInt16LE(offset, offset);
-    chunks.push(buf);
-  }
-  return Buffer.concat(chunks);
-}
-
 interface ImportStats {
   logsCopied: number;
   logsSkipped: number;
@@ -593,6 +580,7 @@ function importCharacterFile(
   dataDir: string,
   selectedCharacters: Set<string>,
   characterInfo: Map<string, BackupCharacterInfo>,
+  context: LogImportContext,
   stats: ImportStats
 ): void {
   if (!entry || !entry.entryName) return;
@@ -614,42 +602,73 @@ function importCharacterFile(
   if (!decision.shouldImport) return;
 
   let relative = normalized.substring('characters/'.length);
-  // Strip .json suffix for JSON log files so they're written as binary
-  if (decision.isLog && relative.endsWith('.json')) {
-    relative = relative.slice(0, -5);
-  }
-  const destination = getSafeDestination(dataDir, relative);
-  if (!destination) return;
 
   try {
+    let fileData: Buffer | undefined;
+    let converted = false;
+    let logName: string | undefined;
+    let recoveredName: string | undefined;
+
+    // JSON logs re-serialize to binary; anything else .json copies through.
+    if (decision.isLog && normalized.endsWith('.json')) {
+      const logKey = segments.slice(3).join('/').slice(0, -5);
+      if (logKey && !logKey.endsWith('/')) {
+        // ^ A binary twin in the ZIP is authoritative; the .json is stale.
+        if (context.binaryLogs.has(`${characterName}/${logKey}`)) {
+          stats.logsSkipped++;
+          return;
+        }
+        fileData = entry.getData();
+        const parsedLog = parseJsonLog(fileData);
+        if (parsedLog) {
+          try {
+            fileData = jsonLogToBinary(parsedLog.messages);
+          } catch (err) {
+            stats.filesErrored++;
+            log.warn('import.file.json-convert-error', normalized, err);
+            return;
+          }
+          relative = relative.slice(0, -5);
+          converted = true;
+          logName =
+            context.names.get(characterName)?.get(logKey) ?? parsedLog.name;
+          if (logName === undefined)
+            recoveredName = recoverLogName(
+              logKey,
+              characterName,
+              context,
+              parsedLog.messages
+            );
+        }
+      }
+    }
+
+    const destination = getSafeDestination(dataDir, relative);
+    if (!destination) return;
+
     fs.mkdirSync(path.dirname(destination), { recursive: true });
 
     const exists = fs.existsSync(destination);
     if (
       shouldSkipExistingFile(destination, exists, vm.importOverwrite, decision)
     ) {
-      if (decision.isLog) stats.logsSkipped++;
-      else stats.settingsSkipped++;
+      if (decision.isLog) {
+        stats.logsSkipped++;
+        // Heal pre-2.4 imports that never wrote indexes.
+        if (converted) {
+          const healed = ensureLogIndex(destination, logName ?? recoveredName);
+          if (removeStaleJsonLogArtifact(destination) || healed)
+            stats.charactersTouched.add(characterName);
+        }
+      } else stats.settingsSkipped++;
       return;
     }
 
-    let fileData: Buffer = entry.getData();
-
-    // JSON log from export: re-serialize to binary
-    if (decision.isLog && normalized.endsWith('.json')) {
-      try {
-        const parsed = JSON.parse(fileData.toString('utf8'));
-        if (Array.isArray(parsed)) {
-          fileData = jsonLogToBinary(parsed);
-        }
-      } catch (err) {
-        stats.filesErrored++;
-        log.warn('import.file.json-convert-error', normalized, err);
-        return;
-      }
-    }
-
-    fs.writeFileSync(destination, fileData);
+    if (fileData === undefined) fileData = entry.getData();
+    if (converted) {
+      writeLogWithIndex(destination, fileData, logName, recoveredName);
+      removeStaleJsonLogArtifact(destination);
+    } else fs.writeFileSync(destination, fileData);
     stats.charactersTouched.add(characterName);
 
     if (decision.isLog) stats.logsCopied++;
@@ -669,6 +688,7 @@ function importCharacterData(
   stats: ImportStats
 ): void {
   const entries = zip.getEntries();
+  const context = buildLogImportContext(entries);
   for (const entry of entries) {
     if (!entry || entry.isDirectory) continue;
     importCharacterFile(
@@ -677,6 +697,7 @@ function importCharacterData(
       dataDir,
       selectedCharacters,
       characterInfo,
+      context,
       stats
     );
   }

--- a/electron/services/importer/backup-import.ts
+++ b/electron/services/importer/backup-import.ts
@@ -25,6 +25,7 @@ import type { ExporterVm } from '../exporter-vm';
 import {
   buildLogImportContext,
   ensureLogIndex,
+  isFilesystemArtifact,
   jsonLogToBinary,
   parseJsonLog,
   recoverLogName,
@@ -600,6 +601,7 @@ function importCharacterFile(
   const category = segments[2];
   const decision = shouldImportEntry(vm, category, segments, info);
   if (!decision.shouldImport) return;
+  if (decision.isLog && segments.slice(3).some(isFilesystemArtifact)) return;
 
   let relative = normalized.substring('characters/'.length);
 

--- a/electron/services/index.ts
+++ b/electron/services/index.ts
@@ -20,6 +20,7 @@ export * from './importer/vanilla-import-ui';
 export * from './exporter/backup-export';
 export type { ExportManifest } from './exporter/manifest';
 export * from './importer/backup-import';
+export * from './log-backup';
 export * as SlimcatImporter from './importer/importer';
 
 export type {

--- a/electron/services/log-backup.ts
+++ b/electron/services/log-backup.ts
@@ -298,6 +298,7 @@ export function recoverLogName(
   messages: JsonLogMessage[]
 ): string | undefined {
   const key = logKey.split('/').pop()!;
+  if (key === '_') return 'Console';
   if (key.startsWith('#'))
     return context.channelNames.get(character)?.get(key.toLowerCase());
   const match = messages.find(

--- a/electron/services/log-backup.ts
+++ b/electron/services/log-backup.ts
@@ -1,0 +1,380 @@
+/**
+ * @license MPL-2.0
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * @copyright 2024-2026 Sylvia Roselie & Respective Horizon Contributors
+ * @version 1.0
+ * @see {@link https://github.com/Fchat-Horizon/Horizon|GitHub repo}
+ *
+ * Conversion helpers between the binary chat log format, the JSON log format
+ * used inside export ZIPs, and the `.idx` sidecar files the log viewer needs.
+ *
+ * ^ Binary record layout must stay in sync with serializeMessage in
+ *   electron/filesystem.ts:
+ *   u32LE time (seconds) | u8 type | u8 senderLength | sender |
+ *   u16LE textLength | text | u16LE recordLength - 2
+ * ^ Index layout must stay in sync with checkIndex/loadIndex in
+ *   electron/filesystem.ts:
+ *   u8 nameLength | name | 7-byte entries of u16LE day + u40LE offset
+ *
+ * ! NEVER IMPORT ELECTRON HERE! This must ALSO WORK FOR THE CLI!!!!!!!!!!!!!!!!!!!!1
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+/** One message inside a JSON log file. Times are seconds since epoch. */
+export interface JsonLogMessage {
+  time: number;
+  type: number;
+  sender: string;
+  text: string;
+}
+
+/**
+ * One JSON log file inside an export ZIP, normalized.
+ *
+ * ! Exports must stay bare arrays: released clients strip the .json suffix
+ *   and write any other shape verbatim to the binary log path. The optional
+ *   name only tolerates hand-made { name, messages } files on import.
+ */
+export interface JsonLog {
+  name?: string;
+  messages: JsonLogMessage[];
+}
+
+/**
+ * Per-character sidecar mapping log file names to display names. Old
+ * importers ignore it, so new exports stay safe on old clients.
+ */
+export const conversationNamesFile = 'conversation-names.json';
+
+const dayMs = 86400000;
+
+function localDay(timeSeconds: number): number {
+  const date = new Date(timeSeconds * 1000);
+  return Math.floor(date.getTime() / dayMs - date.getTimezoneOffset() / 1440);
+}
+
+/**
+ * Validates trailing length markers the way fixLogs does and stops at the
+ * first malformed record, so non-log files yield no messages instead of
+ * garbage.
+ */
+export function binaryLogToJson(buffer: Buffer): JsonLogMessage[] {
+  const messages: JsonLogMessage[] = [];
+  let offset = 0;
+  while (offset + 10 <= buffer.length) {
+    const time = buffer.readUInt32LE(offset);
+    const type = buffer.readUInt8(offset + 4);
+    const senderLength = buffer.readUInt8(offset + 5);
+    if (offset + 6 + senderLength + 2 > buffer.length) break;
+    const sender = buffer.toString(
+      'utf8',
+      offset + 6,
+      offset + 6 + senderLength
+    );
+    const textLength = buffer.readUInt16LE(offset + 6 + senderLength);
+    const textStart = offset + 6 + senderLength + 2;
+    const next = textStart + textLength + 2;
+    if (next > buffer.length) break;
+    if (buffer.readUInt16LE(next - 2) !== next - offset - 2) break;
+    const text = buffer.toString('utf8', textStart, textStart + textLength);
+    messages.push({ time, type, sender, text });
+    offset = next;
+  }
+  return messages;
+}
+
+/**
+ * Byte-identical to what the client itself would have written. Throws on
+ * out-of-range values (e.g. millisecond timestamps); callers treat the whole
+ * file as corrupt.
+ */
+export function jsonLogToBinary(json: JsonLogMessage[]): Buffer {
+  const chunks: Buffer[] = [];
+  for (const msg of json) {
+    const sender = msg.sender || '';
+    const senderLength = Buffer.byteLength(sender);
+    const textLength = Buffer.byteLength(msg.text);
+    const buf = Buffer.allocUnsafe(senderLength + textLength + 10);
+    buf.writeUInt32LE(msg.time, 0);
+    buf.writeUInt8(msg.type, 4);
+    buf.writeUInt8(senderLength, 5);
+    buf.write(sender, 6);
+    let offset = 6 + senderLength;
+    buf.writeUInt16LE(textLength, offset);
+    buf.write(msg.text, offset + 2);
+    offset += 2 + textLength;
+    buf.writeUInt16LE(offset, offset);
+    chunks.push(buf);
+  }
+  return Buffer.concat(chunks);
+}
+
+/** Accepts both the legacy bare-array format and { name, messages }. */
+export function parseJsonLog(raw: Buffer | string): JsonLog | undefined {
+  let data: unknown;
+  try {
+    data = JSON.parse(typeof raw === 'string' ? raw : raw.toString('utf8'));
+  } catch {
+    return undefined;
+  }
+  if (Array.isArray(data)) return { messages: data as JsonLogMessage[] };
+  if (data && typeof data === 'object') {
+    const log = data as { name?: unknown; messages?: unknown };
+    if (Array.isArray(log.messages))
+      return {
+        name: typeof log.name === 'string' ? log.name : undefined,
+        messages: log.messages as JsonLogMessage[]
+      };
+  }
+  return undefined;
+}
+
+export function readLogIndexName(index: Buffer): string | undefined {
+  if (index.length < 1) return undefined;
+  const nameLength = index.readUInt8(0);
+  if (nameLength === 0 || index.length < nameLength + 1) return undefined;
+  return index.toString('utf8', 1, nameLength + 1);
+}
+
+/**
+ * Rebuilds .idx contents from a binary log, walking records the way fixLogs
+ * does. Undefined when the log holds no indexable records.
+ */
+export function buildLogIndexBuffer(
+  name: string,
+  log: Buffer
+): Buffer | undefined {
+  // Pre-cap first; byte-trimming a huge hostile name is quadratic.
+  let indexName = name.slice(0, 255);
+  while (Buffer.byteLength(indexName) > 255) indexName = indexName.slice(0, -1);
+  const nameLength = Buffer.byteLength(indexName);
+  const header = Buffer.allocUnsafe(nameLength + 1);
+  header.writeUInt8(nameLength, 0);
+  header.write(indexName, 1);
+
+  const chunks: Buffer[] = [header];
+  let offset = 0;
+  let lastDay = 0;
+  while (offset + 10 <= log.length) {
+    const senderLength = log.readUInt8(offset + 5);
+    const textStart = offset + 6 + senderLength + 2;
+    if (textStart > log.length) break;
+    const textLength = log.readUInt16LE(textStart - 2);
+    const next = textStart + textLength + 2;
+    if (next > log.length) break;
+    if (log.readUInt16LE(next - 2) !== next - offset - 2) break;
+    const day = localDay(log.readUInt32LE(offset));
+    if (day > lastDay && day <= 0xffff) {
+      const entry = Buffer.allocUnsafe(7);
+      entry.writeUInt16LE(day, 0);
+      entry.writeUIntLE(offset, 2, 5);
+      chunks.push(entry);
+      lastDay = day;
+    }
+    offset = next;
+  }
+  if (chunks.length < 2) return undefined;
+  return Buffer.concat(chunks);
+}
+
+export function parseConversationNames(
+  raw: Buffer | string
+): Map<string, string> | undefined {
+  let data: unknown;
+  try {
+    data = JSON.parse(typeof raw === 'string' ? raw : raw.toString('utf8'));
+  } catch {
+    return undefined;
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data))
+    return undefined;
+  const names = new Map<string, string>();
+  for (const [file, name] of Object.entries(data))
+    if (typeof name === 'string') names.set(file, name);
+  return names;
+}
+
+/**
+ * ^ Key derivation must stay in sync with the channel conversation key in
+ *   chat/conversations.ts; entries are most-recent-first, first wins.
+ */
+export function parseRecentChannelNames(
+  raw: Buffer | string
+): Map<string, string> | undefined {
+  let data: unknown;
+  try {
+    data = JSON.parse(typeof raw === 'string' ? raw : raw.toString('utf8'));
+  } catch {
+    return undefined;
+  }
+  if (!Array.isArray(data)) return undefined;
+  const names = new Map<string, string>();
+  for (const item of data as { channel?: unknown; name?: unknown }[]) {
+    if (!item || typeof item.channel !== 'string') continue;
+    if (typeof item.name !== 'string') continue;
+    const key = `#${item.channel.replace(/[^\w- ]/gi, '')}`.toLowerCase();
+    if (!names.has(key)) names.set(key, item.name);
+  }
+  return names;
+}
+
+/**
+ * ^ binaryLogs exists so a stale foo.json artifact never shadows the
+ *   authoritative foo from the same ZIP regardless of entry order.
+ */
+export interface LogImportContext {
+  names: Map<string, Map<string, string>>;
+  channelNames: Map<string, Map<string, string>>;
+  binaryLogs: Set<string>;
+}
+
+export function buildLogImportContext(
+  entries: ReadonlyArray<{
+    entryName: string;
+    isDirectory: boolean;
+    getData(): Buffer;
+  }>
+): LogImportContext {
+  const names = new Map<string, Map<string, string>>();
+  const channelNames = new Map<string, Map<string, string>>();
+  const binaryLogs = new Set<string>();
+  for (const entry of entries) {
+    if (!entry || entry.isDirectory) continue;
+    const normalized = entry.entryName.replace(/\\/g, '/');
+    if (!normalized.startsWith('characters/') || normalized.includes('..'))
+      continue;
+    const segments = normalized.split('/');
+    if (segments.length === 3 && segments[2] === conversationNamesFile) {
+      try {
+        const parsed = parseConversationNames(entry.getData());
+        if (parsed) names.set(segments[1], parsed);
+      } catch {}
+    } else if (
+      segments.length === 4 &&
+      segments[2] === 'settings' &&
+      segments[3] === 'recentChannels'
+    ) {
+      try {
+        const parsed = parseRecentChannelNames(entry.getData());
+        if (parsed) channelNames.set(segments[1], parsed);
+      } catch {}
+    } else if (
+      segments.length >= 4 &&
+      segments[2] === 'logs' &&
+      !normalized.endsWith('.json') &&
+      !normalized.endsWith('.idx')
+    ) {
+      binaryLogs.add(`${segments[1]}/${segments.slice(3).join('/')}`);
+    }
+  }
+  return { names, channelNames, binaryLogs };
+}
+
+/**
+ * Legacy exports carry no sidecar (#886): channel names come from the ZIP's
+ * recentChannels file, private names from the sender whose name lowercases
+ * to the log's file name.
+ */
+export function recoverLogName(
+  logKey: string,
+  character: string,
+  context: LogImportContext,
+  messages: JsonLogMessage[]
+): string | undefined {
+  const key = logKey.split('/').pop()!;
+  if (key.startsWith('#'))
+    return context.channelNames.get(character)?.get(key.toLowerCase());
+  const match = messages.find(
+    m => typeof m.sender === 'string' && m.sender.toLowerCase() === key
+  );
+  return match?.sender;
+}
+
+/**
+ * Name priority: name, existing index, fallback, file name. A stale index is
+ * removed when the new log yields no entries (#886).
+ */
+export function writeLogWithIndex(
+  destination: string,
+  log: Buffer,
+  name?: string,
+  fallback?: string
+): void {
+  const indexPath = `${destination}.idx`;
+  let indexName = name;
+  if (indexName === undefined)
+    try {
+      indexName = readLogIndexName(fs.readFileSync(indexPath));
+    } catch {}
+  fs.writeFileSync(destination, log);
+  const indexBuffer = buildLogIndexBuffer(
+    indexName ?? fallback ?? path.basename(destination),
+    log
+  );
+  if (indexBuffer) fs.writeFileSync(indexPath, indexBuffer);
+  else if (fs.existsSync(indexPath)) fs.unlinkSync(indexPath);
+}
+
+/** Builds a missing .idx for an existing log; heals pre-2.4 imports (#886). */
+export function ensureLogIndex(destination: string, name?: string): boolean {
+  const indexPath = `${destination}.idx`;
+  if (fs.existsSync(indexPath)) return false;
+  const indexBuffer = buildLogIndexBuffer(
+    name ?? path.basename(destination),
+    fs.readFileSync(destination)
+  );
+  if (!indexBuffer) return false;
+  fs.writeFileSync(indexPath, indexBuffer);
+  return true;
+}
+
+function messageKey(m: JsonLogMessage): string {
+  return JSON.stringify([m.time, m.type, m.sender, m.text]);
+}
+
+function logContainsMessages(log: Buffer, messages: JsonLogMessage[]): boolean {
+  if (messages.length === 0) return true;
+  const counts = new Map<string, number>();
+  for (const m of binaryLogToJson(log)) {
+    const k = messageKey(m);
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  for (const m of messages) {
+    const k = messageKey(m);
+    const remaining = counts.get(k) ?? 0;
+    if (remaining === 0) return false;
+    counts.set(k, remaining - 1);
+  }
+  return true;
+}
+
+/**
+ * Pre-2.4 CLI imports wrote JSON logs verbatim as <log>.json (#886); Fix
+ * Logs surfaces those as spurious empty conversations.
+ *
+ * ! The artifact may hold messages that exist nowhere else: only delete it
+ *   when it is zero-byte or the binary log provably contains every message.
+ */
+export function removeStaleJsonLogArtifact(destination: string): boolean {
+  const artifactPath = `${destination}.json`;
+  try {
+    const raw = fs.readFileSync(artifactPath);
+    if (raw.length > 0) {
+      const artifact = parseJsonLog(raw);
+      if (artifact === undefined) return false;
+      if (!logContainsMessages(fs.readFileSync(destination), artifact.messages))
+        return false;
+    }
+    fs.unlinkSync(artifactPath);
+    const artifactIndex = `${artifactPath}.idx`;
+    if (fs.existsSync(artifactIndex)) fs.unlinkSync(artifactIndex);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/electron/services/log-backup.ts
+++ b/electron/services/log-backup.ts
@@ -51,6 +51,16 @@ export interface JsonLog {
  */
 export const conversationNamesFile = 'conversation-names.json';
 
+/**
+ * ^ Filesystem litter (.DS_Store, ._* AppleDouble, Thumbs.db) is never a log:
+ *   log names are channel keys, lowercased character names, or `_`, none of
+ *   which can start with a dot. Old imports copied litter verbatim (#886), so
+ *   every seam that treats a file as a log must screen through this.
+ */
+export function isFilesystemArtifact(fileName: string): boolean {
+  return /^\.|^(thumbs\.db|desktop\.ini)(\.json)?$/i.test(fileName);
+}
+
 const dayMs = 86400000;
 
 function localDay(timeSeconds: number): number {
@@ -267,7 +277,8 @@ export function buildLogImportContext(
       segments.length >= 4 &&
       segments[2] === 'logs' &&
       !normalized.endsWith('.json') &&
-      !normalized.endsWith('.idx')
+      !normalized.endsWith('.idx') &&
+      !segments.slice(3).some(isFilesystemArtifact)
     ) {
       binaryLogs.add(`${segments[1]}/${segments.slice(3).join('/')}`);
     }


### PR DESCRIPTION
Howdy, folks!

This is the fix for #886. originally, it was just making json imports write index files, but it grew some limbs along the way. Consider it feature complete unless review turns something up.

I intend this for Friday's release. Closes #886.

## Summary

The bug: manual exports convert logs to JSON, but importing them never rebuilt the `.idx` files the log viewer needs, so conversations imported as empty ghosts. On top of that, the display names that only exist in `.idx` files (ad-hoc channel names, proper capitalization) never traveled with the export at all.

- Imported JSON logs now rebuild their `.idx` files
  - Both the GUI and CLI importers, through a new shared `electron/services/log-backup.ts` module.
  - Rebuilt indexes are byte-identical to what Fix Logs produces. This has some unpreventable quirks, but we fix what we can.
- Conversation names now travel with exports
  - New per-character `conversation-names.json` sidecar in the ZIP, read from the `.idx` headers at export time:
    ```json
    { "#adh-b2fb2f4b0a17": "Cool Channel FRFR", "some character": "Some Character" }
    ```
  - Old clients only process `logs`, `settings`, and `drafts.txt`, so they ignore the sidecar entirely, and log entries stay bare JSON arrays. Old clients can still import new exports safely.
- Name recovery for legacy exports that have no sidecar
  - Private conversations: the log file name is just the lowercased character name, and the proper capitalization survives in the message senders, so the name is recovered from the log itself.
  - Channels: recovered from the character's `settings/recentChannels` file in the same ZIP (covers the ~50 most recently joined channels, which is what that file holds. _This is the unpreventable quirk, and can't really be solved any other way._)
  - Recovered names are the lowest-priority source: sidecar > name embedded in the log > existing index > recovered > file name. Recovery can only improve on the raw file key, never override real data.
- Re-imports heal existing damage
  - If you already imported with a broken version (logs on disk, indexes missing), re-importing the same export rebuilds the missing indexes even though the log files themselves are skipped. The summary counts these properly instead of claiming "Restored data for 0 character(s)".
  
  ## Additional
- Broken CLI imports used to write JSON logs verbatim to disk as `foo.json`. Those stale artifacts are now cleaned up on re-import, but **only** when the artifact is zero-byte (Fix Logs already truncated it) or every one of its messages provably exists in the binary log next to it. If that containment check fails, the file stays put. No path in this PR should be able to lose messages.
- A raw binary log in the ZIP now shadows its stale `.json` twin regardless of ZIP entry order.
- `binaryLogToJson` validates each record's trailing length marker (same as Fix Logs) and stops at the first malformed record, so garbage files convert to nothing instead of nonsense.
- CLI import: per-file error handling, a `filesErrored` count in the JSON report, and exit code 1 when anything failed.
- The export loop only yields to the UI after actually appending a file (previously it could spin on skipped entries).

## To test
- [x] Round trip: export, import into an empty log directory, conversations appear with messages, dates, and correct names (ad-hoc channels and capitalization included)
- [x] Legacy ZIP from 2.2.x/2.3.x: conversations appear; PM names recover their capitalization, channel names recover for recently joined channels
- [x] Heal: re-import over an install with missing `.idx` files (no overwrite), conversations become visible and the summary counts those characters
- [x] Stale `foo.json` artifacts from old CLI imports are gone after re-import, and Fix Logs no longer invents empty conversations from them
- [x] CLI: dry run previews without touching disk; a failed file yields exit code 1
- [x] Backward compat: an old release imports a new export cleanly (sidecar ignored, logs still bare arrays) [Low priority, but just to be safe!]