### PR TITLE
feat: Warn about leading whitespace before sending commands

### DIFF
--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -541,7 +541,7 @@
   import ManageChannel from './ManageChannel.vue';
   import MessageView from './message_view';
   import ReportDialog from './ReportDialog.vue';
-  import { isCommand, trimCommandWhitespace } from './slash_commands';
+  import { isCommand } from './slash_commands';
   import UserView from './UserView.vue';
   import CharacterChannelList from './character/CharacterChannelList.vue';
   import * as _ from 'lodash';
@@ -929,10 +929,7 @@
             if (this.tabOptionsIndex >= this.tabOptions.length)
               this.tabOptionsIndex = 0;
             const name = this.tabOptions[this.tabOptionsIndex];
-            // send() will trim this, so complete to a bare name instead of a [user] tag
-            const userName = isCommand(
-              trimCommandWhitespace(this.conversation.enteredText)
-            )
+            const userName = isCommand(this.conversation.enteredText)
               ? name
               : `[user]${name}[/user]`;
             this.tabOptionSelection.end =

--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -541,7 +541,7 @@
   import ManageChannel from './ManageChannel.vue';
   import MessageView from './message_view';
   import ReportDialog from './ReportDialog.vue';
-  import { isCommand } from './slash_commands';
+  import { isCommand, trimCommandWhitespace } from './slash_commands';
   import UserView from './UserView.vue';
   import CharacterChannelList from './character/CharacterChannelList.vue';
   import * as _ from 'lodash';
@@ -929,7 +929,10 @@
             if (this.tabOptionsIndex >= this.tabOptions.length)
               this.tabOptionsIndex = 0;
             const name = this.tabOptions[this.tabOptionsIndex];
-            const userName = isCommand(this.conversation.enteredText)
+            // send() will trim this, so complete to a bare name instead of a [user] tag
+            const userName = isCommand(
+              trimCommandWhitespace(this.conversation.enteredText)
+            )
               ? name
               : `[user]${name}[/user]`;
             this.tabOptionSelection.end =

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -17,7 +17,8 @@ import {
   isAction,
   isCommand,
   isWarn,
-  parse as parseCommand
+  parse as parseCommand,
+  trimCommandWhitespace
 } from './slash_commands';
 import MessageType = Interfaces.Message.Type;
 import { EventBus } from './preview/event-bus';
@@ -147,6 +148,9 @@ abstract class Conversation implements Interfaces.Conversation {
 
   async send(): Promise<void> {
     if (this.enteredText.length === 0) return;
+
+    const trimmed = trimCommandWhitespace(this.enteredText);
+    if (trimmed !== this.enteredText) this.enteredText = trimmed;
 
     if (isCommand(this.enteredText)) {
       const parsed = parseCommand(this.enteredText, this.context);

--- a/chat/conversations.ts
+++ b/chat/conversations.ts
@@ -18,7 +18,7 @@ import {
   isCommand,
   isWarn,
   parse as parseCommand,
-  trimCommandWhitespace
+  indentedCommandName
 } from './slash_commands';
 import MessageType = Interfaces.Message.Type;
 import { EventBus } from './preview/event-bus';
@@ -87,6 +87,9 @@ abstract class Conversation implements Interfaces.Conversation {
   protected allMessages: Interfaces.Message[] = [];
   readonly reportMessages: Interfaces.Message[] = [];
   private lastSent = '';
+  // text of the last send() that was blocked for having spaces before a command,
+  // so the next Enter on that exact text goes through untouched
+  private spacedCommandWarning = '';
   adManager: AdManager;
   cacheActive = false;
   protected cacheInterval: ReturnType<typeof setInterval> | undefined;
@@ -149,8 +152,17 @@ abstract class Conversation implements Interfaces.Conversation {
   async send(): Promise<void> {
     if (this.enteredText.length === 0) return;
 
-    const trimmed = trimCommandWhitespace(this.enteredText);
-    if (trimmed !== this.enteredText) this.enteredText = trimmed;
+    const spaced = indentedCommandName(this.enteredText);
+    if (spaced !== undefined) {
+      if (this.spacedCommandWarning !== this.enteredText) {
+        this.spacedCommandWarning = this.enteredText;
+        this.errorText = l('commands.spacedCommand', { command: spaced });
+        return;
+      }
+      // warning acknowledged, send it as the literal message it is
+      this.spacedCommandWarning = '';
+      this.errorText = '';
+    }
 
     if (isCommand(this.enteredText)) {
       const parsed = parseCommand(this.enteredText, this.context);

--- a/chat/locales/en-US.json
+++ b/chat/locales/en-US.json
@@ -323,6 +323,7 @@
   "commands.setmode.param0.help": "A valid room mode, namely \"ads\", \"chat\" or \"both\".",
   "commands.setowner": "Set channel owner",
   "commands.setowner.help": "Set the owner of a channel to another character. The previous owner will be demoted to a member.",
+  "commands.spacedCommand": "\"/{command}\" has a space in front of it, so it will be sent as a message instead of run as a command. Press Enter again to send it anyway.",
   "commands.status": "Set status",
   "commands.status.help": "Sets your status along with an optional message.",
   "commands.status.param0": "Status",

--- a/chat/slash_commands.ts
+++ b/chat/slash_commands.ts
@@ -28,6 +28,20 @@ export function isCommand(this: void, text: string): boolean {
   return text.charAt(0) === '/' && !isAction(text) && !isWarn(text);
 }
 
+// leading spaces followed by a command e.g. ' /me waves'
+// does not handle newlines before commands, since that's probably intended by the user
+const indentedCommand = /^([^\S\r\n]+)\/([a-z]+)\b/i;
+
+// checks that the trimmed command attempt is an actual command before sending
+// prevents intentional cases like ' /shrug' from being sent as a command, since it's not one
+export function trimCommandWhitespace(this: void, text: string): string {
+  const match = indentedCommand.exec(text);
+  if (match === null) return text;
+  return commands[match[2].toLowerCase()] !== undefined
+    ? text.substring(match[1].length)
+    : text;
+}
+
 export function parse(
   this: void | never,
   input: string,

--- a/chat/slash_commands.ts
+++ b/chat/slash_commands.ts
@@ -30,16 +30,18 @@ export function isCommand(this: void, text: string): boolean {
 
 // leading spaces followed by a command e.g. ' /me waves'
 // does not handle newlines before commands, since that's probably intended by the user
-const indentedCommand = /^([^\S\r\n]+)\/([a-z]+)\b/i;
+const indentedCommand = /^[^\S\r\n]+\/([a-z]+)\b/i;
 
-// checks that the trimmed command attempt is an actual command before sending
-// prevents intentional cases like ' /shrug' from being sent as a command, since it's not one
-export function trimCommandWhitespace(this: void, text: string): string {
+// names the command the text was probably meant to be, so send() can warn about it
+// only matches real commands, since ' /shrug' is not one and is meant to be sent as-is
+export function indentedCommandName(
+  this: void,
+  text: string
+): string | undefined {
   const match = indentedCommand.exec(text);
-  if (match === null) return text;
-  return commands[match[2].toLowerCase()] !== undefined
-    ? text.substring(match[1].length)
-    : text;
+  if (match === null) return undefined;
+  const name = match[1].toLowerCase();
+  return commands[name] !== undefined ? name : undefined;
 }
 
 export function parse(


### PR DESCRIPTION
Removes any leading whitespace from commands before sending them, letting them be actually read as a command rather than sending as raw text. For example, ` /me shrugs` will send the /me command correctly instead of sending the text as-is. Anything that isn't an actual command (` /shrug`) will not be trimmed so that it still sends correctly.

I didn't make a toggle for this to avoid adding even more settings bloat, but I doubt there's many people that intentionally send commands with leading spaces anyways.

Closes #919