### PR TITLE
fix: anyAscii improvements

### DIFF
--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -284,19 +284,32 @@
 
   const standardParser = new StandardBBCodeParser();
 
+  // what anyAscii turns emoji into, e.g. ':emoji:'. nothing below U+2000
+  // converts to this shape, so it can't match real text
+  const ASCII_EMOJI_NAME = /^:[a-z0-9_+-]+:$/;
+
+  // preserves emoji sequences (hands with skin tones, people variations, etc.)
+  const EMOJI_GLUE =
+    /[\u200d\u20e3\ufe0e\ufe0f]|[\u{e0020}-\u{e007f}]|[\u{1f1e6}-\u{1f1ff}]|[\u{1f3fb}-\u{1f3ff}]/u;
+
   // anyAscii turns decorative unicode brackets (「」【】［］) into real ASCII
-  // brackets, which the bbcode parser then tries to convert. this skips those characters
+  // brackets, which the bbcode parser then tries to convert. emojis are also
+  // converted to :emoji: equivalents. this skips those characters
   function safeAnyAscii(s: string): string {
     let out = '';
 
     for (const ch of s) {
-      if (ch.codePointAt(0)! < 128) {
+      if (ch.codePointAt(0)! < 128 || EMOJI_GLUE.test(ch)) {
         out += ch;
         continue;
       }
 
       const converted = anyAscii(ch);
-      out += /[[\]]/.test(converted) ? ch : converted;
+
+      out +=
+        /[[\]]/.test(converted) || ASCII_EMOJI_NAME.test(converted)
+          ? ch
+          : converted;
     }
 
     return out;

--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -284,6 +284,24 @@
 
   const standardParser = new StandardBBCodeParser();
 
+  // anyAscii turns decorative unicode brackets (「」【】［］) into real ASCII
+  // brackets, which the bbcode parser then tries to convert. this skips those characters
+  function safeAnyAscii(s: string): string {
+    let out = '';
+
+    for (const ch of s) {
+      if (ch.codePointAt(0)! < 128) {
+        out += ch;
+        continue;
+      }
+
+      const converted = anyAscii(ch);
+      out += /[[\]]/.test(converted) ? ch : converted;
+    }
+
+    return out;
+  }
+
   export default Vue.extend({
     components: {
       sidebar: Sidebar,
@@ -687,12 +705,12 @@
           core.state.generalSettings &&
           core.state.generalSettings.horizonForceAsciiProfiles
         ) {
-          character.character.description = anyAscii(
+          character.character.description = safeAnyAscii(
             character.character.description
           );
 
           if (character.character.title) {
-            character.character.title = anyAscii(character.character.title);
+            character.character.title = safeAnyAscii(character.character.title);
           }
 
           // We don't do customs and infotags here, so that they are at least sorted before parsing.

--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -242,7 +242,7 @@
 <script lang="ts">
   import * as _ from 'lodash';
 
-  import anyAscii from 'any-ascii';
+  import { safeAnyAscii } from './safe-ascii';
   import Vue from 'vue';
   import log from 'electron-log'; //tslint:disable-line:match-default-export-name
 
@@ -283,37 +283,6 @@
   }
 
   const standardParser = new StandardBBCodeParser();
-
-  // what anyAscii turns emoji into, e.g. ':emoji:'. nothing below U+2000
-  // converts to this shape, so it can't match real text
-  const ASCII_EMOJI_NAME = /^:[a-z0-9_+-]+:$/;
-
-  // preserves emoji sequences (hands with skin tones, people variations, etc.)
-  const EMOJI_GLUE =
-    /[\u200d\u20e3\ufe0e\ufe0f]|[\u{e0020}-\u{e007f}]|[\u{1f1e6}-\u{1f1ff}]|[\u{1f3fb}-\u{1f3ff}]/u;
-
-  // anyAscii turns decorative unicode brackets (「」【】［］) into real ASCII
-  // brackets, which the bbcode parser then tries to convert. emojis are also
-  // converted to :emoji: equivalents. this skips those characters
-  function safeAnyAscii(s: string): string {
-    let out = '';
-
-    for (const ch of s) {
-      if (ch.codePointAt(0)! < 128 || EMOJI_GLUE.test(ch)) {
-        out += ch;
-        continue;
-      }
-
-      const converted = anyAscii(ch);
-
-      out +=
-        /[[\]]/.test(converted) || ASCII_EMOJI_NAME.test(converted)
-          ? ch
-          : converted;
-    }
-
-    return out;
-  }
 
   export default Vue.extend({
     components: {

--- a/site/character_page/infotag.vue
+++ b/site/character_page/infotag.vue
@@ -14,7 +14,7 @@
 
 <script setup lang="ts">
   import { computed } from 'vue';
-  import anyAscii from 'any-ascii';
+  import { safeAnyAscii } from './safe-ascii';
   import core from '../../chat/core';
   import { CharacterInfotag, Infotag, ListItem } from '../../interfaces';
   import { formatContactLink, formatContactValue } from './contact_utils';
@@ -100,7 +100,7 @@
     switch (props.infotag.type) {
       case 'text':
         return shouldFormatAscii
-          ? anyAscii(props.data.string!)
+          ? safeAnyAscii(props.data.string!)
           : props.data.string!;
       case 'number':
         if (props.infotag.allow_legacy && !props.data.number) {
@@ -111,7 +111,7 @@
           //we do that before returning.
           return props.data.string !== undefined
             ? shouldFormatAscii
-              ? anyAscii(props.data.string)
+              ? safeAnyAscii(props.data.string)
               : props.data.string
             : '';
         }

--- a/site/character_page/kink.vue
+++ b/site/character_page/kink.vue
@@ -60,7 +60,7 @@
     onMounted,
     PropType
   } from 'vue';
-  import anyAscii from 'any-ascii';
+  import { safeAnyAscii } from './safe-ascii';
   import core from '../../chat/core';
   import { DisplayKink } from './interfaces';
   import { kinkComparisonSwaps } from '../../learn/matcher-types';
@@ -109,8 +109,8 @@
           core.state.generalSettings &&
           core.state.generalSettings.horizonForceAsciiProfiles
         ) {
-          props.kink.description = anyAscii(props.kink.description);
-          props.kink.name = anyAscii(props.kink.name);
+          props.kink.description = safeAnyAscii(props.kink.description);
+          props.kink.name = safeAnyAscii(props.kink.name);
         }
       });
 

--- a/site/character_page/safe-ascii.ts
+++ b/site/character_page/safe-ascii.ts
@@ -1,0 +1,32 @@
+import anyAscii from 'any-ascii';
+
+// what anyAscii turns emoji into, e.g. ':emoji:'. nothing below U+2000
+// converts to this shape, so it can't match real text
+const ASCII_EMOJI_NAME = /^:[a-z0-9_+-]+:$/;
+
+// preserves emoji sequences (hands with skin tones, people variations, etc.)
+const EMOJI_GLUE =
+  /[\u200d\u20e3\ufe0e\ufe0f]|[\u{e0020}-\u{e007f}]|[\u{1f1e6}-\u{1f1ff}]|[\u{1f3fb}-\u{1f3ff}]/u;
+
+// anyAscii turns decorative unicode brackets (「」【】［］) into real ASCII
+// brackets, which the bbcode parser then tries to convert. emojis are also
+// converted to :emoji: equivalents. this skips those characters
+export function safeAnyAscii(s: string): string {
+  let out = '';
+
+  for (const ch of s) {
+    if (ch.codePointAt(0)! < 128 || EMOJI_GLUE.test(ch)) {
+      out += ch;
+      continue;
+    }
+
+    const converted = anyAscii(ch);
+
+    out +=
+      /[[\]]/.test(converted) || ASCII_EMOJI_NAME.test(converted)
+        ? ch
+        : converted;
+  }
+
+  return out;
+}

--- a/site/character_page/safe-ascii.ts
+++ b/site/character_page/safe-ascii.ts
@@ -1,16 +1,52 @@
 import anyAscii from 'any-ascii';
 
-// what anyAscii turns emoji into, e.g. ':emoji:'. nothing below U+2000
-// converts to this shape, so it can't match real text
+/**
+ * Matches the emoji names `anyAscii` produces, such as `:grinning:`
+ *
+ * @remarks
+ * Nothing below U+2000 converts to this shape, so this can't match real text.
+ */
 const ASCII_EMOJI_NAME = /^:[a-z0-9_+-]+:$/;
 
-// preserves emoji sequences (hands with skin tones, people variations, etc.)
+/**
+ * The invisible parts that hold emoji sequences together, plus the regional
+ * indicators that make up flags.
+ *
+ * @remarks
+ * Covers the zero width joiner, variation selectors, the keycap mark, the tag
+ * characters used by some flags, and skin tone modifiers.
+ *
+ * `anyAscii` maps most of these to nothing and the flag tags to stray letters,
+ * so converting them pulls sequences apart. A family emoji becomes three
+ * separate people,  the Scotland flag renders as `gbsct`, etc.
+ */
 const EMOJI_GLUE =
   /[\u200d\u20e3\ufe0e\ufe0f]|[\u{e0020}-\u{e007f}]|[\u{1f1e6}-\u{1f1ff}]|[\u{1f3fb}-\u{1f3ff}]/u;
 
-// anyAscii turns decorative unicode brackets (「」【】［］) into real ASCII
-// brackets, which the bbcode parser then tries to convert. emojis are also
-// converted to :emoji: equivalents. this skips those characters
+/**
+ * Converts text to ASCII, skipping anything that would break BBCode or
+ * flatten an emoji.
+ *
+ * @param s - the text to convert
+ * @returns the converted text, with decorative brackets and emoji left alone
+ *
+ * @remarks
+ * `anyAscii` turns decorative unicode brackets (「」【】［］) into real ASCII
+ * brackets, which the bbcode parser then tries to convert, and turns emoji into
+ * `:emoji:` equivalents. This skips those characters.
+ *
+ * Conversion runs per code point, which is safe because `anyAscii` translates
+ * each code point independently of its neighbours.
+ *
+ * @example
+ * ```ts
+ * safeAnyAscii('「Héllo」'); // '「Hello」'  - decoration survives
+ * safeAnyAscii('[b]𝓯𝓪𝓷𝓬𝔂[/b]'); // '[b]fancy[/b]' - real bbcode untouched
+ * safeAnyAscii('👍🏽 café'); // '👍🏽 cafe' - emoji kept, accent folded
+ * ```
+ *
+ * @see {@link https://github.com/Fchat-Horizon/Horizon/issues/497}
+ */
 export function safeAnyAscii(s: string): string {
   let out = '';
 


### PR DESCRIPTION
Adds a check when 'Standardize profile fonts' is enabled that will skip any bracket-adjacent or emojis from being converted. This means that bbcode will no longer be broken if used alongside a bracket character like `「」` or `【】` with the setting enabled. All other non-emoji ASCII font should be untouched, but admittedly I don't know any profiles with godawful ASCII on their profile to test with.

### Default (Standardize fonts disabled)
looks fine, because nothing is converted
<img width="674" height="49" alt="image" src="https://github.com/user-attachments/assets/8f48d841-f31c-44cf-8bc1-7814558c642e" />

### OLD Standardize fonts enabled
bad, really bad
<img width="1967" height="54" alt="image" src="https://github.com/user-attachments/assets/6cdcac4d-4c0d-4050-8127-7d0f56a696de" />

### NEW Standardize fonts enabled
emojis and characters that would be converted to brackets are kept the same. in this example, only the `✓` and `✗` characters were converted
<img width="652" height="59" alt="image" src="https://github.com/user-attachments/assets/2c60ae02-6266-4cd0-aad3-62cff24780dd" />

Closes #497 .