### PR TITLE
UserList Virtualization and Cache Manager Improvements

### DIFF
--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -81,24 +81,37 @@
       v-if="channel && tab !== '0'"
       style="padding-left: 5px; flex: 1; display: flex; flex-direction: column"
     >
-      <div class="users hidden-scrollbar" style="flex: 1; padding-left: 5px">
+      <div style="padding-left: 5px; flex-shrink: 0">
         <h4>
           <span style="display: inline-block">{{ memberCountText }}</span>
         </h4>
-        <div
-          v-for="member in filteredMembers"
-          :key="member.character.name"
-          class="userlist-item"
-          :class="{ dimmed: member.character.isIgnored }"
-        >
-          <user
-            :character="member.character"
-            :channel="channel"
-            :showStatus="true"
-            :isMarkerShown="shouldShowMarker"
-          ></user>
-        </div>
       </div>
+      <!-- virtualized members list, because channels with thousands of members shouldn't try to render 
+       every custom-colored name at once. the trade-off is that custom colors can sometimes take a bit to 
+       load for the rendered area if you scroll really fast, but the pros outweigh the cons imo. -->
+      <virtual-list
+        ref="memberList"
+        class="hidden-scrollbar"
+        style="overflow: auto; flex: 1 1 auto; padding-left: 5px"
+        :items="filteredMembers"
+        :itemHeight="rowHeight"
+        :overscan="overscan"
+        :keyFunc="memberKey"
+      >
+        <template slot-scope="{ item: member }">
+          <div
+            class="userlist-item"
+            :class="{ dimmed: member.character.isIgnored }"
+          >
+            <user
+              :character="member.character"
+              :channel="channel"
+              :showStatus="true"
+              :isMarkerShown="shouldShowMarker"
+            ></user>
+          </div>
+        </template>
+      </virtual-list>
 
       <!--<span class="input-group-text">
           <span class="fas fa-search"></span>
@@ -357,6 +370,7 @@
   } from './memberFilters';
   import { computeGenderPreferenceBuckets } from './memberFilters';
   import Dropdown from '../components/Dropdown.vue';
+  import VirtualList from '../components/VirtualList.vue';
 
   const availableSorts = ['normal', 'status', 'gender'] as const;
 
@@ -366,13 +380,17 @@
       user: UserView,
       sidebar: Sidebar,
       tabs: Tabs,
-      dropdown: Dropdown
+      dropdown: Dropdown,
+      'virtual-list': VirtualList
     },
     data() {
       return {
         tab: '0',
         expanded: window.innerWidth >= 992,
         filter: '',
+        rowHeight: 22,
+        rowHeightMeasured: false,
+        overscan: 8,
         genderFilters: (core &&
         core.state &&
         (core.state.settings as any) &&
@@ -559,6 +577,15 @@
         const members = this.getFilteredMembers();
         return sortMembers(members, this.sortType);
       },
+      memberResetKey(): string {
+        return [
+          this.channel?.id,
+          this.filter,
+          this.sortType,
+          this.genderFilters.join(','),
+          this.selectedStatuses.join(',')
+        ].join('|');
+      },
       memberCountText(): string {
         const total = this.channel ? this.channel.sortedMembers.length : 0;
         const shown = this.filteredMembers ? this.filteredMembers.length : 0;
@@ -632,6 +659,20 @@
           } as any;
         }
       });
+
+      // only the scroll position is stale when the list is rebuilt. the measured
+      // row heights are keyed by character and stay valid, so don't use resetKey
+      this.$watch('memberResetKey', () => {
+        const list = this.$refs['memberList'] as
+          | { resetScroll(): void }
+          | undefined;
+        if (list) list.resetScroll();
+      });
+
+      this.$nextTick(() => this.syncRowHeight());
+    },
+    updated(): void {
+      if (!this.rowHeightMeasured) this.syncRowHeight();
     },
     methods: {
       applyOrientationAutoFilter(): void {
@@ -668,6 +709,24 @@
             horizonAutoGenderFilter: false
           } as any;
         }
+      },
+
+      memberKey(member: Channel.Member): string {
+        return member.character.name;
+      },
+
+      // rows are always the same height for a user unless they change their font size,
+      // so we can measure it once and call it a day
+      syncRowHeight(): void {
+        const list = this.$refs['memberList'] as Vue | undefined;
+        const row = list?.$el.querySelector('.virtual-list-row');
+        if (!row) return;
+
+        const height = row.getBoundingClientRect().height;
+        if (height <= 0) return;
+
+        this.rowHeight = height;
+        this.rowHeightMeasured = true;
       },
 
       getFilteredMembers() {

--- a/chat/UserList.vue
+++ b/chat/UserList.vue
@@ -669,6 +669,16 @@
         if (list) list.resetScroll();
       });
 
+      // font size is applied via injected css, so it never re-renders. re-measure on
+      // nextTick, after ChatView's watcher has actually applied the new size
+      this.$watch(
+        () => core.state.settings.fontSize,
+        () => {
+          this.rowHeightMeasured = false;
+          this.$nextTick(() => this.syncRowHeight());
+        }
+      );
+
       this.$nextTick(() => this.syncRowHeight());
     },
     updated(): void {
@@ -715,8 +725,8 @@
         return member.character.name;
       },
 
-      // rows are always the same height for a user unless they change their font size,
-      // so we can measure it once and call it a day
+      // rows are always the same height for a user, so we can measure it once and
+      // call it a day. the font size watcher in mounted() re-arms this if it changes
       syncRowHeight(): void {
         const list = this.$refs['memberList'] as Vue | undefined;
         const row = list?.$el.querySelector('.virtual-list-row');

--- a/chat/UserView.vue
+++ b/chat/UserView.vue
@@ -241,7 +241,7 @@
       ) {
         //Don't bother checking again if we don't get a result.
         core.characters.setOverride(character.name, 'characterColor', null);
-        core.cache.addProfile(character.name, true, true);
+        void core.cache.profileCache.applyOverridesFromStore(character.name);
       }
       if (
         cache === null &&

--- a/learn/cache-manager.ts
+++ b/learn/cache-manager.ts
@@ -245,38 +245,17 @@ export class CacheManager {
    *
    * But under what scenarios do we actually need to process without fetching?
    * @param character Character name to fetch, or a character object to finish
-   * @param fromDiskOnly If true, only attempt to load from disk cache; do not fetch from server
-   * @param deleteAfterFetch If true, delete the profile from cache immediately after fetching
    * Comment imported from Frolic; may be inaccurate if significant changes occured.
+
+   * trimmed significantly with the userlist viertualization changes. fromDiskOnly
+   * caused every profile to reregister no matter what, introducing extra work.
+   * applyOverridesFromStore does the same job without reregistering. 
    */
-  async addProfile(
-    character: string | ComplexCharacter,
-    fromDiskOnly: boolean = false,
-    deleteAfterFetch: boolean = false
-  ): Promise<void> {
+  async addProfile(character: string | ComplexCharacter): Promise<void> {
     if (typeof character === 'string') {
       // console.log('Learn discover', character);
 
-      if (fromDiskOnly) {
-        const diskChar = await this.profileCache.get(character);
-        if (deleteAfterFetch && diskChar) {
-          this.profileCache.delete(character);
-        }
-        return;
-      }
       await this.queueForFetching(character);
-      if (deleteAfterFetch) {
-        // Wait until fetched, then delete
-        const checkAndDelete = async () => {
-          const p = await this.profileCache.get(character);
-          if (p) {
-            this.profileCache.delete(character);
-          } else {
-            setTimeout(checkAndDelete, 1000);
-          }
-        };
-        await checkAndDelete();
-      }
       return;
     }
 

--- a/learn/profile-cache.ts
+++ b/learn/profile-cache.ts
@@ -266,6 +266,26 @@ export class ProfileCache extends AsyncCache<CharacterCacheRecord> {
     return cacheRecord;
   }
 
+  /**
+   * Applies a profile's character overrides (HQ portrait, custom name color).
+   *
+   * Skips register on purpose. Registering runs the matcher, which costs performance
+   * per profile, and the member list calls this once per member. Nothing here needs
+   * a match score, so don't add one.
+   *
+   * Does nothing if the profile isn't on disk
+   * @param name Character to apply overrides for
+   */
+  async applyOverridesFromStore(name: string): Promise<void> {
+    const profile =
+      this.getSync(name)?.character ??
+      (await this.store?.getProfile(name))?.profileData;
+
+    if (profile) {
+      this.updateOverrides(profile);
+    }
+  }
+
   delete(name: string): void {
     const key = AsyncCache.nameKey(name);
 


### PR DESCRIPTION
Feat? Fix? Both? I dunno. Adds virtualization to the UserList (channel members list) and fixes an issue with the cache manager that was slowing things down, introducing some cases where the thread would hang. Fix-wise, a user in the Discord reported that switching channels with the channel members list open would cause Horizon to become unresponsive for a short time, which this should now solve.

Includes a settings watcher for font size changes, since those can change the row height of the user list as font increases/decreases. I don't know if we accounted for font size changes in other virtual lists, but it's something to consider. 

I'll definitely want some testing here, since this is a pretty big change, but it seems to work a lot better in my experience.

(probably) closes #950 