### PR TITLE
fix: SCSS contrast warnings for button and BBCode color picker variants

### DIFF
--- a/scss/themes/chat/dracula.scss
+++ b/scss/themes/chat/dracula.scss
@@ -9,12 +9,12 @@
 //BBCode colors.
 $red-color: $dracula-red;
 $green-color: $dracula-green;
-$blue-color: #1185fe;
+$blue-color: #6a9bcf;
 $yellow-color: $dracula-yellow;
 $purple-color: $dracula-purple;
 $cyan-color: $dracula-cyan;
 $white-color: $dracula-foreground;
-$black-color: $dracula-comment;
+$black-color: color.scale($dracula-comment, $lightness: -20%);
 $brown-color: #b89383;
 $pink-color: $dracula-pink;
 $gray-color: $gray-600;

--- a/scss/themes/variables/_dracula_variables.scss
+++ b/scss/themes/variables/_dracula_variables.scss
@@ -1,3 +1,7 @@
+// If you are making a custom theme, and you are using this as a base.
+// Stop it. It's bad, it's jank, and it keeps having contrast problems that none of the derivatives ever solve.
+// Base your theme on the default blue or light ones instead.
+
 @use 'sass:color';
 
 //Dracula colors
@@ -31,13 +35,15 @@ $black: $dracula-foreground;
 
 // Bootstrap 5 contrast colors
 $light-color: $dracula-foreground;
-$dark-color: $dracula-bg;
+$dark-color: #14141a;
 $component-active-color: $light-color;
 
+$color-contrast-dark: #000;
+$color-contrast-light: #fff;
 $primary: $dracula-purple;
 $secondary: $gray-400;
 $success: $dracula-green;
-$info: $dracula-comment;
+$info: $dracula-cyan;
 $warning: $dracula-orange;
 $danger: $dracula-red;
 $light: $gray-100;

--- a/scss/themes/variables/_mocha_variables.scss
+++ b/scss/themes/variables/_mocha_variables.scss
@@ -36,9 +36,9 @@ $dark-color: $mocha-bg;
 $component-active-color: $light-color;
 
 $primary: $mocha-lavender;
-$secondary: $gray-400;
+$secondary: $gray-100;
 $success: $mocha-green;
-$info: $mocha-comment;
+$info: $mocha-blue;
 $warning: $mocha-orange;
 $danger: $mocha-red;
 $light: $mocha-bg;

--- a/scss/themes/variables/_moon_prism_variables.scss
+++ b/scss/themes/variables/_moon_prism_variables.scss
@@ -18,7 +18,7 @@ $dark-color: $gray-base;
 $component-active-color: $dark-color; // Use dark color for light primary
 
 $moon-prism-silver: #c8d5e8;
-$moon-prism-blue: #6b8cff;
+$moon-prism-blue: #4c4cff;
 $moon-prism-purple: #a685ff;
 $moon-prism-pink: #ff85c7;
 $moon-prism-cyan: #85ffff;
@@ -29,7 +29,7 @@ $moon-prism-magenta: #d485ff;
 $moon-prism-orange: #ffb785;
 
 $primary: #8ba4d9;
-$secondary: $gray-400;
+$secondary: $gray-300;
 $success: $moon-prism-green;
 $info: color.scale($moon-prism-blue, $lightness: -30%);
 $warning: $moon-prism-gold;
@@ -54,7 +54,6 @@ $grid-gutter-width: 20px;
 $input-bg: $gray-200;
 $input-color: $black;
 $custom-select-bg: $gray-200;
-$form-check-input-checked-bg-color: $primary;
 
 $list-group-bg: $gray-200;
 

--- a/scss/themes/variables/_rose_variables.scss
+++ b/scss/themes/variables/_rose_variables.scss
@@ -30,9 +30,9 @@ $rose-brown: #d2908d;
 $rose-pink: #f7a0d3;
 
 $primary: #61364b;
-$secondary: #6b5b6b;
+$secondary: #4b424b;
 $success: $rose-green;
-$info: #1f5fb0;
+$info: #90a9ea;
 $warning: #fce0a5;
 $danger: #ffcdd2;
 $light: $gray-200;


### PR DESCRIPTION
Fixes #867

Might make screenshots later, but the actual differences here are fairly minimal anyway. Just some minor palette touchups (and using appropriate colors!!) for themes that are based on the Dracula one.