### PR TITLE
fix: URL preview allowing popups (for good, probably)

### DIFF
--- a/chat/preview/ImagePreview.vue
+++ b/chat/preview/ImagePreview.vue
@@ -38,7 +38,6 @@
       src="about:blank"
       webpreferences="autoplayPolicy=no-user-gesture-required,contextIsolation,sandbox,disableDialogs,disableHtmlFullScreenWindowResize,webSecurity,enableWebSQL=no,nodeIntegration=no,nativeWindowOpen=no,nodeIntegrationInWorker=no,nodeIntegrationInSubFrames=no,webviewTag=no"
       enableremotemodule="false"
-      nodeIntegration="false"
       partition="persist:adblocked"
       id="image-preview-ext"
       ref="imagePreviewExt"

--- a/chat/preview/ImagePreview.vue
+++ b/chat/preview/ImagePreview.vue
@@ -31,13 +31,13 @@
       ></a>
     </div>
 
-    <!-- note: preload requires a webpack config CopyPlugin configuration -->
+    <!-- note: preload requires a webpack config CopyPlugin configuration
+     also: don't add allowpopups here in any form. see https://www.electronjs.org/docs/latest/api/webview-tag#allowpopups -->
     <webview
       preload="./preview/assets/browser.pre.js"
       src="about:blank"
       webpreferences="autoplayPolicy=no-user-gesture-required,contextIsolation,sandbox,disableDialogs,disableHtmlFullScreenWindowResize,webSecurity,enableWebSQL=no,nodeIntegration=no,nativeWindowOpen=no,nodeIntegrationInWorker=no,nodeIntegrationInSubFrames=no,webviewTag=no"
       enableremotemodule="false"
-      allowpopups="false"
       nodeIntegration="false"
       partition="persist:adblocked"
       id="image-preview-ext"

--- a/learn/dictionary/WordDefinition.vue
+++ b/learn/dictionary/WordDefinition.vue
@@ -5,7 +5,6 @@
       :src="getWebUrl()"
       webpreferences="autoplayPolicy=no-user-gesture-required,contextIsolation,sandbox,disableDialogs,disableHtmlFullScreenWindowResize,webSecurity,enableWebSQL=no,nodeIntegration=no,nativeWindowOpen=no,nodeIntegrationInWorker=no,nodeIntegrationInSubFrames=no,webviewTag=no"
       enableremotemodule="false"
-      nodeIntegration="false"
       partition="persist:adblocked"
       id="defintion-preview"
       ref="definitionPreview"

--- a/learn/dictionary/WordDefinition.vue
+++ b/learn/dictionary/WordDefinition.vue
@@ -1,10 +1,10 @@
 <template>
   <div class="definition-wrapper">
+    <!--don't add allowpopups here in any form. see https://www.electronjs.org/docs/latest/api/webview-tag#allowpopups -->
     <webview
       :src="getWebUrl()"
       webpreferences="autoplayPolicy=no-user-gesture-required,contextIsolation,sandbox,disableDialogs,disableHtmlFullScreenWindowResize,webSecurity,enableWebSQL=no,nodeIntegration=no,nativeWindowOpen=no,nodeIntegrationInWorker=no,nodeIntegrationInSubFrames=no,webviewTag=no"
       enableremotemodule="false"
-      allowpopups="false"
       nodeIntegration="false"
       partition="persist:adblocked"
       id="defintion-preview"


### PR DESCRIPTION
Electron's webview has `allowpopup` as a boolean, but no matter what the boolean is set to, it always allows popups if it's included as an attribute at all. Removing `allowpopup` entirely should (hopefully, permanently) prevent any cases of popups. 

Also removed `nodeIntegration` entirely for the same reason as above, which lowkey could've been a security issue.

https://www.electronjs.org/docs/latest/api/webview-tag#allowpopups