### PR TITLE
feat: Mobile view BBCode editor redesign + eicon picker fix

### DIFF
--- a/bbcode/EIconSelector.vue
+++ b/bbcode/EIconSelector.vue
@@ -20,134 +20,118 @@
         ></div>
       </div>
       <div v-else>
-        <div>
-          <div class="search-bar">
-            <input
-              type="text"
-              class="form-control search"
-              id="search"
-              v-model="search"
-              ref="search"
-              :placeholder="l('eicon.searchPlaceholder')"
-              @input="searchUpdateDebounce()"
+        <div class="search-bar">
+          <input
+            type="text"
+            class="form-control search"
+            id="search"
+            v-model="search"
+            ref="search"
+            :placeholder="l('eicon.searchPlaceholder')"
+            @input="searchUpdateDebounce()"
+            tabindex="0"
+            @click.prevent.stop="setFocus()"
+            @mousedown.prevent.stop
+            @mouseup.prevent.stop
+          />
+          <div class="btn-group search-buttons">
+            <div
+              class="btn btn-light favorites"
+              @click.prevent.stop="searchWithString('category:favorites')"
+              :class="{ active: search === 'category:favorites' }"
+              :title="l('eicon.category.favorites')"
+              role="button"
               tabindex="0"
-              @click.prevent.stop="setFocus()"
-              @mousedown.prevent.stop
-              @mouseup.prevent.stop
-            />
-            <div class="btn-group search-buttons">
-              <div
-                class="btn btn-light favorites"
-                @click.prevent.stop="searchWithString('category:favorites')"
-                :class="{ active: search === 'category:favorites' }"
-                :title="l('eicon.category.favorites')"
-                role="button"
-                tabindex="0"
-              >
-                <i class="fas fa-thumbtack"></i>
-              </div>
-
-              <div
-                class="btn btn-light recent"
-                @click.prevent.stop="searchWithString('category:recent')"
-                :class="{ active: search === 'category:recent' }"
-                :title="l('eicon.category.recent')"
-                role="button"
-                tabindex="0"
-              >
-                <i class="fas fa-history"></i>
-              </div>
-
-              <div
-                class="btn btn-light expressions"
-                @click.prevent.stop="searchWithString('category:expressions')"
-                :class="{ active: search === 'category:expressions' }"
-                :title="l('eicon.category.expressions')"
-                role="button"
-                tabindex="0"
-              >
-                <i class="fas fa-theater-masks"></i>
-              </div>
-
-              <div
-                class="btn btn-light sexual"
-                @click.prevent.stop="searchWithString('category:sexual')"
-                :class="{ active: search === 'category:sexual' }"
-                :title="l('eicon.category.sexual')"
-                role="button"
-                tabindex="0"
-              >
-                <i class="fas fa-heart"></i>
-              </div>
-
-              <div
-                class="btn btn-light bubbles"
-                @click.prevent.stop="searchWithString('category:bubbles')"
-                :class="{ active: search === 'category:bubbles' }"
-                :title="l('eicon.category.bubbles')"
-                role="button"
-                tabindex="0"
-              >
-                <i class="fas fa-comment"></i>
-              </div>
-
-              <div
-                class="btn btn-light actions"
-                @click.prevent.stop="searchWithString('category:symbols')"
-                :class="{ active: search === 'category:symbols' }"
-                :title="l('eicon.category.symbols')"
-                role="button"
-                tabindex="0"
-              >
-                <i class="fas fa-icons"></i>
-              </div>
-
-              <div
-                class="btn btn-light memes"
-                @click.prevent.stop="searchWithString('category:memes')"
-                :class="{ active: search === 'category:memes' }"
-                :title="l('eicon.category.memes')"
-                role="button"
-                tabindex="0"
-              >
-                <i class="fas fa-poo"></i>
-              </div>
-
-              <div
-                class="btn btn-light random"
-                @click.prevent.stop="searchWithString('category:random')"
-                :class="{ active: search === 'category:random' }"
-                :title="l('eicon.category.random')"
-                role="button"
-                tabindex="0"
-              >
-                <i class="fas fa-random"></i>
-              </div>
-
-              <div
-                class="btn btn-light refresh"
-                @click.prevent.stop="refreshIcons()"
-                :title="l('eicon.refresh')"
-                role="button"
-                tabindex="0"
-              >
-                <i class="fas fa-sync"></i>
-              </div>
+            >
+              <i class="fas fa-thumbtack"></i>
             </div>
-          </div>
 
-          <div class="courtesy">
-            <localized-text k="eicon.credit">
-              <template #xariah>
-                <a href="https://xariah.net/eicons">xariah.net</a>
-              </template>
-            </localized-text>
-          </div>
+            <div
+              class="btn btn-light recent"
+              @click.prevent.stop="searchWithString('category:recent')"
+              :class="{ active: search === 'category:recent' }"
+              :title="l('eicon.category.recent')"
+              role="button"
+              tabindex="0"
+            >
+              <i class="fas fa-history"></i>
+            </div>
 
-          <div class="upload">
-            <a href="https://www.f-list.net/icons.php">{{
-              l('eicon.upload')
-            }}</a>
+            <div
+              class="btn btn-light expressions"
+              @click.prevent.stop="searchWithString('category:expressions')"
+              :class="{ active: search === 'category:expressions' }"
+              :title="l('eicon.category.expressions')"
+              role="button"
+              tabindex="0"
+            >
+              <i class="fas fa-theater-masks"></i>
+            </div>
+
+            <div
+              class="btn btn-light sexual"
+              @click.prevent.stop="searchWithString('category:sexual')"
+              :class="{ active: search === 'category:sexual' }"
+              :title="l('eicon.category.sexual')"
+              role="button"
+              tabindex="0"
+            >
+              <i class="fas fa-heart"></i>
+            </div>
+
+            <div
+              class="btn btn-light bubbles"
+              @click.prevent.stop="searchWithString('category:bubbles')"
+              :class="{ active: search === 'category:bubbles' }"
+              :title="l('eicon.category.bubbles')"
+              role="button"
+              tabindex="0"
+            >
+              <i class="fas fa-comment"></i>
+            </div>
+
+            <div
+              class="btn btn-light actions"
+              @click.prevent.stop="searchWithString('category:symbols')"
+              :class="{ active: search === 'category:symbols' }"
+              :title="l('eicon.category.symbols')"
+              role="button"
+              tabindex="0"
+            >
+              <i class="fas fa-icons"></i>
+            </div>
+
+            <div
+              class="btn btn-light memes"
+              @click.prevent.stop="searchWithString('category:memes')"
+              :class="{ active: search === 'category:memes' }"
+              :title="l('eicon.category.memes')"
+              role="button"
+              tabindex="0"
+            >
+              <i class="fas fa-poo"></i>
+            </div>
+
+            <div
+              class="btn btn-light random"
+              @click.prevent.stop="searchWithString('category:random')"
+              :class="{ active: search === 'category:random' }"
+              :title="l('eicon.category.random')"
+              role="button"
+              tabindex="0"
+            >
+              <i class="fas fa-random"></i>
+            </div>
+
+            <div
+              class="btn btn-light refresh"
+              @click.prevent.stop="refreshIcons()"
+              :title="l('eicon.refresh')"
+              role="button"
+              tabindex="0"
+            >
+              <i class="fas fa-sync"></i>
+            </div>
           </div>
         </div>
 
@@ -246,6 +230,22 @@
                 <i class="fas fa-thumbtack"></i>
               </div>
             </div>
+          </div>
+        </div>
+
+        <div class="eicon-footer">
+          <div class="upload">
+            <a href="https://www.f-list.net/icons.php">{{
+              l('eicon.upload')
+            }}</a>
+          </div>
+
+          <div class="courtesy">
+            <localized-text k="eicon.credit">
+              <template #xariah>
+                <a href="https://xariah.net/eicons">xariah.net</a>
+              </template>
+            </localized-text>
           </div>
         </div>
       </div>
@@ -908,13 +908,28 @@
     line-height: 1;
     z-index: 1000;
 
-    &.big {
-      min-height: 530px;
+    .modal-body {
+      overflow-y: hidden;
+      display: flex;
+      min-height: 0;
     }
 
     .eicon-selector-ui {
+      display: flex;
+      flex-direction: column;
+      flex: 1;
+      min-height: 0;
+
+      > div:not(.loading) {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
+      }
+
       .search-bar {
         display: flex;
+        flex-shrink: 0;
 
         .search {
           flex: 1;
@@ -941,19 +956,17 @@
         }
       }
 
-      .courtesy {
-        position: absolute;
-        bottom: 7px;
+      .eicon-footer {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        flex-shrink: 0;
         font-size: 9px;
-        right: 1rem;
-        opacity: 50%;
-      }
+        padding-top: 6px;
 
-      .upload {
-        position: absolute;
-        bottom: 7px;
-        font-size: 9px;
-        left: 1rem;
+        .courtesy {
+          opacity: 50%;
+        }
       }
 
       .results {
@@ -1050,15 +1063,16 @@
     }
 
     &.big {
-      min-height: 530px;
       width: 590px;
       max-width: 590px;
 
       .eicon-selector-ui {
         .carousel.results {
-          max-height: unset;
-          height: 535px;
-          margin-bottom: 0.75rem;
+          // no fixed height so that it can shrink with the window.
+          // max-height keeps the usual size on a tall one.
+          flex: 1 1 auto;
+          min-height: 0;
+          max-height: 535px;
 
           .carousel-inner {
             overflow-x: hidden;

--- a/bbcode/Editor.vue
+++ b/bbcode/Editor.vue
@@ -1,7 +1,11 @@
 <template>
   <div
     class="bbcode-editor"
-    :class="{ 'formatting-open': showFormatting }"
+    :class="{
+      'formatting-open': showFormatting,
+      previewing: preview,
+      'has-toolbar': hasToolbar
+    }"
     style="display: flex; flex-wrap: wrap; justify-content: flex-end"
     @keydown="onKeyDownGlobal"
     tabindex="1"
@@ -79,7 +83,7 @@
 
         <div
           class="btn btn-light btn-sm aa-btn"
-          :class="{ active: showFormatting }"
+          :class="{ active: showFormatting, 'preview-disabled': preview }"
           :title="l('editor.formatting')"
           role="button"
           tabindex="0"
@@ -92,7 +96,13 @@
         <div
           class="btn btn-light btn-sm"
           v-for="button in buttons"
-          :class="[button.outerClass, { 'format-btn': isFormatButton(button) }]"
+          :class="[
+            button.outerClass,
+            {
+              'format-btn': isFormatButton(button),
+              'preview-disabled': preview
+            }
+          ]"
           :title="l(button.titleKey, { modifier: shortcutModifierKey })"
           @click.prevent.stop="apply(button)"
         >
@@ -128,16 +138,18 @@
         @click="showToolbar = false"
       ></button>
     </div>
-    <div
+    <a
       @click="previewBBCode"
-      v-if="preview && !hasToolbar"
-      class="btn btn-light btn-sm bbcode-editor-preview active"
+      v-if="preview"
+      tabindex="0"
+      role="button"
+      class="btn btn-light btn-sm bbcode-editor-preview preview-exit"
       :title="
         l('editor.closePreview', { modifier: `${shortcutModifierKey}+Shift+P` })
       "
     >
       <i class="fa fa-eye-slash"></i>
-    </div>
+    </a>
     <div
       class="bbcode-editor-text-area bg-light"
       style="order: 100; width: 100%"
@@ -745,6 +757,8 @@
             targetElement.removeChild(targetElement.firstChild);
         } else {
           this.preview = true;
+          this.showToolbar = false;
+          this.colorPopupVisible = false;
           this.parser.storeWarnings = true;
           targetElement.appendChild(this.parser.parseEverything(this.text));
           this.previewWarnings = this.parser.warnings;

--- a/bbcode/Editor.vue
+++ b/bbcode/Editor.vue
@@ -1,6 +1,7 @@
 <template>
   <div
     class="bbcode-editor"
+    :class="{ 'formatting-open': showFormatting }"
     style="display: flex; flex-wrap: wrap; justify-content: flex-end"
     @keydown="onKeyDownGlobal"
     tabindex="1"
@@ -33,7 +34,6 @@
       "
       @mousedown.stop.prevent
       v-if="hasToolbar"
-      style="flex: 1 51%"
     >
       <transition name="color-popover">
         <div
@@ -78,9 +78,21 @@
         </div>
 
         <div
+          class="btn btn-light btn-sm aa-btn"
+          :class="{ active: showFormatting }"
+          :title="l('editor.formatting')"
+          role="button"
+          tabindex="0"
+          @mousedown.prevent
+          @click.prevent.stop="showFormatting = !showFormatting"
+        >
+          Aa
+        </div>
+
+        <div
           class="btn btn-light btn-sm"
           v-for="button in buttons"
-          :class="button.outerClass"
+          :class="[button.outerClass, { 'format-btn': isFormatButton(button) }]"
           :title="l(button.titleKey, { modifier: shortcutModifierKey })"
           @click.prevent.stop="apply(button)"
         >
@@ -104,6 +116,9 @@
         >
           <i class="fa" :class="preview ? 'fa-eye' : 'far fa-eye'"></i>
         </div>
+
+        <!--Flex line break for the mobile chat layout. see _bbcode_editor.scss-->
+        <div class="toolbar-row-break" aria-hidden="true"></div>
       </div>
       <button
         type="button"
@@ -218,6 +233,7 @@
         maxHeight: 0 as number,
         minHeight: 0 as number,
         showToolbar: false,
+        showFormatting: false,
         shortcutModifierKey: process.platform == 'darwin' ? '⌘' : 'Ctrl',
         parser: undefined as any as BBCodeParser,
         defaultButtons: defaultButtons,
@@ -353,6 +369,21 @@
 
         return btn;
       },
+      // styling and the markup wrappers go behind the Aa toggle, other buttons remain showing
+      isFormatButton(button: EditorButton): boolean {
+        return [
+          'b',
+          'i',
+          'u',
+          's',
+          'color',
+          'sup',
+          'sub',
+          'spoiler',
+          'noparse'
+        ].includes(button.tag);
+      },
+
       getSelection(): EditorSelection {
         const length = this.element.selectionEnd - this.element.selectionStart;
         return {
@@ -438,6 +469,8 @@
         this.applyButtonEffect(button, btnColor);
 
         this.colorPopupVisible = false;
+        // wait until the color is picked before closing the formatting row in mobile view
+        this.showFormatting = false;
       },
 
       dismissEIconSelector(): void {
@@ -476,6 +509,7 @@
         }
 
         this.applyButtonEffect(button);
+        if (this.isFormatButton(button)) this.showFormatting = false;
       },
 
       applyButtonEffect(
@@ -760,6 +794,7 @@
 
   .bbcode-editor {
     resize: none;
+    position: relative;
     &:focus {
       outline: none;
       .bbcode-editor-text-area {

--- a/chat/ConversationView.vue
+++ b/chat/ConversationView.vue
@@ -360,7 +360,7 @@
       "
       :hasToolbar="settings.bbCodeBar"
       ref="textBox"
-      style="position: relative; margin-top: 5px"
+      style="margin-top: 5px"
       :maxlength="
         isChannel(conversation) || isPrivate(conversation)
           ? conversation.maxMessageLength
@@ -410,6 +410,7 @@
       </div>
       <div class="bbcode-editor-controls">
         <div
+          class="char-count"
           v-if="isChannel(conversation) || isPrivate(conversation)"
           style="margin-right: 5px"
         >

--- a/chat/ManageChannel.vue
+++ b/chat/ManageChannel.vue
@@ -39,7 +39,6 @@
         classes="form-control"
         id="description"
         v-model="description"
-        style="position: relative"
         :maxlength="50000"
       >
         <div class="bbcode-editor-controls">

--- a/chat/locales/en-US.json
+++ b/chat/locales/en-US.json
@@ -401,6 +401,7 @@
   "editor.format.underline": "Underline ({modifier}+U)\n\nMakes text appear with an underline beneath it.",
   "editor.format.url": "URL ({modifier}+L)\n\nCreates a clickable link to another page of your choosing.",
   "editor.format.user": "User ({modifier}+R)\n\nLinks to a character's profile.",
+  "editor.formatting": "Formatting\n\nShows the text formatting buttons.",
   "editor.help": "Help\n\nClick this button for a quick overview of slash commands.",
   "editor.preview": "Preview ({modifier})\n\nShows a preview of the BBCode you have typed, including any formatting errors.",
   "eicon.action": "Select EIcon",

--- a/scss/_bbcode_editor.scss
+++ b/scss/_bbcode_editor.scss
@@ -34,8 +34,8 @@
         margin: 0 -1px -1px 0;
         border: 1px solid var(--bs-border-color-translucent);
         border-radius: 0 !important;
-        min-width: 40px;
-        min-height: 40px;
+        min-width: 36px;
+        min-height: 36px;
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -167,14 +167,20 @@
     .bbcode-editor:has(.chat-text-box) & {
       display: none;
     }
+    // reopening it would put the toolbar back over the preview
+    .bbcode-editor.previewing & {
+      display: none;
+    }
   }
 }
 
 // only mobile chat hides the formatting buttons, so only it needs the toggle
 .aa-btn {
-  display: none;
+  .bbcode-toolbar .toolbar-buttons & {
+    display: none;
+  }
   @include media-breakpoint-down(md) {
-    .bbcode-editor:has(.chat-text-box) & {
+    .bbcode-editor:has(.chat-text-box) .toolbar-buttons & {
       display: inline-flex;
       font-weight: 700;
       letter-spacing: -0.02em;
@@ -193,6 +199,27 @@
   justify-content: flex-end;
   @include media-breakpoint-down(md) {
     flex: 1 49%;
+  }
+}
+
+// it looks better to leave the toolbar showing in the chat when previewing imo,
+// but only after preventing clicking the other buttons
+@include media-breakpoint-down(md) {
+  .bbcode-editor.previewing:has(.chat-text-box) .preview-disabled {
+    opacity: 0.4;
+    pointer-events: none;
+  }
+}
+
+.bbcode-editor.has-toolbar .preview-exit {
+  display: none;
+}
+// dedicated preview close button for bbcode editor in status/ads/filter reply settings when
+// previewing on those screens, hide the other editor buttons so that you can actually see the preview
+@include media-breakpoint-down(md) {
+  .bbcode-editor.has-toolbar.previewing:not(:has(.chat-text-box))
+    .preview-exit {
+    display: inline-flex;
   }
 }
 

--- a/scss/_bbcode_editor.scss
+++ b/scss/_bbcode_editor.scss
@@ -11,6 +11,7 @@
 .bbcode-toolbar {
   align-items: flex-start;
   flex-wrap: nowrap;
+  flex: 1 51%;
   @include media-breakpoint-down(md) {
     background: $text-background-color;
     padding: 10px;
@@ -19,15 +20,81 @@
     left: 0px;
     border-radius: var(--bs-border-radius);
     width: 100%;
-    height: 100%;
+    height: auto;
+    max-height: 75%;
     z-index: 20;
     display: none;
     .toolbar-buttons {
       width: 100%;
+      border: 1px solid var(--bs-border-color-translucent);
+      border-radius: var(--bs-border-radius);
+      overflow: hidden;
+
+      .btn {
+        margin: 0 -1px -1px 0;
+        border: 1px solid var(--bs-border-color-translucent);
+        border-radius: 0 !important;
+        min-width: 40px;
+        min-height: 40px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+      }
     }
-    .btn {
-      margin: 3px;
-      border-radius: $btn-border-radius !important;
+
+    .toolbar-row-break {
+      display: none;
+    }
+
+    .bbcode-editor:has(.chat-text-box) & {
+      display: flex;
+      position: static;
+      max-height: none;
+      flex: 1 0 100%;
+      padding: 0;
+      background: none;
+      z-index: auto;
+
+      .btn-close {
+        display: none;
+      }
+
+      .format-btn {
+        order: 1;
+        display: none;
+      }
+      .toolbar-row-break {
+        order: 2;
+        width: 100%;
+        height: 0;
+        margin: 0;
+        border: 0;
+      }
+
+      .character-btn,
+      .btn:not(.format-btn) {
+        order: 3;
+      }
+
+      .character-btn {
+        width: 40px;
+        height: auto;
+        min-height: 40px;
+        margin: 0 -1px -1px 0;
+        border: 1px solid var(--bs-border-color-translucent);
+
+        img {
+          object-fit: cover;
+        }
+      }
+    }
+    .bbcode-editor.formatting-open:has(.chat-text-box) & {
+      .format-btn {
+        display: inline-flex;
+      }
+      .toolbar-row-break {
+        display: block;
+      }
     }
   }
   @include media-breakpoint-up(md) {
@@ -96,6 +163,26 @@
   @include media-breakpoint-up(md) {
     display: none;
   }
+  @include media-breakpoint-down(md) {
+    .bbcode-editor:has(.chat-text-box) & {
+      display: none;
+    }
+  }
+}
+
+// only mobile chat hides the formatting buttons, so only it needs the toggle
+.aa-btn {
+  display: none;
+  @include media-breakpoint-down(md) {
+    .bbcode-editor:has(.chat-text-box) & {
+      display: inline-flex;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+  }
+  &.active {
+    background-color: var(--bs-secondary) !important;
+  }
 }
 
 .bbcode-editor-controls {
@@ -106,5 +193,17 @@
   justify-content: flex-end;
   @include media-breakpoint-down(md) {
     flex: 1 49%;
+  }
+}
+
+// if i'm being honest, i don't know who in their right mind would type 50000 characters
+// on their phone for a smut roleplay. if you write that much with a tiny screen and
+// a touchscreen keyboard, then props to you. *however*, the overwhelming majority of
+// mobile players will likely never get close to the limit, so let's hide it for them.
+// i also couldn't find a good place to put the text counter, so this saves it from
+// looking ugly somewhere
+@include media-breakpoint-down(md) {
+  .bbcode-editor:has(.chat-text-box) .char-count {
+    display: none;
   }
 }


### PR DESCRIPTION
Redesigns the BBCode editor in the responsive mobile view to enhance the overall UX and UI. I originally started this as just a basic fix for #349 and #823, but after messing with the mobile view enough, I decided that it needed a proper overhaul of sorts.

- The BBCode editor now shows at all times in the chat view instead of needing to hit the code button every time. 
  - Any formatting related tag (`[b]`, `[i]`,  etc.) are hidden underneath a formatting (Aa) button to save space, inspired by Luna's UX.
- As a whole, the BBCode editor buttons are bigger and should be easier to tap for mobile users. 
- The preview toggle now disables the other BBCode buttons when enabled, because being able to add tags that you can't even see is a little dumb.
  - Maybe we could apply this to the main desktop view too, if people like it? It's a small thing, tho
- The text count tracker has been hidden on the mobile view to save screen real estate, because I **really** doubt a mobile user will need to know when they get close to the 50,000 character limit. 
- The BBCode editor on the status/ad/smart filter auto-reply views is now inline, so you can see the text you're editing, and the preview button will actually show you something.
- The EIcon picker is mostly the same, but now the footer (the Xariah credit + upload button) will show properly even with shorter screen sizes.

I'm pretty happy with how the redesign looks, but I'm also open to suggestions or criticism as well, either for the UI or UX. More importantly, this should probably be tested on some mobile devices before release since this affects Solstice pretty heavily.

Closes #349, closes #823

## Chat View
### Before
<img width="448" height="191" alt="Code_wFHI5MtUnv" src="https://github.com/user-attachments/assets/aa39dea0-5d34-4167-9b4c-f9980be01e22" />

### After
<img width="533" height="228" alt="Code_waCMbTfHhK" src="https://github.com/user-attachments/assets/163f880e-46b2-4a29-959a-0b14bc4c2054" />


## Editor for Status/Ad/Smart Filter auto-reply 
### Before
<img width="469" height="590" alt="Horizon_liDrnnE0C8" src="https://github.com/user-attachments/assets/9cc36b7f-cb7f-4ecf-925c-66353711bdaf" />

### After
<img width="487" height="526" alt="electron_1REucxLB1K" src="https://github.com/user-attachments/assets/af6954cf-5e35-4ecd-a207-394154eb0a5f" />