### PR TITLE
fix: about:blank when opening devtools

### DIFF
--- a/chat/preview/ImagePreview.vue
+++ b/chat/preview/ImagePreview.vue
@@ -7,7 +7,7 @@
     <div class="image-preview-toolbar" v-show="sticky || debug">
       <a
         @click="toggleDevMode()"
-        :class="{ toggled: debug }"
+        :class="{ toggled: debug, disabled: !debug && !canDebug }"
         :title="l('imagePreview.debug')"
         ><i class="fa fa-terminal"></i
       ></a>
@@ -126,6 +126,7 @@
         state: 'hidden',
         shouldShowSpinner: false,
         shouldShowError: true,
+        canDebug: false,
         interval: null as TimerHandle | null,
         exitInterval: null as TimerHandle | null,
         exitUrl: null as string | null,
@@ -829,9 +830,11 @@
         this.previewManager.setDebug(this.debug);
 
         if (this.debug) {
-          const webview = this.getWebview();
+          const helper = this.previewManager.getVisiblePreview();
 
-          webview.openDevTools();
+          if (helper && helper.usesWebView()) {
+            this.getWebview().openDevTools();
+          }
         }
       },
       async executeJavaScript(
@@ -939,6 +942,7 @@
         this.state = state;
         this.shouldShowSpinner = this.testSpinner();
         this.shouldShowError = this.testError();
+        this.canDebug = this.testDebug();
       },
       testSpinner(): boolean {
         return this.visibleSince > 0
@@ -953,6 +957,11 @@
         }
 
         return this.state === 'error';
+      },
+      testDebug(): boolean {
+        const helper = this.previewManager.getVisiblePreview();
+
+        return !!helper && helper.usesWebView();
       }
     }
   });
@@ -1057,6 +1066,11 @@
       .toggled {
         background-color: rgba(255, 255, 255, 0.2);
         box-shadow: 0 0 1px 0px rgba(255, 255, 255, 0.6);
+      }
+
+      .disabled {
+        opacity: 0.35;
+        pointer-events: none;
       }
     }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1270,7 +1270,17 @@ async function onReady(): Promise<void> {
     submenu: [
       { role: 'reload' },
       { role: 'forceReload' },
-      { role: 'toggleDevTools' },
+      {
+        // electron 42 changed the way that dev tools targeted objects, so we'd get about:blank
+        // instead of the actual object. this points it to the right view
+        label: 'Toggle Developer Tools',
+        accelerator:
+          process.platform === 'darwin' ? 'Alt+Command+I' : 'Ctrl+Shift+I',
+        click: (_menu, window) => {
+          if (window instanceof electron.BrowserWindow)
+            window.webContents.toggleDevTools();
+        }
+      },
       { type: 'separator' },
       {
         label: 'Show update notice',


### PR DESCRIPTION
Fixes the dev tools not pointing to the correct window object after some changes that came with Electron 42, causing every instance to show `about:blank` instead. This points the correct view to the dev tools so we actually see something.

I also went and disabled the dev tools button when viewing a preview for any `f-list.net` URL or a character preview, because those have always opened an `about:blank` view due to how we handle those URLs. @FatCatClient idk if you want to/already did handle that differently in the V2 previewer, but I figured you should know.

This should *probably* be merged for 2.4.0 since it's a regression 

Closes #943 