### PR TITLE
Remove follows directive for nixpkgs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,6 @@ Horizon is available as a Nix Flake input based on the GitHub repo. See [this](h
 ```nix
     horizon = {
       url = "github:Fchat-Horizon/Horizon?ref=main";
-      inputs.nixpkgs.follows = "nixpkgs-unstable";
     };
 ```
 


### PR DESCRIPTION
This seems to fix an issue of looking for electron 40 versions. The flake has it fixed, but following was causing an issue of looking for insecure packages.