### PR TITLE
fix: Guestbook counter is accurate past 15 posts

### DIFF
--- a/chat/profile_api.ts
+++ b/chat/profile_api.ts
@@ -504,15 +504,36 @@ async function imagesGet(id: number): Promise<CharacterImage[]> {
   ).images;
 }
 
-async function guestbookGet(id: number, offset: number): Promise<Guestbook> {
-  const data = await core.connection.queryApi<{
+// if anybody has more than 100 *pages* of guestbook posts (1500+ posts), i'll be stunned
+const GUESTBOOK_MAX_COUNT_PAGES = 100;
+
+async function guestbookPageFetch(id: number, page: number) {
+  return core.connection.queryApi<{
     nextPage: boolean;
     posts: GuestbookPost[];
-  }>('character-guestbook.php', {
-    id,
-    page: offset / 10
-  });
+  }>('character-guestbook.php', { id, page });
+}
+
+async function guestbookGet(id: number, offset: number): Promise<Guestbook> {
+  const data = await guestbookPageFetch(id, offset / 10);
   return { posts: data.posts, total: data.nextPage ? offset + 100 : offset };
+}
+
+// character-guestbook.php never reports a total, only whether another page
+// follows, so the only way to get an exact post count is to check every page.
+async function guestbookCountedGet(id: number): Promise<Guestbook> {
+  const first = await guestbookPageFetch(id, 0);
+
+  let postCount = first.posts.length;
+  let hasNextPage = first.nextPage;
+
+  for (let page = 1; hasNextPage && page < GUESTBOOK_MAX_COUNT_PAGES; page++) {
+    const data = await guestbookPageFetch(id, page);
+    postCount += data.posts.length;
+    hasNextPage = data.nextPage;
+  }
+
+  return { posts: first.posts, total: first.nextPage ? 100 : 0, postCount };
 }
 
 async function kinksGet(id: number): Promise<CharacterKink[]> {
@@ -555,6 +576,7 @@ export function init(settings: Settings, characters: SimpleCharacter[]): void {
   registerMethod('kinksGet', kinksGet);
   registerMethod('imagesGet', imagesGet);
   registerMethod('guestbookPageGet', guestbookGet);
+  registerMethod('guestbookCountedGet', guestbookCountedGet);
   registerMethod('imageUrl', (image: CharacterImageOld) => image.url);
   registerMethod('memoUpdate', async (id: number, memo: string) => {
     await core.connection.queryApi('character-memo-save.php', {

--- a/site/character_page/character_page.vue
+++ b/site/character_page/character_page.vue
@@ -345,8 +345,11 @@
 
         // Guestbook tab - key '3'
         if ((this as any).character?.settings?.guestbook) {
+          // falls back to the first page's length rather than showing nothing if postCount doesn't exist
           const guestbookCount =
-            this.guestbook !== null ? ` (${this.guestbook.posts.length})` : '';
+            this.guestbook !== null
+              ? ` (${this.guestbook.postCount ?? this.guestbook.posts.length})`
+              : '';
           labels['3'] = this.l('profile.tab.guestbook') + guestbookCount;
         }
 
@@ -459,9 +462,8 @@
             return;
           }
 
-          const result = await methods.guestbookPageGet(
-            this.character.character.id,
-            1
+          const result = await methods.guestbookCountedGet(
+            this.character.character.id
           );
 
           if (this.name !== expectedName) return;

--- a/site/character_page/interfaces.ts
+++ b/site/character_page/interfaces.ts
@@ -70,6 +70,7 @@ export interface StoreMethods {
     limit?: number,
     unapproved_only?: boolean
   ): Promise<Guestbook>;
+  guestbookCountedGet(character: number): Promise<Guestbook>;
   guestbookPostApprove(
     character: number,
     id: number,
@@ -186,6 +187,7 @@ export interface GuestbookPost {
 export interface Guestbook {
   readonly posts: GuestbookPost[];
   readonly total: number;
+  readonly postCount?: number;
 }
 
 export interface CharacterReportData {


### PR DESCRIPTION
Fixes an OLD issue where any profiles with more than 15 guestbook posts would only show 15 for the guestbook post counter.  character-guestbook,php never gives us a total guestbook count, so our only option is to walk through every single guestbook page and sum them up.

For most profiles this won't change much, since it's rare to see anyone with more than 15 posts nowadays, but every extra page is an extra API call, so it might be a *little* slower to count some really-filled guestbooks.

Fixes #854 