### PR TITLE
fix: order channel groups in mobile quick switcher

### DIFF
--- a/chat/ChatView.vue
+++ b/chat/ChatView.vue
@@ -366,7 +366,7 @@
           <div class="name">{{ conversation.character.name }}</div>
         </a>
         <a
-          v-for="conversation in conversations.channelConversations"
+          v-for="conversation in orderedChannelConversations"
           href="#"
           @click.prevent="conversation.show()"
           @click.middle.prevent.stop="conversation.close()"
@@ -549,6 +549,14 @@
         return core.conversations.channelConversations.filter(
           (c: any) => !core.conversations.channelGroupAssignments[c.channel.id]
         );
+      },
+      orderedChannelConversations(): any[] {
+        return [
+          ...this.sortedChannelGroups.flatMap((g: any) =>
+            this.channelsInGroup(g.id)
+          ),
+          ...this.ungroupedChannels
+        ];
       },
       showAvatars(): boolean {
         return core.state.settings.showAvatars;
@@ -754,12 +762,7 @@
       onKeyDown(e: KeyboardEvent): void {
         const selected = this.conversations.selectedConversation;
         const pms = this.conversations.privateConversations;
-        const channels = [
-          ...this.sortedChannelGroups.flatMap((g: any) =>
-            this.channelsInGroup(g.id)
-          ),
-          ...this.ungroupedChannels
-        ];
+        const channels = this.orderedChannelConversations;
         const console = this.conversations.consoleTab;
         if (getKey(e) === Keys.ArrowUp) {
           if (e.altKey && !e.shiftKey && !e.ctrlKey && !e.metaKey) {


### PR DESCRIPTION
When I added the channel grouping system I decoupled group order (the numeric `order` field) from the flat `channelConversations` array, and wired the desktop sidebar and keyboard navigation to read it back through `sortedChannelGroups`, but I missed the mobile-sized quick switcher. It kept iterating the raw `channelConversations` array, so the groups rendered in creation order and never moved when dragged (the channels within each group stayed correct). This adds an `orderedChannelConversations` computed built from the existing `sortedChannelGroups`, `channelsInGroup` and `ungroupedChannels` helpers, and points the mobile strip (and the now-deduplicated `onKeyDown` handler) at it.

Fixes #874
