### PR TITLE
Native window controls for Windows and Linux

### DIFF
--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -139,6 +139,7 @@
           display: flex;
           justify-content: flex-end;
           -webkit-app-region: drag;
+          margin-right: 130px;
         "
         id="windowButtons"
         class="btn-group"
@@ -149,19 +150,6 @@
           class="d-none d-md-flex btn btn-light"
         >
           <i class="fa fa-cog"> </i>
-        </span>
-
-        <span class="btn btn-light" @click.stop="minimize()">
-          <i class="far fa-window-minimize"></i>
-        </span>
-        <span class="btn btn-light" @click="maximize()">
-          <i
-            class="far"
-            :class="'fa-window-' + (isMaximized ? 'restore' : 'maximize')"
-          ></i>
-        </span>
-        <span class="btn btn-light" @click.stop="close()">
-          <i class="fa fa-times fa-lg"></i>
         </span>
       </div>
     </div>
@@ -277,6 +265,13 @@
         hideSingleTab: true
       };
     },
+    watch: {
+      styling(): void {
+        this.$nextTick(() => {
+          this.updateWindowOverlayColors();
+        });
+      }
+    },
     computed: {
       styling(): string {
         try {
@@ -310,6 +305,8 @@
       updateSupportedLanguages(
         browserWindow.webContents.session.availableSpellCheckerLanguages
       );
+
+      this.updateWindowOverlayColors();
 
       log.debug('init.window.languages.supported');
       // console.log('MOUNT DICTIONARIES', getSafeLanguages(this.settings.spellcheckLang), this.settings.spellcheckLang);
@@ -841,6 +838,15 @@
             ['platform-' + this.platform]: true
           };
         }
+      },
+      updateWindowOverlayColors(): void {
+        let color = getComputedStyle(document.body).color;
+        log.debug('window.titlebar.color', color);
+        browserWindow.setTitleBarOverlay({
+          color: '#ff000000',
+          symbolColor: color || 'white',
+          height: 32
+        });
       },
       shouldShowNotificationBadge(tab: Tab): boolean {
         return (

--- a/electron/Window.vue
+++ b/electron/Window.vue
@@ -139,8 +139,8 @@
           display: flex;
           justify-content: flex-end;
           -webkit-app-region: drag;
-          margin-right: 130px;
         "
+        :style="{ marginRight: windowControlsOverlayMargin }"
         id="windowButtons"
         class="btn-group"
         v-if="!hideWindowControls"
@@ -262,7 +262,8 @@
           : 'title.dev') as string,
         isClosing: false,
         hideWindowControls: false,
-        hideSingleTab: true
+        hideSingleTab: true,
+        windowControlsOverlayMargin: '130px'
       };
     },
     watch: {
@@ -290,6 +291,12 @@
     },
     async mounted(): Promise<void> {
       log.debug('init.window.mounting');
+      this.updateWindowControlsOverlayMargin();
+      const windowControlsOverlay = (navigator as any).windowControlsOverlay;
+      windowControlsOverlay?.addEventListener(
+        'geometrychange',
+        this.updateWindowControlsOverlayMargin
+      );
       // top bar devtools
       // browserWindow.webContents.openDevTools({ mode: 'detach' });
 
@@ -572,7 +579,33 @@
 
       log.debug('init.window.mounted');
     },
+    beforeDestroy(): void {
+      //Yes, this is a to any cast. Too bad.
+      //This is not a property that gets exposed through the navigator type, but it exists in Electron's runtime as of 2026-09-12. (We are using v42.4.1 as of writing)
+      //If this ever breaks, now you know why. You'll have to find a different way to get the margin areas.
+      const windowControlsOverlay = (navigator as any).windowControlsOverlay;
+      windowControlsOverlay?.removeEventListener(
+        'geometrychange',
+        this.updateWindowControlsOverlayMargin
+      );
+    },
     methods: {
+      //Same comment as the beforeDestroy method. This is not a property that gets exposed through the navigator type, but it exists in Electron's runtime as of 2026-09-12. Blah blah blah...
+      //On Windows we can kind of guess the size this takes. Have fun doing the same shit on Linux.
+      updateWindowControlsOverlayMargin(): void {
+        const windowControlsOverlay = (navigator as any).windowControlsOverlay;
+        const titlebarArea = windowControlsOverlay?.getTitlebarAreaRect();
+
+        if (!titlebarArea) {
+          this.windowControlsOverlayMargin = '130px';
+          return;
+        }
+
+        this.windowControlsOverlayMargin = `${Math.max(
+          0,
+          window.innerWidth - titlebarArea.right
+        )}px`;
+      },
       getSyncedTheme() {
         if (!this.settings.themeSync) return this.settings.theme;
         return this.osIsDark

--- a/electron/browser_windows.ts
+++ b/electron/browser_windows.ts
@@ -355,6 +355,11 @@ export function createMainWindow(
     windowProperties.titleBarStyle = 'hiddenInset';
   } else {
     windowProperties.frame = settings.forceNativeWindowControls;
+    windowProperties.titleBarStyle = settings.forceNativeWindowControls
+      ? 'default'
+      : 'hidden';
+    //we'll set the actual colors in Window.vue, but passing 'true' just enables overlay controls with default controls
+    windowProperties.titleBarOverlay = true;
   }
 
   const window = new electron.BrowserWindow(windowProperties);


### PR DESCRIPTION
Adds native window control overlays for Windows and Linux. MacOS already had these (through different methods), but they look perfectly fine on Linux and Windows too. Doubly so because they add specific functionality (like hover menus on Windows 11) that we can't mimic with our implementation.

~~Consider this a Do not merge for now, because the settings button might float a bit awkwardly. I can align it 1:1 for Windows 11, but on Linux the location where it'd go can vary quite a bit depending on your window decorations. I might remove that button altogether as a result of #640  but I can't say for sure.~~

nvm solved it. because i'm just that good 💅

<img width="333" height="119" alt="image" src="https://github.com/user-attachments/assets/b23b6b78-da6a-4097-b627-20764bf77c87" />


Top: Windows
Bottom: Linux w/ (I think, I can't tell from that install) default KDE window controls.