### PR TITLE
fix: Spellcheck setting changes will apply without a restart

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -58,6 +58,7 @@ import { Event } from 'electron/main';
 import { autoUpdater } from 'electron-updater';
 import Axios from 'axios';
 import { ProfileViewerGalleryType } from '../site/utils';
+import { getSafeLanguages } from './language';
 
 const configuredSessions = new WeakSet<electron.Session>();
 
@@ -1551,6 +1552,10 @@ async function onReady(): Promise<void> {
         let badgeChange =
           settings.horizonShowNotificationBadge !==
           _options.horizonShowNotificationBadge;
+        let spellcheckChange = !_.isEqual(
+          getSafeLanguages(settings.spellcheckLang),
+          getSafeLanguages(_options.spellcheckLang)
+        );
         Object.assign(settings, _options);
         //Now we save it to a file
         setGeneralSettings(_options);
@@ -1570,6 +1575,12 @@ async function onReady(): Promise<void> {
         if (badgeChange) {
           browserWindows.updateNotificationBadges(
             settings.horizonShowNotificationBadge
+          );
+        }
+
+        if (spellcheckChange) {
+          updateSpellCheckerLanguages(
+            getSafeLanguages(settings.spellcheckLang)
           );
         }
       }


### PR DESCRIPTION
Applies spellcheck setting changes immediately without silently requiring the user to restart the app. Apparently this already existed in the past, but barely worked, but now it seems to work fine. 

Something to note is that if you have words with typos in a chat input, then change the spellcheck settings to add a language where that word is *not* a typo, the typo indicator will remain until you edit the word. I don't think this is a real concern, and my attempt at fixing that (automatically disabling + re-enabling the spellchecker after a language change) was too much jank for such a small issue.